### PR TITLE
[qase-playwright] ignore unnecessary ts files when build

### DIFF
--- a/qase-playwright/package-lock.json
+++ b/qase-playwright/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "v1.1.0",
+  "version": "v1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-qase-reporter",
-      "version": "v1.1.0",
+      "version": "v1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "qaseio": "^1.5.0"

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "v1.1.0",
+  "version": "v1.1.1",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/tsconfig.json
+++ b/qase-playwright/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es2020", "dom"],                 /* Specify library files to be included in the compilation. */
+    "lib": ["es2015", "dom"],                 /* Specify library files to be included in the compilation. */
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     "declarationDir": "./dist",               /* Output directory for generated declaration files. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
@@ -18,6 +18,8 @@
     "node_modules",
     "dist",
     "demo",
+    "**/**.test.ts",
+    "**/playwright.config.ts",
     "**/webpack.config.ts"
   ],
   "compilation": {

--- a/qase-playwright/tsconfig.json
+++ b/qase-playwright/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es2015", "dom"],                 /* Specify library files to be included in the compilation. */
+    "lib": ["es2020", "dom"],                 /* Specify library files to be included in the compilation. */
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     "declarationDir": "./dist",               /* Output directory for generated declaration files. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */


### PR DESCRIPTION
Problem: compiler puts js files to /dist/src instead of /dist
Solution: ignore unnecessary ts files when building