### PR TITLE
added form-data constructor to api init params

### DIFF
--- a/qaseio/package-lock.json
+++ b/qaseio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qaseio",
-  "version": "v2.0.0",
+  "version": "v2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qaseio",
-      "version": "v2.0.0",
+      "version": "v2.0.1",
       "license": "Apache 2.0",
       "dependencies": {
         "axios": "^0.25.0",

--- a/qaseio/package.json
+++ b/qaseio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qaseio",
-  "version": "v2.0.0",
+  "version": "v2.1.0",
   "description": "Qase TMS Javascript Api Client",
   "main": "./dist/src/qaseio.js",
   "types": "./dist/src/qaseio.d.ts",

--- a/qaseio/package.json
+++ b/qaseio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qaseio",
-  "version": "v2.1.0",
+  "version": "v2.0.1",
   "description": "Qase TMS Javascript Api Client",
   "main": "./dist/src/qaseio.js",
   "types": "./dist/src/qaseio.d.ts",

--- a/qaseio/src/qaseio.ts
+++ b/qaseio/src/qaseio.ts
@@ -36,7 +36,8 @@ export class QaseApi {
     public constructor(
         apiToken: string,
         basePath?: string,
-        headers?: { [key: string]: string }
+        headers?: { [key: string]: string },
+        formDataCtor?: new () => any,
     ) {
         const baseURL = basePath || 'https://api.qase.io/v1';
         const config: AxiosRequestConfig = {
@@ -50,6 +51,7 @@ export class QaseApi {
         this.configuration = new Configuration({
             apiKey: apiToken,
             basePath: baseURL,
+            formDataCtor: formDataCtor
         });
 
         this.projects = new ProjectsApi(this.configuration, baseURL, this.api);

--- a/qaseio/src/qaseio.ts
+++ b/qaseio/src/qaseio.ts
@@ -51,7 +51,7 @@ export class QaseApi {
         this.configuration = new Configuration({
             apiKey: apiToken,
             basePath: baseURL,
-            formDataCtor: formDataCtor
+            formDataCtor,
         });
 
         this.projects = new ProjectsApi(this.configuration, baseURL, this.api);


### PR DESCRIPTION
Problem: for attachments uploading, we need to use in api FormData library, but it is not imported in autogenerated clients
Solution: inject FormData via ApiClient constructor