### PR TITLE
`jest-qase-reporter` v1.2.0

### DIFF
--- a/qase-jest/README.md
+++ b/qase-jest/README.md
@@ -18,6 +18,7 @@ Reporter options (* - required):
   page of your project: `https://app.qase.io/project/DEMOTR` - 
   `DEMOTR` is project code here)
 - `runId` - Run ID from Qase TMS (also can be got from run URL)
+- `environmentId` - Environment ID from Qase TMS
 - `logging` [true/false] - Enabled debug logging from reporter or not
 - `runComplete` [true/false] - Complete run after all tests are finished
 
@@ -33,6 +34,7 @@ module.exports = {
         apiToken: '578e3b73a34f06e84eafea103cd44dc24253b2c5',
         projectCode: 'PRJCODE',
         runId: 45,
+        environmentId: 1,
         logging: true,
         runComplete: true,
       },
@@ -50,6 +52,7 @@ Supported ENV variables:
   qase reporter
 - `QASE_API_TOKEN` - API token
 - `QASE_RUN_ID` - Pass Run ID from ENV and override reporter options
+- `QASE_ENVIRONMENT_ID` - Pass Environment ID from ENV and override reporter options
 - `QASE_RUN_NAME` - Set custom Run name, when new run is created
 - `QASE_RUN_DESCRIPTION` - Set custom Run description, when new run is created
 - `QASE_RUN_COMPLETE` - Complete run after all tests are finished

--- a/qase-jest/README.md
+++ b/qase-jest/README.md
@@ -62,21 +62,20 @@ If you want to decorate come test with Qase Case ID you could use qase function:
 import { qase } from 'jest-qase-reporter/dist/jest';
 
 describe('My First Test', () => {
-    
     test(qase([1,2], 'Several ids'), () => {
-        expect(true).to.equal(true);
+        expect(true).toBe(true);
     })
 
     test(qase(3, 'Correct test'), () => {
-        expect(true).to.equal(true);
+        expect(true).toBe(true);
     })
 
     test.skip(qase("4", 'Skipped test'), () => {
-        expect(true).to.equal(true);
+        expect(true).toBe(true);
     })
 
     test(qase(["5", "6"], 'Failed test'), () => {
-        expect(true).to.equal(false);
+        expect(true).toBe(false);
     })
 });
 

--- a/qase-jest/examples/jest.config.js
+++ b/qase-jest/examples/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
             'jest-qase-reporter',
             {
                 projectCode: '',
+                environmentId: 1,
                 runComplete: true,
                 logging: true,
             },

--- a/qase-jest/examples/jest.config.js
+++ b/qase-jest/examples/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
             {
                 apiToken: '',
                 projectCode: '',
-                completeRun: true,
+                runComplete: true,
                 logging: true,
             },
         ],

