### PR TITLE
[qase-cypress] Feature request: Removing dependency on deasync

### DIFF
--- a/qase-cypress/package-lock.json
+++ b/qase-cypress/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "v1.3.2",
+  "version": "v1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1122,12 +1122,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/deasync": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@types/deasync/-/deasync-0.1.1.tgz",
-      "integrity": "sha512-/AsDEUsHjyzMX0UjPgysggxFO8r7//c4aS9aeQwHzgs5POBsqaBFWW9+KYFGUyx/VYT4HrT/+JzAGTEEL2d4OQ==",
-      "dev": true
-    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1760,14 +1754,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -2593,15 +2579,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
-    },
-    "deasync": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.21.tgz",
-      "integrity": "sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
-      }
     },
     "debug": {
       "version": "3.1.0",
@@ -3489,11 +3466,6 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -6072,11 +6044,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -29,13 +29,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "deasync": "^0.1.21",
     "qaseio": "^1.5.0"
   },
   "devDependencies": {
     "@hutson/npm-deploy-git-tag": "^6.0.0",
     "@types/chalk": "^2.2.0",
-    "@types/deasync": "^0.1.1",
     "@types/jest": "^23.3.7",
     "@types/mocha": "^7.0.2",
     "@typescript-eslint/eslint-plugin": "^3.10.1",

--- a/qase-cypress/src/index.ts
+++ b/qase-cypress/src/index.ts
@@ -3,7 +3,6 @@ import { MochaOptions, Runner, Test, reporters } from 'mocha';
 import { ResultCreate, ResultCreated, ResultStatus, RunCreate, RunCreated } from 'qaseio/dist/src/models';
 import { QaseApi } from 'qaseio';
 import chalk from 'chalk';
-import { sleep } from 'deasync';
 
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -121,8 +120,10 @@ class CypressQaseReporter extends reporters.Base {
                 );
                 const endTime = Date.now() + 30e3;
                 while ((this.shouldPublish !== 0) && (Date.now() < endTime)) {
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-                    sleep(500);
+                    // sleep 500 ms
+                    const sharedArrayBuffer = new SharedArrayBuffer(8);
+                    const int32array = new Int32Array(sharedArrayBuffer);
+                    Atomics.wait(int32array, 0, 0, 500);
                 }
                 if (this.runId && this.shouldPublish !== 0) {
                     this.log(


### PR DESCRIPTION
Related: #74 

## Feature request

`deasync` (https://github.com/abbr/deasync) is a native dependency, which can cause problems on many platforms.
Would it be possible to remove it?

- https://github.com/cypress-io/cypress-parcel-preprocessor/issues/39
- https://github.com/abbr/deasync/issues/142

## Strategy

use Atomics.wait (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait)