### PR TITLE
feat: [qase-testcafe] add support for auto create defect and unit tests

### DIFF
--- a/qase-testcafe/examples/package.json
+++ b/qase-testcafe/examples/package.json
@@ -4,7 +4,7 @@
   "description": "Test cafe example",
   "main": "test.js",
   "scripts": {
-    "test": "npx testcafe chrome test.js test2.js -r spec,qase -s path=screenshots,takeOnFails=true,fullPage=true"
+    "test": "npx testcafe chrome test.js test2.js -r spec,qase -s path=screenshots,takeOnFails=true"
   },
   "author": "",
   "license": "ISC",

--- a/qase-testcafe/src/index.ts
+++ b/qase-testcafe/src/index.ts
@@ -5,10 +5,10 @@ import { CustomBoundaryFormData, customBoundary } from './CustomBoundaryFormData
 import {
     IdResponse, ResultCreate, ResultCreateStatusEnum,
 } from 'qaseio/dist/src';
-import {createReadStream, readFileSync} from 'fs';
+import { createReadStream, readFileSync } from 'fs';
 import { QaseApi } from 'qaseio';
 import chalk from 'chalk';
-import {execSync} from 'child_process';
+import { execSync } from 'child_process';
 import moment from 'moment';
 import path from 'path';
 import RuntimeError = WebAssembly.RuntimeError;
