### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -22,8 +22,8 @@ jobs:
           - "qase-testcafe"
           - "qaseio"
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - working-directory: ./${{ matrix.package }}
@@ -49,12 +49,11 @@ jobs:
         - "qaseio"
     if: startsWith(github.event.ref, 'refs/tags')
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       if: contains(github.event.ref, matrix.package)
       with:
         node-version: '16'
-        registry-url: 'https://registry.npmjs.org'
     - if: contains(github.event.ref, matrix.package)
       working-directory: ./${{ matrix.package }}
       run: npm install

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        node-version: [ '14', '15', '16' ]
+        node-version: [ '16' ]
         package:
           - "qase-cucumberjs"
           - "qase-cypress"
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/setup-node@v1
       if: contains(github.event.ref, matrix.package)
       with:
-        node-version: '14'
+        node-version: '16'
         registry-url: 'https://registry.npmjs.org'
     - if: contains(github.event.ref, matrix.package)
       working-directory: ./${{ matrix.package }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -7,48 +7,62 @@ on:
 
 jobs:
   test:
+    name: Test ${{ matrix.package }} at Node v${{ matrix.node-version }}
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
       matrix:
         node-version: [ '14', '15', '16' ]
-        prefix: [ "qaseio", "qase-cypress", "qase-cucumberjs", "qase-newman", "qase-testcafe", "qase-jest", "qase-playwright" ]
-    name: Project ${{ matrix.prefix }} - Node ${{ matrix.node-version }}
+        package:
+          - "qase-cucumberjs"
+          - "qase-cypress"
+          - "qase-jest"
+          - "qase-newman"
+          - "qase-playwright"
+          - "qase-testcafe"
+          - "qaseio"
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - working-directory: ./${{ matrix.prefix }}
+    - working-directory: ./${{ matrix.package }}
       run: npm install
-    - working-directory: ./${{ matrix.prefix }}
+    - working-directory: ./${{ matrix.package }}
       run: npm run lint
-    - working-directory: ./${{ matrix.prefix }}
+    - working-directory: ./${{ matrix.package }}
       run: npm run test
   build-n-publish:
+    name: Build and publish ${{ matrix.package }}
     runs-on: ubuntu-latest
     needs: test
     strategy:
       max-parallel: 5
       matrix:
-        prefix: [ "qaseio", "qase-cypress", "qase-cucumberjs", "qase-newman", "qase-testcafe", "qase-jest", "qase-playwright" ]
+        package:
+        - "qase-cucumberjs"
+        - "qase-cypress"
+        - "qase-jest"
+        - "qase-newman"
+        - "qase-playwright"
+        - "qase-testcafe"
+        - "qaseio"
     if: startsWith(github.event.ref, 'refs/tags')
-    name: Publish ${{ matrix.prefix }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
-      if: contains(github.event.ref, matrix.prefix)
+      if: contains(github.event.ref, matrix.package)
       with:
         node-version: '14'
         registry-url: 'https://registry.npmjs.org'
-    - if: contains(github.event.ref, matrix.prefix)
-      working-directory: ./${{ matrix.prefix }}
+    - if: contains(github.event.ref, matrix.package)
+      working-directory: ./${{ matrix.package }}
       run: npm install
-    - if: contains(github.event.ref, matrix.prefix)
-      working-directory: ./${{ matrix.prefix }}
+    - if: contains(github.event.ref, matrix.package)
+      working-directory: ./${{ matrix.package }}
       run: npm run build
-    - if: contains(github.event.ref, matrix.prefix)
-      working-directory: ./${{ matrix.prefix }}
+    - if: contains(github.event.ref, matrix.package)
+      working-directory: ./${{ matrix.package }}
       run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# ci: drop support of Node.js 14 and 15, build on v16

All three versions are outdated. First, let's get rid of the oldest ones.
Updating to v20 will be done in the next step.

# ci: cleanup workflow definition

* Give jobs more clear names
* Put job names first in the job definitions
* Rename matrix.prefix to matrix.package, which better reflects the
  meaning of the variable.
* Rearrange matrix workflow items, so that thir list visually matches
  the list of packages in this repo.
  
# ci: update GitHub actions to use Node.js v20

Update actions/checkout and actions/setup-node to the latest versions,
using Node.js v20.

This change removes the multiple warnings from the GitHub run view:

> The following actions uses node12 which is deprecated and will be forced
> to run on node16: actions/checkout@v2, actions/setup-node@v1. For more info:
> https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

In addition, remove `registry-url` parameter from the second `setup-node`,
because it equals the default value.