### PR TITLE
added the missed `environment_id`

### DIFF
--- a/qase-playwright/src/index.ts
+++ b/qase-playwright/src/index.ts
@@ -225,6 +225,7 @@ class PlaywrightReporter implements Reporter {
                 this.options.projectCode,
                 new RunCreate(name || `Automated run ${new Date().toLocaleString()}`, [], {
                     description: description || 'Playwright automated run',
+                    environment_id: Number.parseInt(this.getEnv(Envs.environmentId)!, 10) || this.options.environmentId,
                     // eslint-disable-next-line camelcase
                     is_autotest: true,
                 })


### PR DESCRIPTION
Added the missed property `environment_id` to the create run method of the qase-playwright reporter.