### PR TITLE
feat: add run link

### DIFF
--- a/qase-playwright/src/index.ts
+++ b/qase-playwright/src/index.ts
@@ -279,6 +279,7 @@ class PlaywrightReporter implements Reporter {
         } catch (err) {
             this.log(`Error on completing run ${err as string}`);
         }
+        this.log(chalk`{blue https://app.qase.io/run/${this.options.projectCode}/dashboard/${this.runId}}`);
     }
 
     private log(message?: any, ...optionalParams: any[]) {


### PR DESCRIPTION
Added additional log at the run completion so it'd be possible to open results right from the console output (especially useful for CI/CD runs).

Feature request: https://qase.canny.io/feature-requests/p/log-a-link-to-qase-test-run-in-playwright-test-runs

![image](https://user-images.githubusercontent.com/51059105/188879193-bc3d50e5-531c-4add-918a-58c15fc51fae.png)
