### PR TITLE
feat: [qase-newman] add support for optional environmentId

### DIFF
--- a/qase-newman/src/index.ts
+++ b/qase-newman/src/index.ts
@@ -78,7 +78,7 @@ class NewmanQaseReporter {
             _options.projectCode || this.getEnv(Envs.projectCode) || '';
         this.collectionOptions = collectionRunOptions;
         this.options.runComplete =
-            !!this.getEnv(Envs.runComplete) || this.options.runComplete;
+            !!this.getEnv(Envs.runComplete) || this.options.runComplete || false;
         this.options.environmentId = Number(this.getEnv(Envs.environmentId)) || this.options.environmentId || undefined;
 
         this.api = new QaseApi(

--- a/qase-newman/src/index.ts
+++ b/qase-newman/src/index.ts
@@ -79,6 +79,7 @@ class NewmanQaseReporter {
         this.collectionOptions = collectionRunOptions;
         this.options.runComplete =
             !!this.getEnv(Envs.runComplete) || this.options.runComplete;
+        this.options.environmentId = Number(this.getEnv(Envs.environmentId)) || this.options.environmentId || undefined;
 
         this.api = new QaseApi(
             this.getEnv(Envs.apiToken) || this.options.apiToken || '',
@@ -327,6 +328,7 @@ class NewmanQaseReporter {
                 {
                     description: description || 'Newman automated run',
                     is_autotest: true,
+                    environment_id: this.options.environmentId,
                 }
             );
 
@@ -348,6 +350,7 @@ class NewmanQaseReporter {
         args?: {
             description?: string;
             is_autotest: boolean;
+            environment_id?: number;
         }
     ) {
         return {

--- a/qase-newman/test/plugin.test.ts
+++ b/qase-newman/test/plugin.test.ts
@@ -7,6 +7,26 @@ describe('Tests', () => {
         new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "" }, { collection: "" });
     });
 
+    describe('Options', () => {
+        describe('Support Optional Environmental ID', () => {
+            it('should set environmental Id to undefined by default', () => {
+                const reporter = new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "" }, { collection: "" });
+                expect(reporter['options'].environmentId).toBe(undefined);
+            });
+
+            it('should set environmental Id by reporter option - environmentalId', () => {
+                const reporter = new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "", environmentId: 5 }, { collection: "" });
+                expect(reporter['options'].environmentId).toBe(5);
+            });
+
+            it('should set environmental Id by environmental variable - QASE_ENVIRONMENT_ID', () => {
+                process.env.QASE_ENVIRONMENT_ID = '6';
+                const reporter = new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "" }, { collection: "" });
+                expect(reporter['options'].environmentId).toBe(6);
+            });
+        });
+    });
+
     describe('Auto Create Defect', () => {
         describe('known test cases', () => {
             const reporter = new NewmanQaseReporter(new EventEmitter(), { apiToken: "", projectCode: "" }, { collection: "" });


### PR DESCRIPTION
Link test run to a specific environment by specifying **QASE_ENVIRONMENT_ID**, or using **environmentalId** reporter option. 

**What changed**:
- Update config to set environmentId by environmental variable or report options
- Set environmentId to undefined by default since this is optional
- Added unit tests to account for all states when setting the environment ID

**How to test**:
1. Ensure that you have an environment configured in your QASE account
2. Run newman tests and specify the environment  ID 
```
QASE_ENVIRONMENT_ID=your_environment_id npm run tests
or 
newman run ./sample-collection.json -r qase --reporter-qase-logging --reporter-qase-projectCode project_code --reporter-qase-apiToken api_key --reporter-qase-rootSuiteTitle 'Newman tests' --reporter-qase-environmentId your_environment_id
```
3. Observe that your tests are linked to environment in your run

resolves #249  