### PR TITLE
feat: [qase-cucumberjs] added support for create auto defect and unit tests

### DIFF
--- a/qase-cucumberjs/src/index.ts
+++ b/qase-cucumberjs/src/index.ts
@@ -1,16 +1,16 @@
 /* eslint-disable camelcase */
 /* eslint-disable max-len */
 /* eslint-disable no-console,no-underscore-dangle,@typescript-eslint/no-non-null-assertion */
-import {IdResponse, ResultCreate, ResultCreateStatusEnum} from 'qaseio/dist/src';
+import { IdResponse, ResultCreate, ResultCreateStatusEnum } from 'qaseio/dist/src';
 import FormData from 'form-data';
-import {Formatter} from '@cucumber/cucumber';
-import {IFormatterOptions} from '@cucumber/cucumber/lib/formatter';
-import {QaseApi} from 'qaseio';
+import { Formatter } from '@cucumber/cucumber';
+import { IFormatterOptions } from '@cucumber/cucumber/lib/formatter';
+import { QaseApi } from 'qaseio';
 import chalk from 'chalk';
 import crypto from 'crypto';
-import {execSync} from 'child_process';
+import { execSync } from 'child_process';
 import fs from 'fs';
-import {io} from '@cucumber/messages/dist/src/messages';
+import { io } from '@cucumber/messages/dist/src/messages';
 import mime from 'mime-types';
 import moment from 'moment';
 import os from 'os';
@@ -71,7 +71,7 @@ class CustomBoundaryFormData extends FormData {
 
 const loadJSON = (file: string): Config | undefined => {
     try {
-        const data = fs.readFileSync(file, {encoding: 'utf8'});
+        const data = fs.readFileSync(file, { encoding: 'utf8' });
 
         if (data) {
             return JSON.parse(data) as Config;
@@ -117,7 +117,7 @@ const prepareReportName = (
 };
 
 const verifyConfig = (config: Config) => {
-    const {enabled, apiToken, projectCode} = config;
+    const { enabled, apiToken, projectCode } = config;
     if (enabled) {
         if (!projectCode) {
             console.log(chalk`{bold {blue qase:}} {red Project Code should be provided}`);
@@ -356,7 +356,7 @@ class QaseReporter extends Formatter {
     }
 
     private _log(message?: any, ...optionalParams: any[]) {
-        if (this.config.logging){
+        if (this.config.logging) {
             console.log(chalk`{bold {blue qase:}} ${message}`, ...optionalParams);
         }
     }
@@ -453,7 +453,7 @@ class QaseReporter extends Formatter {
         }
     }
 
-    private addForSending(test: Test, status: ResultCreateStatusEnum){
+    private addForSending(test: Test, status: ResultCreateStatusEnum) {
         this.logTestItem(test.name, status);
 
         if (test.caseIds.length) {
@@ -480,6 +480,7 @@ class QaseReporter extends Formatter {
                 time: test.duration,
                 stacktrace: test.error,
                 comment: test.error ? test.error.split('\n')[0] : undefined,
+                defect: status === ResultCreateStatusEnum.FAILED,
             };
         });
     }
@@ -503,6 +504,7 @@ class QaseReporter extends Formatter {
             time: test.duration,
             stacktrace: test.error,
             comment: test.error ? test.error.split('\n')[0] : undefined,
+            defect: status === ResultCreateStatusEnum.FAILED,
         };
     }
 

--- a/qase-cucumberjs/test/plugin.test.ts
+++ b/qase-cucumberjs/test/plugin.test.ts
@@ -1,9 +1,175 @@
-import 'jest';
-import {IFormatterOptions} from "@cucumber/cucumber/lib/formatter";
+import { describe, expect, it } from '@jest/globals';
+import { IFormatterOptions } from "@cucumber/cucumber/lib/formatter";
 import Index from '../src';
 
 describe('Tests', () => {
     it('Init main class', () => {
-        new Index({parsedArgvOptions:{}} as unknown as IFormatterOptions);
+        new Index({ parsedArgvOptions: {} } as unknown as IFormatterOptions);
+    });
+
+    describe('Auto Create Defect', () => {
+        const qReporter = new Index({ parsedArgvOptions: {} } as unknown as IFormatterOptions);
+
+        describe('known test cases', () => {
+            const testData = [
+                {
+                    test: {
+                        name: 'Test 1',
+                        caseIds: [1],
+                        status: 'failed',
+                        duration: 1,
+                        finished: {
+                            testCaseStartedId: 'c6e6a2f8-245b12-k1'
+                        },
+                    },
+                    defect: true,
+                },
+                {
+                    test: {
+                        name: 'Test 2',
+                        caseIds: [2],
+                        status: 'passed',
+                        duration: 1,
+                        finished: {
+                            testCaseStartedId: 'c6e6a2f8-245b12-k2'
+                        },
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        name: 'Test 3',
+                        caseIds: [3],
+                        status: 'pending',
+                        duration: 1,
+                        finished: {
+                            testCaseStartedId: 'c6e6a2f8-245b12-k3'
+                        },
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        name: 'Test 4',
+                        caseIds: [4],
+                        status: null,
+                        duration: 1,
+                        finished: {
+                            testCaseStartedId: 'c6e6a2f8-245b12-k4'
+                        },
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        name: 'Test 5',
+                        caseIds: [5],
+                        status: 'skipped',
+                        duration: 1,
+                        finished: {
+                            testCaseStartedId: 'c6e6a2f8-245b12-k5'
+                        },
+                    },
+                    defect: false,
+                },
+            ]
+
+            testData.forEach(tD => {
+                qReporter['addForSending'](tD.test as any, tD.test.status as any);
+            })
+
+            testData.map(tD => {
+                return {
+                    caseId: tD.test.finished.testCaseStartedId,
+                    defectValue: tD.defect,
+                    status: tD.test.status,
+                }
+            }).forEach(eTestData => {
+                it(`should set defect=${eTestData.defectValue} when status=${eTestData.status}`, () => {
+                    expect(qReporter['results'][eTestData.caseId].defect).toBe(eTestData.defectValue);
+                });
+            });
+        });
+
+        describe('unknown test cases', () => {
+            const testData = [
+                {
+                    test: {
+                        name: 'Test 1',
+                        caseIds: [],
+                        status: 'failed',
+                        duration: 1,
+                        finished: {
+                            testCaseStartedId: 'c6e6a2f8-245b12-u1'
+                        },
+                    },
+                    defect: true,
+                },
+                {
+                    test: {
+                        name: 'Test 2',
+                        caseIds: [],
+                        status: 'passed',
+                        duration: 1,
+                        finished: {
+                            testCaseStartedId: 'c6e6a2f8-245b12-u2'
+                        },
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        name: 'Test 3',
+                        caseIds: [],
+                        status: 'pending',
+                        duration: 1,
+                        finished: {
+                            testCaseStartedId: 'c6e6a2f8-245b12-u3'
+                        },
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        name: 'Test 4',
+                        caseIds: [],
+                        status: null,
+                        duration: 1,
+                        finished: {
+                            testCaseStartedId: 'c6e6a2f8-245b12-u4'
+                        },
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        name: 'Test 5',
+                        caseIds: [],
+                        status: 'skipped',
+                        duration: 1,
+                        finished: {
+                            testCaseStartedId: 'c6e6a2f8-245b12-u5'
+                        },
+                    },
+                    defect: false,
+                }
+            ]
+
+            testData.forEach(tD => {
+                qReporter['addForSending'](tD.test as any, tD.test.status as any);
+            })
+
+            testData.map(tD => {
+                return {
+                    caseId: tD.test.finished.testCaseStartedId,
+                    defectValue: tD.defect,
+                    status: tD.test.status,
+                }
+            }).forEach(eTestData => {
+                it(`should set defect=${eTestData.defectValue} when status=${eTestData.status}`, () => {
+                    expect(qReporter['results'][eTestData.caseId].defect).toBe(eTestData.defectValue);
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
Adding support for auto create defects when a test fails by setting defect to true in Qase test results.

**What changed**:

Added a defect field to `ResultCreate` objects and set to true only if the test result is failed.
Added unit test to verify that all results has a defect field and the value is set appropriately based on the test status. (both known and unknown cases)

<img width="1349" alt="cj-defect" src="https://user-images.githubusercontent.com/12203794/180103819-8c45d284-9009-47e0-845b-f0b265750bd5.png">
<img width="775" alt="cjs-tests" src="https://user-images.githubusercontent.com/12203794/180103821-222c0746-4148-44c3-afc5-086053814b5f.png">


**How to test**:
1. Run cucumberjs tests as normal
2. Confirm that defect/s is created for failed tests automatically