### PR TITLE
qaseio: Unable to publish run results

### DIFF
--- a/qaseio/src/generated/api/result-api.ts
+++ b/qaseio/src/generated/api/result-api.ts
@@ -43,7 +43,7 @@ export const ResultApiAxiosParamCreator = function (configuration?: Configuratio
             assertParamExists('createResultsV2', 'runId', runId)
             // verify required parameter 'createResultsRequestV2' is not null or undefined
             assertParamExists('createResultsV2', 'createResultsRequestV2', createResultsRequestV2)
-            const localVarPath = `/{project_code}/run/{run_id}/results`
+            const localVarPath = `/v2/{project_code}/run/{run_id}/results`
                 .replace(`{${"project_code"}}`, encodeURIComponent(String(projectCode)))
                 .replace(`{${"run_id"}}`, encodeURIComponent(String(runId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.


### PR DESCRIPTION
qaseio: Unable to publish run results
--
Resolves the following error:
```
 Error: Request failed with status code 404
      at createError (/Users/gda/Documents/github/qase-javascript/node_modules/axios/lib/core/createError.js:16:15)
      at settle (/Users/gda/Documents/github/qase-javascript/node_modules/axios/lib/core/settle.js:17:12)
      at IncomingMessage.handleStreamEnd (/Users/gda/Documents/github/qase-javascript/node_modules/axios/lib/adapters/http.js:269:11)
      at IncomingMessage.emit (node:events:531:35)
      at endReadableNT (node:internal/streams/readable:1696:12)
      at processTicksAndRejections (node:internal/process/task_queues:82:21)
```