### PR TITLE
feat: [qase-cypress] automatic case creation #261

### DIFF
--- a/qase-cypress/examples_cypress_v10/cypress.config.js
+++ b/qase-cypress/examples_cypress_v10/cypress.config.js
@@ -16,6 +16,7 @@ module.exports = defineConfig({
       sendScreenshot: true,
       runComplete: true,
       environmentId: 1,
+      rootSuiteTitle: 'Cypress tests',
     },
   },
   video: false,

--- a/qase-cypress/examples_cypress_v10/cypress/e2e/second.cy.js
+++ b/qase-cypress/examples_cypress_v10/cypress/e2e/second.cy.js
@@ -14,7 +14,7 @@ describe('My First Test', () => {
         cy.visit('https://example.cypress.io');
 
         cy.contains('type').click();
-        
+
         // Should be on a new URL which includes '/commands/actions'
         cy.url().should('include', '/commands/actions');
         // Get an input, type into it and verify that the value has been updated
@@ -36,4 +36,24 @@ describe('My First Test', () => {
             .type('fake@email.com')
             .should('have.value', 'unexpected@email.com');
     }));
+
+    it('Go to utilities', () => {
+        cy.visit('https://example.cypress.io');
+
+        cy.contains('Utilities').click();
+
+        // Should be on a new URL which includes 'utilities'
+        cy.url().should('include', 'utilities');
+    });
+
+    describe('Test Suite - Level 2', () => {
+        it('Go to Cypress API', () => {
+            cy.visit('https://example.cypress.io');
+
+            cy.contains('Cypress API').click();
+
+            // Should be on a new URL which includes 'utilities'
+            cy.url().should('include', 'cypress-api');
+        });
+    });
 });


### PR DESCRIPTION
Support automatic test case creation when a QASE ID is not provided for a test. 

**What changed:**
- Added support for root suite title, reporter option and environmental variable: `rootSuiteTitle`, `QASE_ROOT_SUITE_TITLE`
- Replace `BulkCaseObject`  interface with `ResultCreate` from QASE types
- Added `getSuitePath` static method to help find suite title recursively based on test parent
- Updated `transformCaseResultToBulkObject` to account for both known and unknown test cases
- Updated cypress 10 example with `rootSuiteTitle` reporter option set, and added nested tests

**How to test**:
- Add `rootSuiteTitle` to your cypress reporter options
- Add tests without a QASE ID
- Run cypress tests as normal
- Observe that the test cases without a QASE ID can be found under the name used for rootSuiteTitle