--- a/qase-jest/examples/jest.config.js
+++ b/qase-jest/examples/jest.config.js
@@ -5,7 +5,6 @@ module.exports = {
         [
             'jest-qase-reporter',
             {
-                apiToken: '',
                 projectCode: '',
                 runComplete: true,
                 logging: true,

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-qase-reporter",
-  "version": "v1.1.1",
+  "version": "v1.2.0",
   "description": "Qase TMS Jest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-jest/src/index.ts
+++ b/qase-jest/src/index.ts
@@ -11,6 +11,7 @@ enum Envs {
     runName = 'QASE_RUN_NAME',
     runDescription = 'QASE_RUN_DESCRIPTION',
     runComplete = 'QASE_RUN_COMPLETE',
+    environmentId = 'QASE_ENVIRONMENT_ID',
 }
 
 const Statuses = {
@@ -28,6 +29,7 @@ interface QaseOptions {
     runPrefix?: string;
     logging?: boolean;
     runComplete?: boolean;
+    environmentId?: number;
 }
 
 const alwaysUndefined = () => undefined;
@@ -188,12 +190,19 @@ class QaseReporter implements Reporter {
         cb: (created: RunCreated | undefined) => void
     ): Promise<void> {
         try {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const environmentId = Number.parseInt(this.getEnv(Envs.environmentId)!, 10) || this.options.environmentId;
+
             const res = await this.api.runs.create(
                 this.options.projectCode,
                 new RunCreate(
                     name || `Automated run ${new Date().toISOString()}`,
                     [],
-                    {description: description || 'Jest automated run'}
+                    {
+                        description: description || 'Jest automated run',
+                        // eslint-disable-next-line camelcase
+                        environment_id: environmentId,
+                    }
                 )
             );
             cb(res.data);

--- a/qase-jest/src/index.ts
+++ b/qase-jest/src/index.ts
@@ -41,8 +41,8 @@ class QaseReporter implements Reporter {
 
     public constructor(_: Record<string, unknown>, _options: QaseOptions ) {
         this.options = _options;
-        this.options.runComplete = this.options.runComplete || !!this.getEnv(Envs.runComplete);
-        this.api = new QaseApi(this.options.apiToken || this.getEnv(Envs.apiToken) || '');
+        this.options.runComplete = !!this.getEnv(Envs.runComplete) || this.options.runComplete;
+        this.api = new QaseApi(this.getEnv(Envs.apiToken) || this.options.apiToken || '');
 
         this.log(chalk`{yellow Current PID: ${process.pid}}`);
 

--- a/qase-jest/src/index.ts
+++ b/qase-jest/src/index.ts
@@ -1,6 +1,5 @@
-/* eslint-disable no-console,@typescript-eslint/no-non-null-assertion */
 import { Reporter, Test, TestResult } from '@jest/reporters';
-import { ResultCreate, ResultCreated, ResultStatus, RunCreate, RunCreated } from 'qaseio/dist/src/models';
+import { ResultCreate, ResultStatus, RunCreate, RunCreated } from 'qaseio/dist/src/models';
 import { AssertionResult } from '@jest/types/build/TestResult';
 import { QaseApi } from 'qaseio';
 import chalk from 'chalk';
@@ -31,115 +30,110 @@ interface QaseOptions {
     runComplete?: boolean;
 }
 
+const alwaysUndefined = () => undefined;
+
 class QaseReporter implements Reporter {
     private api: QaseApi;
-    private pending: Array<(runId: string | number) => void> = [];
-    private results: Array<{test: AssertionResult; result: ResultCreated}> = [];
-    private shouldPublish = 0;
     private options: QaseOptions;
     private runId?: number | string;
     private isDisabled = false;
+    private publishedResultsCount = 0;
 
     public constructor(_: Record<string, unknown>, _options: QaseOptions ) {
         this.options = _options;
-        this.options.runComplete = this.options.runComplete ||
-            (this.getEnv(Envs.runComplete) ? true:'' !== '') || false;
+        this.options.runComplete = this.options.runComplete || !!this.getEnv(Envs.runComplete);
         this.api = new QaseApi(this.options.apiToken || this.getEnv(Envs.apiToken) || '');
+
+        this.log(chalk`{yellow Current PID: ${process.pid}}`);
 
         if (!this.getEnv(Envs.report)) {
             this.log(chalk`{yellow QASE_REPORT env variable is not set. Reporting to qase.io is disabled.}`);
             this.isDisabled = true;
             return;
         }
-
-        this.log(chalk`{yellow Current PID: ${process.pid}}`);
     }
 
-    public onRunStart(): void {
+    public async onRunStart(): Promise<void> {
         if (this.isDisabled) {
             return;
         }
 
-        this.checkProject(
+        return this.checkProject(
             this.options.projectCode,
-            (prjExists) => {
-                if (prjExists) {
-                    this.log(chalk`{green Project ${this.options.projectCode} exists}`);
-                    if (this.getEnv(Envs.runId) || this.options.runId) {
-                        this.saveRunId(this.getEnv(Envs.runId) || this.options.runId);
-                        this.checkRun(
-                            this.runId,
-                            (runExists: boolean) => {
-                                const run = this.runId as unknown as string;
-                                if (runExists) {
-                                    this.log(chalk`{green Using run ${run} to publish test results}`);
-                                } else {
-                                    this.log(chalk`{red Run ${run} does not exist}`);
-                                }
-                            }
-                        );
-                    } else if (!this.runId) {
-                        this.createRun(
-                            this.getEnv(Envs.runName),
-                            this.getEnv(Envs.runDescription),
-                            (created) => {
-                                if (created) {
-                                    this.saveRunId(created.id);
-                                    process.env.QASE_RUN_ID = created.id.toString();
-                                    this.log(chalk`{green Using run ${this.runId} to publish test results}`);
-                                } else {
-                                    this.log(chalk`{red Could not create run in project ${this.options.projectCode}}`);
-                                }
-                            }
-                        );
-                    }
-                } else {
+            async (prjExists): Promise<void> => {
+                if (!prjExists) {
                     this.log(chalk`{red Project ${this.options.projectCode} does not exist}`);
+                    this.isDisabled = true;
+                    return;
+                }
+
+                this.log(chalk`{green Project ${this.options.projectCode} exists}`);
+                const userDefinedRunId = this.getEnv(Envs.runId) || this.options.runId;
+                if (userDefinedRunId) {
+                    this.runId = userDefinedRunId;
+                    return this.checkRun(
+                        this.runId,
+                        (runExists: boolean) => {
+                            if (runExists) {
+                                this.log(chalk`{green Using run ${this.runId} to publish test results}`);
+                            } else {
+                                this.log(chalk`{red Run ${this.runId} does not exist}`);
+                                this.isDisabled = true;
+                            }
+                        }
+                    );
+                } else {
+                    return this.createRun(
+                        this.getEnv(Envs.runName),
+                        this.getEnv(Envs.runDescription),
+                        (created) => {
+                            if (created) {
+                                this.runId = created.id;
+                                process.env.QASE_RUN_ID = this.runId.toString();
+                                this.log(chalk`{green Using run ${this.runId} to publish test results}`);
+                            } else {
+                                this.log(chalk`{red Could not create run in project ${this.options.projectCode}}`);
+                                this.isDisabled = true;
+                            }
+                        }
+                    );
                 }
             }
         );
     }
 
-    public onTestResult(_test: Test, testResult: TestResult): void {
+    public async onTestResult(_test: Test, testResult: TestResult): Promise<void> {
         if (this.isDisabled) {
             return;
         }
 
-        testResult.testResults.map(((value) => {
-            this.publishCaseResult(value);
-        }));
+        return Promise.all(
+            testResult.testResults.map(
+                (value): Promise<void> => this.publishCaseResult(value)
+            )
+        ).then(alwaysUndefined);
     }
 
-    public onRunComplete(): void {
+    public async onRunComplete(): Promise<void> {
         if (this.isDisabled) {
             return;
         }
 
-        if (this.results.length === 0 && this.shouldPublish === 0) {
+        if (this.publishedResultsCount === 0) {
             this.log('No testcases were matched. Ensure that your tests are declared correctly.');
+            return;
         }
 
-        if (this.runId && this.shouldPublish !== 0 && this.options.runComplete) {
-            this.log(
-                chalk`{blue Waiting for 30 seconds to publish pending results}`
-            );
-            const endTime = Date.now() + 30e3;
+        if (!this.options.runComplete) {
+            return;
+        }
 
-            const interval = setInterval(() => {
-                if (this.shouldPublish === 0) {
-                    this.api.runs.complete(this.options.projectCode, this.runId!)
-                        .then(() => this.log(chalk`{green Run ${this.runId} completed}`))
-                        .catch((err) => this.log(`Error on completing run ${err as string}`));
-                    if (this.runId && this.shouldPublish !== 0) {
-                        this.log(
-                            chalk`{red Could not send all results for 30 seconds after run. Please contact Qase Team.}`
-                        );
-                    }
-                    clearInterval(interval);
-                } else if ((Date.now() > endTime)) {
-                    clearInterval(interval);
-                }
-            }, 200);
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            await this.api.runs.complete(this.options.projectCode, this.runId!);
+            this.log(chalk`{green Run ${this.runId} completed}`);
+        } catch (err) {
+            this.log(`Error on completing run ${err as string}`);
         }
     }
 
@@ -148,6 +142,7 @@ class QaseReporter implements Reporter {
 
     private log(message?: any, ...optionalParams: any[]) {
         if (this.options.logging){
+            // eslint-disable-next-line no-console
             console.log(chalk`{bold {blue qase:}} ${message}`, ...optionalParams);
         }
     }
@@ -156,7 +151,7 @@ class QaseReporter implements Reporter {
         return process.env[name];
     }
 
-    private getCaseId(test: AssertionResult): number[] {
+    private getCaseIds(test: AssertionResult): number[] {
         const regexp = /(\(Qase ID: ([\d,]+)\))/;
         const results = regexp.exec(test.title);
         if (results && results.length === 3) {
@@ -178,99 +173,93 @@ class QaseReporter implements Reporter {
         }
     }
 
-    private checkProject(projectCode: string, cb: (exists: boolean) => void) {
-        this.api.projects.exists(projectCode)
+    private checkProject(projectCode: string, cb: (exists: boolean) => Promise<void>): Promise<void> {
+        return this.api.projects.exists(projectCode)
             .then(cb)
             .catch((err) => {
                 this.log(err);
+                this.isDisabled = true;
             });
     }
 
-    private createRun(
-        name: string | undefined, description: string | undefined, cb: (created: RunCreated | undefined) => void
-    ) {
-        this.api.runs.create(
-            this.options.projectCode,
-            new RunCreate(
-                name || `Automated run ${new Date().toISOString()}`,
-                [],
-                {description: description || 'Jest automated run'}
-            )
-        )
-            .then((res) => res.data)
+    private async createRun(
+        name: string | undefined,
+        description: string | undefined,
+        cb: (created: RunCreated | undefined) => void
+    ): Promise<void> {
+        try {
+            const res = await this.api.runs.create(
+                this.options.projectCode,
+                new RunCreate(
+                    name || `Automated run ${new Date().toISOString()}`,
+                    [],
+                    {description: description || 'Jest automated run'}
+                )
+            );
+            cb(res.data);
+        } catch (err) {
+            this.log(`Error on creating run ${err as string}`);
+            this.isDisabled = true;
+        }
+    }
+
+    private async checkRun(runId: string | number | undefined, cb: (exists: boolean) => void): Promise<void> {
+        if (runId === undefined) {
+            cb(false);
+            return;
+        }
+
+        return this.api.runs.exists(this.options.projectCode, runId)
             .then(cb)
             .catch((err) => {
-                this.log(`Error on creating run ${err as string}`);
+                this.log(`Error on checking run ${err as string}`);
+                this.isDisabled = true;
             });
+
     }
 
-    private checkRun(runId: string | number | undefined, cb: (exists: boolean) => void) {
-        if (runId !== undefined) {
-            this.api.runs.exists(this.options.projectCode, runId)
-                .then(cb)
-                .catch((err) => {
-                    this.log(`Error on checking run ${err as string}`);
-                });
-        } else {
-            cb(false);
-        }
-    }
-
-    private saveRunId(runId?: string | number) {
-        this.runId = runId;
-        if (this.runId) {
-            while (this.pending.length) {
-                this.log(`Number of pending: ${this.pending.length}`);
-                const cb = this.pending.shift();
-                if (cb) {
-                    cb(this.runId);
-                }
-            }
-        }
-    }
-
-    private publishCaseResult(test: AssertionResult){
+    private async publishCaseResult(test: AssertionResult): Promise<void> {
         this.logTestItem(test);
 
-        const caseIds = this.getCaseId(test);
-        caseIds.forEach((caseId) => {
-            this.shouldPublish++;
-            const publishTest = (runId: string | number) => {
-                if (caseId) {
+        const caseIds = this.getCaseIds(test);
+        if (caseIds.length === 0) {
+            // TODO: autocreate case for result
+            return;
+        }
+        return Promise.all(
+            caseIds.map(
+                async (caseId) => {
                     const add = caseIds.length > 1 ? chalk` {white For case ${caseId}}`:'';
                     this.log(
                         chalk`{gray Start publishing: ${test.title}}${add}`
                     );
                     test.failureMessages = test.failureMessages.map((value) => value.replace(/\u001b\[.*?m/g, ''));
-                    this.api.results.create(this.options.projectCode, runId, new ResultCreate(
-                        caseId,
-                        Statuses[test.status],
-                        {
-                            time: test.duration!,
-                            stacktrace: test.failureMessages.join('\n'),
-                            comment: test.failureMessages.length > 0 ? test.failureMessages.map(
-                                (value) => value.split('\n')[0]
-                            ).join('\n'):undefined,
-                        }
-                    ))
-                        .then((res) => {
-                            this.results.push({test, result: res.data});
-                            this.log(chalk`{gray Result published: ${test.title} ${res.data.hash}}${add}`);
-                            this.shouldPublish--;
-                        })
-                        .catch((err) => {
-                            this.log(err);
-                            this.shouldPublish--;
-                        });
+                    try {
+                        const res = await this.api.results.create(
+                            this.options.projectCode,
+                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                            this.runId!,
+                            new ResultCreate(
+                                caseId,
+                                Statuses[test.status],
+                                {
+                                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                                    time: test.duration!,
+                                    stacktrace: test.failureMessages.join('\n'),
+                                    comment: test.failureMessages.length > 0 ? test.failureMessages.map(
+                                        (value) => value.split('\n')[0]
+                                    ).join('\n'):undefined,
+                                }
+                            ));
+                        this.publishedResultsCount++;
+                        this.log(chalk`{gray Result published: ${test.title} ${res.data.hash}}${add}`);
+                    } catch (err) {
+                        this.log(err);
+                    }
                 }
-            };
+            )
+        ).then(alwaysUndefined);
 
-            if (this.runId) {
-                publishTest(this.runId);
-            } else {
-                this.pending.push(publishTest);
-            }
-        });
     }
 }
 


### PR DESCRIPTION
- massive rewrite to avoid async bugs (closes #17)
- make all options passed as env variables take precedence over options from config
- add new option `environmentId` (and corresponding env variable `QASE_ENVIRONMENT_ID`) to specify run environment (closes #42)
- minor tweaks to docs and examples