### PR TITLE
feat: [qase-jest] add support for auto create defect and unit tests

### DIFF
--- a/qase-jest/src/index.ts
+++ b/qase-jest/src/index.ts
@@ -330,6 +330,7 @@ class QaseReporter implements Reporter {
                 stacktrace: failureMessages.join('\n'),
                 comment: failureMessages.length > 0 ? failureMessages.map(
                     (value) => value.split('\n')[0]).join('\n') : undefined,
+                defect: Statuses[elem.status] === Statuses.failed,
             };
 
             // Verifies that the user defined the ID through the use of the 'qase' wrapper;

--- a/qase-jest/test/plugin.test.ts
+++ b/qase-jest/test/plugin.test.ts
@@ -1,9 +1,144 @@
-import 'jest';
+import { describe, expect, it } from '@jest/globals';
 import QaseReporter from '../src';
 
 describe('Client', () => {
     it('Init client', () => {
-        const options = {apiToken: "", projectCode: ""};
+        const options = { apiToken: "", projectCode: "" };
         new QaseReporter({}, options);
+    });
+
+    describe('Auto Create Defect', () => {
+        const options = { apiToken: "", projectCode: "" };
+        describe('known test cases', () => {
+            const qReporter = new QaseReporter({}, options);
+            const testData = [
+                {
+                    test: {
+                        duration: 0,
+                        status: 'failed',
+                        title: 'Test (Qase ID: 1)',
+                        failureMessages: ['failure message'],
+                        ancestorTitles: ['some ancestor', "path"]
+                    },
+                    defect: true,
+                },
+                {
+                    test: {
+                        duration: 0,
+                        status: 'passed',
+                        title: 'Test (Qase ID: 2)',
+                        failureMessages: [],
+                        ancestorTitles: ['some ancestor 2', "path"]
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        duration: 0,
+                        status: 'skipped',
+                        title: 'Test (Qase ID: 3)',
+                        failureMessages: [],
+                        ancestorTitles: ['some ancestor 3', "path"]
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        duration: 0,
+                        status: 'pending',
+                        title: 'Test (Qase ID: 4)',
+                        failureMessages: [],
+                        ancestorTitles: ['some ancestor 4', "path"]
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        duration: 0,
+                        status: 'disabled',
+                        title: 'Test (Qase ID: 5)',
+                        failureMessages: [],
+                        ancestorTitles: ['some ancestor 5', "path"]
+                    },
+                    defect: false,
+                },
+            ]
+            qReporter['preparedTestCases'] = qReporter['createPreparedForPublishTestsArray'](testData.map(td => td.test) as any);
+            const testResultsForPublishing = qReporter['createResultCasesArray']();
+
+            for (const index in testData) {
+                const status = testData[index].test.status;
+                const defect = testData[index].defect;
+                it(`should set defect=${defect} when status=${status}`, () => {
+                    expect(testResultsForPublishing[index].defect).toBe(defect);
+                });
+            };
+        });
+
+        describe('unknown test cases', () => {
+            const qReporter = new QaseReporter({}, options);
+            const testData = [
+                {
+                    test: {
+                        duration: 0,
+                        status: 'failed',
+                        title: 'Test 1',
+                        failureMessages: ['failure message'],
+                        ancestorTitles: ['some ancestor', "path"]
+                    },
+                    defect: true,
+                },
+                {
+                    test: {
+                        duration: 0,
+                        status: 'passed',
+                        title: 'Test 2',
+                        failureMessages: [],
+                        ancestorTitles: ['some ancestor 2', "path"]
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        duration: 0,
+                        status: 'skipped',
+                        title: 'Test 3',
+                        failureMessages: [],
+                        ancestorTitles: ['some ancestor 3', "path"]
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        duration: 0,
+                        status: 'pending',
+                        title: 'Test 4',
+                        failureMessages: [],
+                        ancestorTitles: ['some ancestor 4', "path"]
+                    },
+                    defect: false,
+                },
+                {
+                    test: {
+                        duration: 0,
+                        status: 'disabled',
+                        title: 'Test 5',
+                        failureMessages: [],
+                        ancestorTitles: ['some ancestor 5', "path"]
+                    },
+                    defect: false,
+                },
+            ]
+            qReporter['preparedTestCases'] = qReporter['createPreparedForPublishTestsArray'](testData.map(td => td.test) as any);
+            const testResultsForPublishing = qReporter['createResultCasesArray']();
+
+            for (const index in testData) {
+                const status = testData[index].test.status;
+                const defect = testData[index].defect;
+                it(`should set defect=${defect} when status=${status}`, () => {
+                    expect(testResultsForPublishing[index].defect).toBe(defect);
+                });
+            };
+        });
     });
 });


### PR DESCRIPTION
Adding support for auto create defects when a test fails by setting defect to true in Qase test results.

**What changed**:

- Added a defect field to `caseObject` objects and set to true only if the test result is failed.
- Added unit test to verify that all results have a defect field and the value is set appropriately based on the test status. (both known and unknown cases)

<img width="1088" alt="qase-jest-app" src="https://user-images.githubusercontent.com/12203794/180433483-a260e6ba-1d52-45d5-ad11-1707bff7c629.png">
<img width="1164" alt="qase-jest-unit" src="https://user-images.githubusercontent.com/12203794/180433496-7b6a411b-c177-42e8-95f9-396b37f856ca.png">

**How to test**:
1. Run jest tests as normal
2. Confirm that defect/s is created for failed tests automatically

