### PR TITLE
feat: [qase-newman] add support for auto create defect and unit tests

### DIFF
--- a/qase-newman/src/index.ts
+++ b/qase-newman/src/index.ts
@@ -57,6 +57,7 @@ interface BulkCaseObject {
     time_ms: number;
     stacktrace?: string;
     comment: string;
+    defect: boolean;
 }
 
 class NewmanQaseReporter {
@@ -412,6 +413,7 @@ class NewmanQaseReporter {
                     time_ms: test.duration,
                     stacktrace: test.err?.stack,
                     comment: test.err ? test.err.message : '',
+                    defect: test.result === ResultCreateStatusEnum.FAILED,
                 }));
                 return [
                     ...accum,
@@ -428,6 +430,7 @@ class NewmanQaseReporter {
                         time_ms: test.duration,
                         stacktrace: test.err?.stack,
                         comment: test.err ? test.err.message : '',
+                        defect: test.result === ResultCreateStatusEnum.FAILED,
                     },
                 ];
 

--- a/qase-newman/test/plugin.test.ts
+++ b/qase-newman/test/plugin.test.ts
@@ -1,9 +1,112 @@
-import 'jest';
+import { describe, expect, it } from '@jest/globals';
 import { EventEmitter } from 'events';
 import NewmanQaseReporter from '../src';
 
 describe('Tests', () => {
     it('Init main class', () => {
-        new NewmanQaseReporter(new EventEmitter(), {apiToken: "", projectCode: ""}, {collection: ""});
+        new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "" }, { collection: "" });
+    });
+
+    describe('Auto Create Defect', () => {
+        describe('known test cases', () => {
+            const reporter = new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "" }, { collection: "" });
+            const tests = [
+                {
+                    data:
+                    {
+                        name: 'test k1',
+                        result: 'failed',
+                        duration: 1,
+                        ids: [1]
+                    },
+                    defect: true
+                },
+                {
+                    data:
+                    {
+                        name: 'test k2',
+                        result: 'passed',
+                        duration: 1,
+                        ids: [2]
+                    },
+                    defect: false
+                },
+                {
+                    data:
+                    {
+                        name: 'test k3',
+                        result: 'pending',
+                        duration: 1,
+                        ids: [3]
+                    },
+                    defect: false
+                }
+            ];
+
+            tests.forEach(test => {
+                reporter['prePending'][test.data.name] = test.data as any;
+            });
+
+            const resultsToPublishData = reporter['createBulkResultsBodyObject']();
+
+            for (const index in tests) {
+                const test = tests[index];
+                const status = test.data.result;
+                const defectValue = test.defect;
+                it(`should set defect=${defectValue} when status=${status}`, () => {
+                    expect(resultsToPublishData[index].defect).toBe(defectValue);
+                });
+            }
+        });
+        describe('unknown test cases', () => {
+            const reporter = new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "" }, { collection: "" });
+            const tests = [
+                {
+                    data:
+                    {
+                        name: 'test 1',
+                        result: 'failed',
+                        duration: 1,
+                        ids: []
+                    },
+                    defect: true
+                },
+                {
+                    data:
+                    {
+                        name: 'test 2',
+                        result: 'passed',
+                        duration: 1,
+                        ids: []
+                    },
+                    defect: false
+                },
+                {
+                    data:
+                    {
+                        name: 'test 3',
+                        result: 'pending',
+                        duration: 1,
+                        ids: []
+                    },
+                    defect: false
+                }
+            ];
+
+            tests.forEach(test => {
+                reporter['prePending'][test.data.name] = test.data as any;
+            });
+
+            const resultsToPublishData = reporter['createBulkResultsBodyObject']();
+
+            for (const index in tests) {
+                const test = tests[index];
+                const status = test.data.result;
+                const defectValue = test.defect;
+                it(`should set defect=${defectValue} when status=${status}`, () => {
+                    expect(resultsToPublishData[index].defect).toBe(defectValue);
+                });
+            }
+        });
     });
 });


### PR DESCRIPTION
Adding support for auto create defects when a test fails by setting defect to true in Qase test results.

**What changed**:

- Added a defect field to `BulkCaseObject` objects and set to true only if the test result is failed.
- Added unit test to verify that all results has a defect field and the value is set appropriately based on the test status. (both known and unknown cases)

<img width="1155" alt="newman-defect" src="https://user-images.githubusercontent.com/12203794/180207639-f016c504-c460-43e8-84e5-59b158d359a8.png">
<img width="1060" alt="unknow, known" src="https://user-images.githubusercontent.com/12203794/180207644-910e5245-e35d-448d-8c1c-4dcf60c662f6.png">

**How to test**: 
1. Run newman tests as normal
2. Confirm that defect/s is created for failed tests automatically