### PR TITLE
feat:playwright auto create defect

### DIFF
--- a/qase-playwright/src/index.ts
+++ b/qase-playwright/src/index.ts
@@ -224,7 +224,7 @@ class PlaywrightReporter implements Reporter {
         if (this.isDisabled) {
             return;
         }
-        this.queued ++;
+        this.queued++;
         let attachmentsArray: any[] = [];
         if (this.options.uploadAttachments && testResult.attachments.length > 0) {
             attachmentsArray = await this.uploadAttachments(testResult);
@@ -238,9 +238,9 @@ class PlaywrightReporter implements Reporter {
         }
 
         await new Promise((resolve, reject) => {
-            let timer  = 0;
-            const interval = setInterval( () => {
-                timer ++;
+            let timer = 0;
+            const interval = setInterval(() => {
+                timer++;
                 if (this.runId && this.queued === 0) {
                     clearInterval(interval);
                     resolve();
@@ -397,7 +397,7 @@ class PlaywrightReporter implements Reporter {
     }
 
     private prepareCaseResult(test: TestCase, testResult: TestResult, attachments: any[]) {
-        this.queued --;
+        this.queued--;
         this.logTestItem(test, testResult);
         const caseIds = this.getCaseIds(test);
         const caseObject: ResultCreate = {
@@ -409,6 +409,7 @@ class PlaywrightReporter implements Reporter {
             attachments: attachments.length > 0
                 ? attachments
                 : undefined,
+            defect: testResult.status === Statuses.failed,
         };
 
         if (caseIds.length === 0) {

--- a/qase-playwright/src/index.ts
+++ b/qase-playwright/src/index.ts
@@ -409,7 +409,7 @@ class PlaywrightReporter implements Reporter {
             attachments: attachments.length > 0
                 ? attachments
                 : undefined,
-            defect: testResult.status === Statuses.failed,
+            defect: Statuses[testResult.status] === Statuses.failed,
         };
 
         if (caseIds.length === 0) {

--- a/qase-playwright/test/plugin.test.ts
+++ b/qase-playwright/test/plugin.test.ts
@@ -1,9 +1,60 @@
 import PlaywrightReporter from '../src';
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 test.describe('Client', () => {
     test('Init client', () => {
-        const options = {apiToken: '', projectCode: ''};
+        const options = { apiToken: '', projectCode: '' };
         new PlaywrightReporter(options);
+    });
+
+    test.describe('Auto Create Defect', () => {
+        const options = { apiToken: '', projectCode: '' };
+        const pReporter = new PlaywrightReporter(options);
+
+        const testData = [
+            {
+                testCase: { title: 'Test (Qase ID: 1)' },
+                testResult: { status: 'failed' },
+                attachments: [],
+                defect: true
+            },
+            {
+                testCase: { title: 'Test (Qase ID: 2)' },
+                testResult: { status: 'passed' },
+                attachments: [],
+                defect: false
+            },
+            {
+                testCase: { title: 'Test (Qase ID: 3)' },
+                testResult: { status: 'skipped' },
+                attachments: [],
+                defect: false
+            },
+            {
+                testCase: { title: 'Test (Qase ID: 4)' },
+                testResult: { status: 'disabled' },
+                attachments: [],
+                defect: false
+            },
+            {
+                testCase: { title: 'Test (Qase ID: 5)' },
+                testResult: { status: 'pending' },
+                attachments: [],
+                defect: false
+            }
+        ];
+
+        testData.forEach(data => {
+            pReporter['prepareCaseResult'](data.testCase as any, data.testResult as any, data.attachments);
+        });
+
+        for (const index in testData) {
+            let status = testData[index].testResult.status;
+            let expectedDefect = testData[index].defect;
+
+            test(`should set defect=${expectedDefect} when status=${status}`, async () => {
+                expect(pReporter['resultsToBePublished'][index].defect).toBe(expectedDefect);
+            });
+        };
     });
 });


### PR DESCRIPTION
Adding support for auto create defects when a test fails by setting defect to true in Qase test results.

**What changed**:

Added a defect field to `caseObject` objects and set to true only if the test result is failed.
Added unit test to verify that all resultsForPublishing has a defect field and the value is set appropriately based on the test status.

<img width="1088" alt="Xnapper-2022-07-20-06 34 49" src="https://user-images.githubusercontent.com/12203794/179973283-415a0a3a-9221-413f-aaa4-4792da095b2a.png">
<img width="1088" alt="Xnapper-2022-07-20-06 36 08" src="https://user-images.githubusercontent.com/12203794/179973290-79d5cefa-79d8-414c-9b80-cce420c16ee4.png">


**How to test**:
1. Run playwright tests as normal
2. Confirm that defect/s is created for failed tests automatically