### PR TITLE
qase-jest-reporter: Complete test run after all results are published

### DIFF
--- a/qaseio/src/services/runs.ts
+++ b/qaseio/src/services/runs.ts
@@ -27,6 +27,12 @@ export class Runs extends BaseService {
             .catch(() => false);
     }
 
+    public complete(code: string, runId: string | number): Promise<AxiosResponse<undefined>> {
+        return this.api
+            .post(`/run/${code}/${runId}/complete`)
+            .then(this.validateResponse<undefined>());
+    }
+
     public create(code: string, data: RunCreate): Promise<AxiosResponse<RunCreated>> {
         return this.api
             .post(`/run/${code}`, data)


### PR DESCRIPTION
Jest reporter will complete Test Run after all test results are published to Qase if env var `QASE_COMPLETE_RUN=1` if set.

The [Jest reporter interface](https://github.com/facebook/jest/blob/master/packages/jest-reporters/src/types.ts#L64) may wait for all promises resolution and only then call the API to complete the run via API call. I guess this is the right approach. For that `publishCaseResult()` should be refactored, but I feel no confidence to do this in your repo. Instead, it checks if the test run should be complete after each test result. 

I'm also not sure about the correctness of `api.runs.complete` return. Could you please assist here?