### PR TITLE
feat:cypress auto create defect

### DIFF
--- a/qase-cypress/src/index.ts
+++ b/qase-cypress/src/index.ts
@@ -10,7 +10,7 @@ import { readFileSync } from 'fs';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const { EVENT_TEST_FAIL, EVENT_TEST_PASS, EVENT_TEST_PENDING, EVENT_RUN_END } =
-  Runner.constants;
+    Runner.constants;
 
 enum Envs {
     report = 'QASE_REPORT',
@@ -44,6 +44,7 @@ interface BulkCaseObject {
     time_ms: number;
     stacktrace?: string;
     comment: string;
+    defect: boolean;
 }
 
 class CypressQaseReporter extends reporters.Base {
@@ -163,8 +164,7 @@ class CypressQaseReporter extends reporters.Base {
             'cypress-qase-reporter'
         );
         const xPlatformHeader = `node=${nodeVersion}; npm=${npmVersion}; os=${os}; arch=${arch}`;
-        const xClientHeader = `cypress=${cypressVersion as string}; qase-cypress=${
-            cypressCaseReporterVersion as string
+        const xClientHeader = `cypress=${cypressVersion as string}; qase-cypress=${cypressCaseReporterVersion as string
         }; qaseapi=${qaseapiVersion as string}`;
 
         return {
@@ -276,8 +276,8 @@ class CypressQaseReporter extends reporters.Base {
     ): Promise<void> {
         try {
             const environmentId =
-        Number(CypressQaseReporter.getEnv(Envs.environmentId)) ||
-        this.options.environmentId;
+                Number(CypressQaseReporter.getEnv(Envs.environmentId)) ||
+                this.options.environmentId;
 
             const runObject = CypressQaseReporter.createRunObject(
                 name || `Automated run ${new Date().toISOString()}`,
@@ -313,8 +313,7 @@ class CypressQaseReporter extends reporters.Base {
             .getRun(this.options.projectCode, Number(runId))
             .then((resp) => {
                 this.log(
-                    `Get run result on checking run ${
-            resp.data.result?.id as unknown as string
+                    `Get run result on checking run ${resp.data.result?.id as unknown as string
                     }`
                 );
                 cb(Boolean(resp.data.result?.id));
@@ -361,8 +360,9 @@ class CypressQaseReporter extends reporters.Base {
                     time_ms: test.duration || 0,
                     stacktrace: test.err?.stack,
                     comment: test.err ? `${test.err.name}: ${test.err.message}` : '',
+                    defect: status === ResultCreateStatusEnum.FAILED,
                 };
-                this.resultsForPublishing.push(caseResultBulkObject );
+                this.resultsForPublishing.push(caseResultBulkObject);
             }
         });
     }

--- a/qase-cypress/test/plugin.test.ts
+++ b/qase-cypress/test/plugin.test.ts
@@ -70,7 +70,7 @@ describe('Client', () => {
         ];
 
         const runner = new mocha.Runner(new mocha.Suite('new'), false)
-        const options = { reporterOptions: { apiToken: "", autoAddDefect: true } };
+        const options = { reporterOptions: { apiToken: "" } };
         qReporter = new QaseCypressReporter(runner, options);
 
         testData.forEach(test => {

--- a/qase-cypress/test/plugin.test.ts
+++ b/qase-cypress/test/plugin.test.ts
@@ -1,11 +1,88 @@
-import 'jest';
+import { describe, expect, it } from '@jest/globals';
 import mocha from 'mocha';
 import QaseCypressReporter from '../src';
 
 describe('Client', () => {
     it('Init client', () => {
         const runner = new mocha.Runner(new mocha.Suite('new'), false)
-        const options = {reporterOptions: {apiToken: ""}};
+        const options = { reporterOptions: { apiToken: "" } };
         new QaseCypressReporter(runner, options);
     });
+
+    describe('Auto add defect', () => {
+        let qReporter;
+        const testData = [{
+            test: {
+                title: 'Test (Qase ID: 1)',
+                duration: 1,
+                err: {
+                    message: 'Error message',
+                    stack: 'Error stack',
+                    name: 'Error name'
+                }
+            },
+            status: 'failed',
+            defect: true
+        }, {
+            test: {
+                title: 'Test (Qase ID: 2)',
+                duration: 1,
+                err: null,
+            },
+            status: 'passed',
+            defect: false
+        }, {
+            test: {
+                title: 'Test (Qase ID: 3)',
+                duration: 0,
+                err: null,
+            },
+            status: 'skipped',
+            defect: false
+        },
+        {
+            test: {
+                title: 'Test (Qase ID: 4)',
+                duration: 1,
+                err: null,
+            },
+            status: 'in_progress',
+            defect: false
+        },
+        {
+            test: {
+                title: 'Test (Qase ID: 5)',
+                duration: 1,
+                err: null,
+            },
+            status: 'invalid',
+            defect: false
+        },
+        {
+            test: {
+                title: 'Test (Qase ID: 6)',
+                duration: 1,
+                err: null,
+            },
+            status: 'blocked',
+            defect: false
+        }
+        ];
+
+        const runner = new mocha.Runner(new mocha.Suite('new'), false)
+        const options = { reporterOptions: { apiToken: "", autoAddDefect: true } };
+        qReporter = new QaseCypressReporter(runner, options);
+
+        testData.forEach(test => {
+            // add test data
+            qReporter['transformCaseResultToBulkObject'](test.test, test.status);
+        });
+
+        for (const index in testData) {
+            // check test data in bulk object
+            it(`should set defect=${testData[index].defect} when status=${testData[index].status}`, () => {
+                expect(qReporter['resultsForPublishing'][index].defect).toBe(testData[index].defect);
+            });
+        }
+    })
 });


### PR DESCRIPTION
Adding support for `auto create defects` when a test fails by setting defect to true in Qase test results. 

**What changed:**
- Added a defect field to `caseResultBulkObject` objects  and set to true only if the test result is `failed`.
- Added unit test to verify that all `resultsForPublishing` has a defect field and the value is set appropriately based on the test status.

<img width="1053" alt="auto-defect-tests" src="https://user-images.githubusercontent.com/12203794/179866718-69152c00-88ef-4b80-b6b7-50f0f043642e.png">
<img width="1088" alt="auto-defect" src="https://user-images.githubusercontent.com/12203794/179866724-547f0390-8f68-4445-9c1e-90ce481b8a8b.png">


**How to test**:  
1. Run cypress tests as normal 
2. Confirm that defect/s is created for failed tests automatically