### PR TITLE
feat(#247) : qase cucumberjs runComplete option 

### DIFF
--- a/qase-cucumberjs/examples/.qaserc
+++ b/qase-cucumberjs/examples/.qaserc
@@ -7,5 +7,6 @@
   "environmentId": 1,
   "basePath": "https://api.qase.io/v1",
   "runId": 0,
-  "rootSuiteTitle": "CucumberJS tests"
+  "rootSuiteTitle": "CucumberJS tests",
+  "runComplete": true
 }

--- a/qase-cucumberjs/src/index.ts
+++ b/qase-cucumberjs/src/index.ts
@@ -31,6 +31,7 @@ interface Config {
     runName: string;
     runDescription?: string;
     logging: boolean;
+    runComplete?: boolean;
 }
 
 interface Test {
@@ -105,6 +106,7 @@ const prepareConfig = (options: Config = {} as Config, configFile = '.qaserc'): 
         runName: process.env.QASE_RUN_NAME || config.runName || 'Automated Run %DATE%',
         runDescription: process.env.QASE_RUN_DESCRIPTION || config.runDescription,
         logging: process.env.QASE_LOGGING !== '' || config.logging,
+        runComplete: process.env.QASE_RUN_COMPLETE === 'true' || config.runComplete || false,
     };
 };
 
@@ -338,8 +340,13 @@ class QaseReporter extends Formatter {
             {
                 results: res,
             }
-        ).then(() => {
+        ).then(async () => {
             this._log(chalk`{gray Results sent}`);
+
+            if (this.config.runComplete) {
+                await this.api.runs.completeRun(this.config.projectCode, Number(this.config.runId));
+                this._log(chalk`{green Run completed}`);
+            }
         }).catch((err) => {
             this._log(err);
         });

--- a/qase-cucumberjs/test/plugin.test.ts
+++ b/qase-cucumberjs/test/plugin.test.ts
@@ -7,6 +7,24 @@ describe('Tests', () => {
         new Index({ parsedArgvOptions: {} } as unknown as IFormatterOptions);
     });
 
+    describe('runComplete option', () => {
+        it('should have runComplete option false by default', () => {
+            const qReporter = new Index({ parsedArgvOptions: {} } as unknown as IFormatterOptions);
+            expect(qReporter['config'].runComplete).toBe(false);
+        });
+
+        it('should set runComplete from reporter options', () => {
+            const qReporter = new Index({ parsedArgvOptions: { runComplete: true } } as unknown as IFormatterOptions);
+            expect(qReporter['config'].runComplete).toBe(true);
+        });
+
+        it('should set runComplete from environmental variable [QASE_RUN_COMPLETE=true]', () => {
+            process.env.QASE_RUN_COMPLETE = 'true';
+            const qReporter = new Index({ parsedArgvOptions: {} } as unknown as IFormatterOptions);
+            expect(qReporter['config'].runComplete).toBe(true);
+        });
+    });
+
     describe('Auto Create Defect', () => {
         const qReporter = new Index({ parsedArgvOptions: {} } as unknown as IFormatterOptions);
 


### PR DESCRIPTION
runComplete [true/false] - Permission for automatic completion of the test run

**What changed**:

- Updated config.runComplete to be false by default
- Check for `config.runComplete` = true in `publishResults` and make API call to automatically complete run
- included unit tests for checking different states of config.runComplete based on environmental variable and reporter options
- Updated examples to include runComeplete as a reporter option in `.qaserc`

**How to test**:

- Run cucumberjs tests as normal
- Observe that the run is automatically completed based on the new updates.

resolve #247 