@@ -279,7 +279,7 @@ class TestcafeQaseReporter {
         if (!this.enabled) {
             return;
         }
-        this.queued ++;
+        this.queued++;
         const hasErr = testRunInfo.errs.length;
         let testStatus: ResultCreateStatusEnum;
 
@@ -303,7 +303,7 @@ class TestcafeQaseReporter {
             attachmentsArray = await this.uploadAttachments(testRunInfo);
         }
 
-        this.prepareCaseResult({name, info: testRunInfo, meta, error: errorLog}, testStatus, attachmentsArray);
+        this.prepareCaseResult({ name, info: testRunInfo, meta, error: errorLog }, testStatus, attachmentsArray);
     };
 
     public reportTaskDone = async () => {
@@ -311,9 +311,9 @@ class TestcafeQaseReporter {
             return;
         }
         await new Promise((resolve, reject) => {
-            let timer  = 0;
-            const interval = setInterval( () => {
-                timer ++;
+            let timer = 0;
+            const interval = setInterval(() => {
+                timer++;
                 if (this.config.runId && this.queued === 0) {
                     clearInterval(interval);
                     resolve();
@@ -361,7 +361,7 @@ class TestcafeQaseReporter {
     }
 
     private log(message?: any, ...optionalParams: any[]) {
-        if (this.config.logging){
+        if (this.config.logging) {
             console.log(chalk`{bold {blue qase:}} ${message}`, ...optionalParams);
         }
     }
@@ -446,17 +446,18 @@ class TestcafeQaseReporter {
         }
     }
 
-    private prepareCaseResult(test: Test, status: ResultCreateStatusEnum, attachments: any[]){
+    private prepareCaseResult(test: Test, status: ResultCreateStatusEnum, attachments: any[]) {
         this.logTestItem(test.name, status);
-        this.queued --;
+        this.queued--;
         const caseObject: ResultCreate = {
             status,
             time_ms: test.info.durationMs,
             stacktrace: test.error,
-            comment: test.error ? test.error.split('\n')[0]:undefined,
+            comment: test.error ? test.error.split('\n')[0] : undefined,
             attachments: attachments.length > 0
                 ? attachments
                 : undefined,
+            defect: status === ResultCreateStatusEnum.FAILED,
         };
         if (!test.meta.CID) {
             caseObject.case = {
@@ -470,7 +471,7 @@ class TestcafeQaseReporter {
             const caseIds = TestcafeQaseReporter.getCaseId(test.meta);
             caseIds.forEach((caseId) => {
                 if (caseId) {
-                    const add = caseIds.length > 1 ? chalk` {white For case ${caseId}}`:'';
+                    const add = caseIds.length > 1 ? chalk` {white For case ${caseId}}` : '';
                     this.log(
                         chalk`{gray Ready for publishing: ${test.name}}${add}`
                     );

--- a/qase-testcafe/test/plugin.test.ts
+++ b/qase-testcafe/test/plugin.test.ts
@@ -1,8 +1,194 @@
-import 'jest';
+import { describe, expect, it } from '@jest/globals';
 import init from '../src';
 
 describe('Tests', () => {
     it('Init main class', () => {
         init();
     });
+
+    describe('Auto Create Defect', () => {
+        describe('known test cases', () => {
+            const { reporter } = init();
+            const testData = [{
+                test: {
+                    name: 'test 1',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {
+                        CID: [1],
+                    }
+                },
+                status: 'failed',
+                defect: true,
+            },
+            {
+                test: {
+                    name: 'test 2',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {
+                        CID: [2],
+                    }
+                },
+                status: 'passed',
+                defect: false,
+            },
+            {
+                test: {
+                    name: 'test 3',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {
+                        CID: [3],
+                    }
+                },
+                status: 'skipped',
+                defect: false,
+            },
+            {
+                test: {
+                    name: 'test 4',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {
+                        CID: [4],
+                    }
+                },
+                status: 'blocked',
+                defect: false,
+            }, {
+                test: {
+                    name: 'test 5',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {
+                        CID: [5],
+                    }
+                },
+                status: 'invalid',
+                defect: false,
+            },
+            {
+                test: {
+                    name: 'test 6',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {
+                        CID: [6],
+                    }
+                },
+                status: 'in_progress',
+                defect: false,
+            }];
+
+            testData.forEach(({ test, status, defect }, index) => {
+                // add test data
+                reporter['prepareCaseResult'](test as any, status as any, []);
+
+                // check test data for expected defect value
+                it(`should set defect=${defect} when status=${status}`, () => {
+                    expect(reporter['results'][index].defect).toBe(defect);
+                });
+            });
+        });
+
+        describe('unknown test cases', () => {
+            const { reporter } = init();
+            const testData = [{
+                test: {
+                    name: 'test 1',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {}
+                },
+                status: 'failed',
+                defect: true,
+            },
+            {
+                test: {
+                    name: 'test 2',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {}
+                },
+                status: 'passed',
+                defect: false,
+            },
+            {
+                test: {
+                    name: 'test 3',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {}
+                },
+                status: 'skipped',
+                defect: false,
+            },
+            {
+                test: {
+                    name: 'test 4',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {}
+                },
+                status: 'blocked',
+                defect: false,
+            },
+            {
+                test: {
+                    name: 'test 5',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {}
+                },
+                status: 'invalid',
+                defect: false,
+            },
+            {
+                test: {
+                    name: 'test 1',
+                    info: {
+                        durationMs: 1
+                    },
+                    attachments: [],
+                    meta: {}
+                },
+                status: 'in_progress',
+                defect: false,
+            }];
+
+            testData.forEach(({ test, status, defect }, index) => {
+                // add test data
+                reporter['prepareCaseResult'](test as any, status as any, []);
+
+                // check test data for expected defect value
+                it(`should set defect=${defect} when status=${status}`, () => {
+                    expect(reporter['results'][index].defect).toBe(defect);
+                });
+            });
+        });
+    });
+
 });


### PR DESCRIPTION
Adding support for auto create defects when a test fails by setting defect to true in Qase test results.

**What changed**:

- Added a defect field to `caseObject` objects and set to true only if the test result is failed.
- Added unit test to verify that all results has a defect field and the value is set appropriately based on the test status. (both known and unknown cases)

<img width="1266" alt="testcase-attachment" src="https://user-images.githubusercontent.com/12203794/180198032-09bc463a-c278-4b78-901a-4aae197622df.png">

<img width="978" alt="testcase-unit-tests" src="https://user-images.githubusercontent.com/12203794/180196863-83441220-0ac7-46cb-b8f4-2ae66cd56e1f.png">

- Updated examples test command since full-page screenshots aren't supported in chrome, this was causing an error when QASE would try to find a screenshot after failure to upload, but it didn't exist.
<img width="694" alt="no screenshot" src="https://user-images.githubusercontent.com/12203794/180198978-636e8a5e-c75c-4767-a33e-5b62956ffd40.png">


**How to test**:
1. Run testcafe tests as normal
2. Confirm that defect/s is created for failed tests automatically