### PR TITLE
Updated the RunCreate class with is_autotest field

### DIFF
--- a/qaseio/src/models/runs.ts
+++ b/qaseio/src/models/runs.ts
@@ -12,7 +12,7 @@ export class RunFilters {
         public filter: {
             status?: RunStatus[];
         }
-    ) {}
+    ) { }
 }
 
 export class RunCreate {
@@ -24,6 +24,7 @@ export class RunCreate {
         args?: {
             description?: string;
             environment_id?: number;
+            is_autotest: boolean;
         },
     ) {
         Object.assign(this, args);
@@ -34,7 +35,7 @@ export interface RunCreated {
     id: number;
 }
 
-export interface RunInfoStats{
+export interface RunInfoStats {
     total: any;
     untested: any;
     passed: any;
@@ -45,7 +46,7 @@ export interface RunInfoStats{
     deleted: any;
 }
 
-export interface RunInfo{
+export interface RunInfo {
     id: any;
     title: any;
     description: any;

--- a/qaseio/test/services/runs.test.ts
+++ b/qaseio/test/services/runs.test.ts
@@ -9,9 +9,9 @@ const mock = new MockAdapter(axios);
 
 describe('Run api', () => {
     Array.from([
-        {limit: 10, offset: 30},
-        {offset: 30},
-        {limit: 10},
+        { limit: 10, offset: 30 },
+        { offset: 30 },
+        { limit: 10 },
     ]).forEach((params) => {
         it('Get all runs', async () => {
             const content = list(run())
@@ -33,9 +33,9 @@ describe('Run api', () => {
 
 
     Array.from([
-        {status: 200, content: run(), equal: true},
-        {status: 404, content: {}, equal: false},
-    ]).forEach(({status, content, equal}) => {
+        { status: 200, content: run(), equal: true },
+        { status: 404, content: {}, equal: false },
+    ]).forEach(({ status, content, equal }) => {
         it('Check run exists', async () => {
             mock.onGet("/run/TEST/123").reply(status, statusTrue(content))
             const client = new QaseApi('123')
@@ -45,16 +45,17 @@ describe('Run api', () => {
     })
 
     it('Create new run', async () => {
-        const content = {id: 1}
+        const content = { id: 1 }
         mock.onPost("/run/TEST").reply(200, statusTrue(content))
         const client = new QaseApi('123')
-        const create = new RunCreate("new", [1,2,3], {environment_id: 1, description: "some"})
+        const create = new RunCreate("new", [1, 2, 3], { environment_id: 1, description: "some", is_autotest: true })
         const resp: AxiosResponse<RunCreated> = await client.runs.create('TEST', create)
         expect(resp.config.data).toEqual(JSON.stringify({
             title: 'new',
             cases: [1, 2, 3],
             environment_id: 1,
             description: 'some',
+            is_autotest: true,
         }))
         expect(resp.data).toEqual(content as RunCreated)
     })
@@ -68,10 +69,10 @@ describe('Run api', () => {
 
     it('Validate filters', () => {
         const filter = new Filter(new RunFilters(
-            {status: [RunStatus.ABORT, RunStatus.ACTIVE]}
+            { status: [RunStatus.ABORT, RunStatus.ACTIVE] }
         ).filter);
         expect(filter.filter()).toEqual(
-            {"filters[status]": "abort,active"}
+            { "filters[status]": "abort,active" }
         )
     })
 })


### PR DESCRIPTION
Link to. API: https://developers.qase.io/reference/create-run

When we try to create a Test Run with qase-jest-reporter, the new Test Run has no is_autotest field.
So when we try to filter all test runs by the Automation filter, we see an empty page instead of the Test Run we just created.