### PR TITLE
feat(#247): [qase-newman] added runComplete option support

### DIFF
--- a/qase-newman/examples/package.json
+++ b/qase-newman/examples/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "example",
-    "version": "1.0.0",
-    "description": "",
-    "main": "index.js",
-    "scripts": {
-        "test": "newman run ./sample-collection.json -r qase --reporter-qase-logging --reporter-qase-projectCode project_code --reporter-qase-apiToken api_key --reporter-qase-rootSuiteTitle 'Newman tests'"
-    },
-    "keywords": [],
-    "author": "",
-    "license": "ISC",
-    "devDependencies": {
-        "newman": "^5.3.0",
-        "newman-reporter-qase": "../"
-    }
+  "name": "example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "newman run ./sample-collection.json -r qase --reporter-qase-logging --reporter-qase-projectCode project_code --reporter-qase-apiToken api_key --reporter-qase-rootSuiteTitle 'Newman tests' --reporter-qase-runComplete"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "newman": "^5.3.0",
+    "newman-reporter-qase": "../"
+  }
 }

--- a/qase-newman/src/index.ts
+++ b/qase-newman/src/index.ts
@@ -78,7 +78,7 @@ class NewmanQaseReporter {
             _options.projectCode || this.getEnv(Envs.projectCode) || '';
         this.collectionOptions = collectionRunOptions;
         this.options.runComplete =
-            !!this.getEnv(Envs.runComplete) || this.options.runComplete;
+            !!this.getEnv(Envs.runComplete) || this.options.runComplete || false;
 
         this.api = new QaseApi(
             this.getEnv(Envs.apiToken) || this.options.apiToken || '',
@@ -259,6 +259,7 @@ class NewmanQaseReporter {
                     body: {
                         results: this.createBulkResultsBodyObject(),
                     },
+                    runComplete: this.options.runComplete,
                 };
 
                 spawnSync('node', [`${__dirname}/reportBulk.js`], {

--- a/qase-newman/src/reportBulk.js
+++ b/qase-newman/src/reportBulk.js
@@ -21,6 +21,11 @@ const publishBulkResult = async () => {
             if (res.status === 200) {
                 console.log(chalk`{green Results are sent}`);
             }
+
+            if (config.runComplete) {
+                await api.runs.completeRun(config.code, config.runId);
+                console.log(chalk`{green Run completed}`);
+            }
         } catch (error) {
             console.log('Error till publishing', error);
         }

--- a/qase-newman/test/plugin.test.ts
+++ b/qase-newman/test/plugin.test.ts
@@ -7,6 +7,24 @@ describe('Tests', () => {
         new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "" }, { collection: "" });
     });
 
+    describe('runComplete option', () => {
+        it('should have runComplete option false by default', () => {
+            const reporter = new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "" }, { collection: "" });
+            expect(reporter['options'].runComplete).toBe(false);
+        });
+
+        it('should set runComplete from reporter options', () => {
+            const reporter = new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "", runComplete: true }, { collection: "" });
+            expect(reporter['options'].runComplete).toBe(true);
+        });
+
+        it('should set runComplete from environmental variable [QASE_RUN_COMPLETE=true]', () => {
+            process.env.QASE_RUN_COMPLETE = 'true';
+            const reporter = new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "" }, { collection: "" });
+            expect(reporter['options'].runComplete).toBe(true);
+        });
+    });
+
     describe('Auto Create Defect', () => {
         describe('known test cases', () => {
             const reporter = new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "" }, { collection: "" });


### PR DESCRIPTION
runComplete [true/false] - Permission for automatic completion of the test run

**What changed:**
- Updated `options.runComplete` to be false by default
- Added `runComplete` to `reporting_config` for reportBulk usage
- Check for runComplete = true in reportBulk.js and make API call to automatically complete run
- included unit tests for checking different states of options.runComplete based on environmental variable and reporter options
- Updated examples to include runComeplete as a reporter option in the `test` command

**How to test**?:
- Run newman tests as normal
- Observe that the run is automatically completed based on the new updates. 

resolve #247 