### PR TITLE
feat: test case parameterization support [POC]

### DIFF
--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -30,7 +30,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "qaseio": "^2.0.0-alpha.5"
+    "qaseio": "^2.0.1"
   },
   "devDependencies": {
     "@hutson/npm-deploy-git-tag": "^6.0.0",

--- a/qase-jest/src/jest.ts
+++ b/qase-jest/src/jest.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+type Param = [number, Record<string, unknown>];
 export = {
     qase: (caseId: number | string | number[] | string[], name: string): string => {
         let caseIds: number[] | string[];
@@ -10,4 +11,29 @@ export = {
         const newName = `${name} (Qase ID: ${caseIds.join(',')})`;
         return newName;
     },
+    qaseParam: (caseId: number | string | number[] | string[], param: Param, name: string): string => {
+
+        const [id, dataset] = param;
+        const normalizedParam = typeof dataset === 'string' ? dataset : Object.keys(dataset)
+            .map((key: string) => `${key}: ${dataset[key] as string}`).join(', ');
+
+        const formattedDataset = `(Qase Dataset: #${id} (${normalizedParam}))`;
+
+        let newName = `${name} ${formattedDataset}`;
+        let caseIds: number[] | string[];
+
+        if (caseId === null) {
+            return newName;
+        }
+
+        if (typeof caseId === 'string' || typeof caseId === 'number') {
+            caseIds = [caseId.toString()];
+        } else {
+            caseIds = caseId;
+        }
+
+        newName = `${name} (Qase ID: ${caseIds.join(',')}) ${formattedDataset}`;
+        return newName;
+    },
+
 };

--- a/qase-jest/test/plugin.test.ts
+++ b/qase-jest/test/plugin.test.ts
@@ -141,4 +141,14 @@ describe('Client', () => {
             };
         });
     });
+
+    // describe("Parameterized", () => {
+
+    //     const add = (a, b) => a + b;
+
+    //     const cases = [[1, 1, 2], [1, 2, 3], [1, 3, 4], [1, 4, 5], [1, 5, 6], [1, 6, 7], [1, 7, 8], [1, 8, 9], [1, 9, 10]];
+    //     it.each(cases)(`%i + %i = %i`, (a, b, expected) => {
+    //         expect(add(a, b)).toBe(expected);
+    //     });
+    // });
 });

--- a/qase-playwright/examples/test/arith.test.js
+++ b/qase-playwright/examples/test/arith.test.js
@@ -1,5 +1,5 @@
 const { add, mul, sub, div } = require('./arith');
-const { qase } = require('playwright-qase-reporter/dist/playwright');
+const { qase, qaseParam } = require('playwright-qase-reporter/dist/playwright');
 const { test, expect } = require('@playwright/test');
 
 test.describe.parallel('Test suite. Level 1', () => {
@@ -24,11 +24,11 @@ test.describe.parallel('Test suite. Level 1', () => {
         expect(mul(3, 4)).toBe(12);
     });
 
-        test('5 - 6 = -1', () => {
-            expect(sub(5, 6)).toBe(-1);
-        });
+    test('5 - 6 = -1', () => {
+        expect(sub(5, 6)).toBe(-1);
+    });
 
-        test.describe('Test suite. Level 2', () => {
+    test.describe('Test suite. Level 2', () => {
 
         test('5 - 6 = -2', () => {
             expect(sub(5, 6)).toBe(-2);
@@ -39,5 +39,15 @@ test.describe.parallel('Test suite. Level 1', () => {
         });
     });
 
+    test.describe.only('Parameterization', () => {
+        const cases = [[1, 2, 3], [3, 4, 7], [5, 6, 11], [5, 7, 12]];
+        cases.forEach(([a, b, expected], index) => {
 
+            // const testTile = `Addition with parameters (Qase Dataset: #${index} (a: ${a}, b: ${b}, expected: ${expected}))`;
+
+            test(qaseParam(null, [index, { a, b, expected }], 'Addition with parameters'), () => {
+                expect(add(a, b)).toBe(expected);
+            });
+        })
+    });
 });

--- a/qase-playwright/src/index.ts
+++ b/qase-playwright/src/index.ts
@@ -303,7 +303,7 @@ class PlaywrightReporter implements Reporter {
     }
 
     private getParameterizedData(test: TestCase): ParameterizedTestData {
-        const regexp = /\(Qase Dataset: (#\d) (\(.*\))\)/;
+        const regexp = /\(Qase Dataset: (#\d+) (\(.*\))\)/;
         const results = regexp.exec(test.title) || [];
         if (results?.length > 0) {
             return {
@@ -315,7 +315,7 @@ class PlaywrightReporter implements Reporter {
     }
 
     private removeQaseDataset(title: string): string {
-        const regexp = /\(Qase Dataset: (#\d) (\(.*\))\)/;
+        const regexp = /\(Qase Dataset: (#\d+) (\(.*\))\)/;
         return title.replace(regexp, '');
     }
 

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -9,4 +9,28 @@ export = {
         const newName = `${name} (Qase ID: ${caseIds.join(',')})`;
         return newName;
     },
+    qaseParam: (caseId: number | string | number[] | string[], param: [number, Object | string], name: string): string => {
+
+        const [id, dataset] = param;
+        const normalizedParam = typeof dataset === "string" ? dataset : Object.keys(dataset)
+            .map((key: string) => `${key}: ${dataset[key] as string}`).join(', ');
+
+        const formattedDataset = `(Qase Dataset: #${id} (${normalizedParam}))`;
+
+        let newName = `${name} ${formattedDataset}`;
+        let caseIds: number[] | string[];
+
+        if (caseId === null) {
+            return newName;
+        }
+
+        if (typeof caseId === 'string' || typeof caseId === 'number') {
+            caseIds = [caseId.toString()];
+        } else {
+            caseIds = caseId;
+        }
+
+        newName = `${name} (Qase ID: ${caseIds.join(',')}) ${formattedDataset}`;
+        return newName;
+    },
 };


### PR DESCRIPTION
Investigating possible ways of adding param data to tests that are ran in a loop for JS test frameworks that would work well with Qase setup and easy to use.

See [document](https://dimitriharding.notion.site/POC-Test-Case-Parameterization-for-JS-libraries-55c30ab566654868b07ca80d338bef35) for additional information.  