### PR TITLE
qase-javascript-commons: add support for standard config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ jspm_packages/
 
 # macos artifacts
 .DS_Store
+
+# IDE files
+.idea
+.vscode

--- a/qase-javascript-commons/src/config/config-validation-schema.ts
+++ b/qase-javascript-commons/src/config/config-validation-schema.ts
@@ -1,8 +1,7 @@
 import { JSONSchemaType } from 'ajv';
 
 import { ModeEnum } from '../options';
-import { DriverEnum } from '../writer';
-
+import { DriverEnum, FormatEnum } from '../writer';
 import { ConfigType } from './config-type';
 
 /**
@@ -13,6 +12,11 @@ export const configValidationSchema: JSONSchemaType<ConfigType> = {
 
   properties: {
     mode: {
+      type: 'string',
+      enum: [ModeEnum.report, ModeEnum.testops, ModeEnum.off],
+      nullable: true,
+    },
+    fallback: {
       type: 'string',
       enum: [ModeEnum.report, ModeEnum.testops, ModeEnum.off],
       nullable: true,
@@ -79,11 +83,6 @@ export const configValidationSchema: JSONSchemaType<ConfigType> = {
           nullable: true,
         },
 
-        baseUrl: {
-          type: 'string',
-          nullable: true,
-        },
-
         run: {
           type: 'object',
           nullable: true,
@@ -105,11 +104,29 @@ export const configValidationSchema: JSONSchemaType<ConfigType> = {
               type: 'boolean',
               nullable: true,
             },
-            environment: {
+          },
+        },
+
+        plan: {
+          type: 'object',
+          nullable: true,
+
+          properties: {
+            id: {
               type: 'number',
               nullable: true,
             },
           },
+        },
+
+        chunk: {
+          type: 'number',
+          nullable: true,
+        },
+
+        defect: {
+          type: 'boolean',
+          nullable: true,
         },
       },
     },
@@ -140,8 +157,9 @@ export const configValidationSchema: JSONSchemaType<ConfigType> = {
                   nullable: true,
                 },
 
-                ext: {
+                format: {
                   type: 'string',
+                  enum: [FormatEnum.json, FormatEnum.jsonb],
                   nullable: true,
                 },
               },

--- a/qase-javascript-commons/src/env/env-enum.ts
+++ b/qase-javascript-commons/src/env/env-enum.ts
@@ -3,6 +3,7 @@
  */
 export enum EnvEnum {
   mode = 'QASE_MODE',
+  fallback = 'QASE_FALLBACK',
   debug = 'QASE_DEBUG',
   environment = 'QASE_ENVIRONMENT',
 }
@@ -12,8 +13,9 @@ export enum EnvEnum {
  */
 export enum EnvTestOpsEnum {
   project = 'QASE_TESTOPS_PROJECT',
-  baseUrl = 'QASE_TESTOPS_BASE_URL',
   uploadAttachments = 'QASE_TESTOPS_UPLOAD_ATTACHMENTS',
+  chunk = 'QASE_TESTOPS_CHUNK',
+  defect = 'QASE_TESTOPS_DEFECT',
 }
 
 /**
@@ -21,7 +23,7 @@ export enum EnvTestOpsEnum {
  */
 export enum EnvApiEnum {
   token = 'QASE_TESTOPS_API_TOKEN',
-  baseUrl = 'QASE_TESTOPS_API_BASE_URL',
+  baseUrl = 'QASE_TESTOPS_API_HOST',
 }
 
 /**
@@ -31,14 +33,20 @@ export enum EnvRunEnum {
   id = 'QASE_TESTOPS_RUN_ID',
   title = 'QASE_TESTOPS_RUN_TITLE',
   description = 'QASE_TESTOPS_RUN_DESCRIPTION',
-  complete = 'QASE_TESTOPS_RUN_COMPLETE',
-  environment = 'QASE_TESTOPS_ENVIRONMENT',
+  complete = 'QASE_TESTOPS_RUN_COMPLETE'
+}
+
+/**
+ * @enum {string}
+ */
+export enum EnvPlanEnum {
+  id = 'QASE_TESTOPS_PLAN_ID',
 }
 
 /**
  * @enum {string}
  */
 export enum EnvLocalEnum {
-  path = 'QASE_REPORT_CONNECTIONS_LOCAL_PATH',
-  ext = 'QASE_REPORT_CONNECTIONS_LOCAL_EXT',
+  path = 'QASE_REPORT_CONNECTION_PATH',
+  format = 'QASE_REPORT_CONNECTION_FORMAT',
 }

--- a/qase-javascript-commons/src/env/env-to-config.ts
+++ b/qase-javascript-commons/src/env/env-to-config.ts
@@ -5,6 +5,7 @@ import {
   EnvApiEnum,
   EnvRunEnum,
   EnvLocalEnum,
+  EnvPlanEnum,
 } from './env-enum';
 
 import { DriverEnum } from '../writer';
@@ -21,7 +22,6 @@ export const envToConfig = (env: EnvType): ConfigType => ({
 
   testops: {
     project: env[EnvTestOpsEnum.project],
-    baseUrl: env[EnvTestOpsEnum.baseUrl],
     uploadAttachments: env[EnvTestOpsEnum.uploadAttachments],
 
     api: {
@@ -34,15 +34,21 @@ export const envToConfig = (env: EnvType): ConfigType => ({
       title: env[EnvRunEnum.title],
       description: env[EnvRunEnum.description],
       complete: env[EnvRunEnum.complete],
-      environment: env[EnvRunEnum.environment],
     },
+
+    plan: {
+      id: env[EnvPlanEnum.id],
+    },
+
+    chunk: env[EnvTestOpsEnum.chunk],
+    defect: env[EnvTestOpsEnum.defect],
   },
 
   report: {
     connections: {
       [DriverEnum.local]: {
         path: env[EnvLocalEnum.path],
-        ext: env[EnvLocalEnum.ext],
+        format: env[EnvLocalEnum.format],
       },
     },
   },

--- a/qase-javascript-commons/src/env/env-type.ts
+++ b/qase-javascript-commons/src/env/env-type.ts
@@ -4,18 +4,22 @@ import {
   EnvApiEnum,
   EnvRunEnum,
   EnvLocalEnum,
+  EnvPlanEnum,
 } from './env-enum';
 
 import { ModeEnum } from '../options';
+import { FormatEnum } from '../writer';
 
 export type EnvType = {
   [EnvEnum.mode]?: `${ModeEnum}`;
+  [EnvEnum.fallback]?: `${ModeEnum}`;
   [EnvEnum.debug]?: boolean;
   [EnvEnum.environment]?: string | number;
 
   [EnvTestOpsEnum.project]?: string;
-  [EnvTestOpsEnum.baseUrl]?: string;
   [EnvTestOpsEnum.uploadAttachments]?: boolean;
+  [EnvTestOpsEnum.chunk]?: number;
+  [EnvTestOpsEnum.defect]?: boolean;
 
   [EnvApiEnum.token]?: string;
   [EnvApiEnum.baseUrl]?: string;
@@ -24,8 +28,9 @@ export type EnvType = {
   [EnvRunEnum.title]?: string;
   [EnvRunEnum.description]?: string;
   [EnvRunEnum.complete]?: boolean;
-  [EnvRunEnum.environment]?: number;
+
+  [EnvPlanEnum.id]?: number;
 
   [EnvLocalEnum.path]?: string;
-  [EnvLocalEnum.ext]?: string;
+  [EnvLocalEnum.format]?: `${FormatEnum}`;
 };

--- a/qase-javascript-commons/src/env/env-validation-schema.ts
+++ b/qase-javascript-commons/src/env/env-validation-schema.ts
@@ -5,11 +5,13 @@ import {
   EnvApiEnum,
   EnvEnum,
   EnvLocalEnum,
+  EnvPlanEnum,
   EnvRunEnum,
   EnvTestOpsEnum,
 } from './env-enum';
 
 import { ModeEnum } from '../options';
+import { FormatEnum } from '../writer';
 
 /**
  * @type {JSONSchemaType<EnvType>}
@@ -19,6 +21,11 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
 
   properties: {
     [EnvEnum.mode]: {
+      type: 'string',
+      enum: [ModeEnum.report, ModeEnum.testops, ModeEnum.off],
+      nullable: true,
+    },
+    [EnvEnum.fallback]: {
       type: 'string',
       enum: [ModeEnum.report, ModeEnum.testops, ModeEnum.off],
       nullable: true,
@@ -40,8 +47,12 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
       type: 'boolean',
       nullable: true,
     },
-    [EnvTestOpsEnum.baseUrl]: {
-      type: 'string',
+    [EnvTestOpsEnum.chunk]: {
+      type: 'number',
+      nullable: true,
+    },
+    [EnvTestOpsEnum.defect]: {
+      type: 'boolean',
       nullable: true,
     },
 
@@ -70,7 +81,8 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
       type: 'boolean',
       nullable: true,
     },
-    [EnvRunEnum.environment]: {
+
+    [EnvPlanEnum.id]: {
       type: 'number',
       nullable: true,
     },
@@ -79,8 +91,9 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
       type: 'string',
       nullable: true,
     },
-    [EnvLocalEnum.ext]: {
+    [EnvLocalEnum.format]: {
       type: 'string',
+      enum: [FormatEnum.json, FormatEnum.jsonb],
       nullable: true,
     },
   },

--- a/qase-javascript-commons/src/options/options-type.ts
+++ b/qase-javascript-commons/src/options/options-type.ts
@@ -27,6 +27,7 @@ export type OptionsType = {
   frameworkName: string;
   reporterName: string;
   mode?: `${ModeEnum}` | undefined;
+  fallback?: `${ModeEnum}` | undefined;
   debug?: boolean | undefined;
   environment?: string | number | undefined;
   testops?:

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -186,13 +186,13 @@ export class QaseReporter extends AbstractReporter {
             headers,
             ...api
           } = {},
-          baseUrl,
           project,
           run: {
             title,
             description,
             ...run
           } = {},
+          plan = {},
           uploadAttachments,
         } = testops;
 
@@ -223,19 +223,19 @@ export class QaseReporter extends AbstractReporter {
 
         return new TestOpsReporter(
           {
-            baseUrl,
             project,
             uploadAttachments,
             run: {
               title: title ?? `Automated run ${new Date().toISOString()}`,
               description: description ?? `${reporterName} automated run`,
-              environment: typeof environment === 'number' ? environment : undefined,
               ...run,
             },
+            plan,
             ...commonOptions,
           },
           apiClient,
           logger,
+          typeof environment === 'number' ? environment : undefined
         );
       }
 

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -35,14 +35,19 @@ export type TestOpsRunType = {
   title: string;
   description: string;
   complete?: boolean | undefined;
-  environment?: number | undefined;
+};
+
+export type TestOpsPlanType = {
+  id?: number | undefined;
 };
 
 export type TestOpsOptionsType = {
   project: string;
-  baseUrl?: string | undefined;
   uploadAttachments?: boolean | undefined;
   run: TestOpsRunType;
+  plan: TestOpsPlanType;
+  chunk?: number | undefined;
+  defect?: boolean | undefined;
 };
 
 /**
@@ -93,6 +98,12 @@ export class TestOpsReporter extends AbstractReporter {
   private run: TestOpsRunType;
 
   /**
+   * @type { number | undefined}
+   * @private
+   */
+  private environment: number | undefined;
+
+  /**
    * @type {TestResultType[]}
    * @private
    */
@@ -117,10 +128,10 @@ export class TestOpsReporter extends AbstractReporter {
     options: ReporterOptionsType & TestOpsOptionsType,
     private api: QaseApiInterface,
     logger?: LoggerInterface,
+    environment?: number,
   ) {
     const {
       project,
-      baseUrl = 'https://app.qase.io',
       uploadAttachments,
       run,
 
@@ -129,10 +140,13 @@ export class TestOpsReporter extends AbstractReporter {
 
     super(restOptions, logger);
 
+    const baseUrl = 'https://app.qase.io';
+
     this.baseUrl = baseUrl.replace(/\/$/, '');
     this.projectCode = project;
     this.uploadAttachments = uploadAttachments;
     this.run = { complete: true, ...run };
+    this.environment = environment;
   }
 
   /**
@@ -169,7 +183,7 @@ export class TestOpsReporter extends AbstractReporter {
       const { result } = await this.createRun(
         this.run.title,
         this.run.description,
-        this.run.environment,
+        this.environment,
       );
 
       if (!result?.id) {

--- a/qase-javascript-commons/src/writer/driver-enum.ts
+++ b/qase-javascript-commons/src/writer/driver-enum.ts
@@ -4,3 +4,12 @@
 export enum DriverEnum {
   local = 'local',
 }
+
+
+/**
+ * @enum {string}
+ */
+export enum FormatEnum {
+  json = 'json',
+  jsonb = 'jsonb',
+}

--- a/qase-javascript-commons/src/writer/fs-writer.ts
+++ b/qase-javascript-commons/src/writer/fs-writer.ts
@@ -5,10 +5,11 @@ import { WriterInterface } from './writer-interface';
 
 import { TestResultType } from '../models';
 import { FormatterInterface } from '../formatter';
+import { FormatEnum } from './driver-enum';
 
 export type FsWriterOptionsType = {
   path?: string | undefined;
-  ext?: string | undefined;
+  format?: `${FormatEnum}` | undefined;
 };
 
 /**
@@ -17,7 +18,7 @@ export type FsWriterOptionsType = {
  */
 export class FsWriter implements WriterInterface {
   private path: string;
-  private ext: string;
+  private format: string;
 
   /**
    * @param {FsWriterOptionsType | undefined} options
@@ -29,11 +30,11 @@ export class FsWriter implements WriterInterface {
   ) {
     const {
       path: pathOptions = path.join('build', 'qase-report'),
-      ext = 'json',
+      format = FormatEnum.json,
     } = options ?? {};
 
     this.path = pathOptions;
-    this.ext = ext;
+    this.format = format;
   }
 
   /**
@@ -46,7 +47,7 @@ export class FsWriter implements WriterInterface {
       mkdirSync(this.path, { recursive: true });
     } catch (error) {/* ignore */}
 
-    const filePath = path.join(this.path, `results-${Date.now()}.${this.ext}`);
+    const filePath = path.join(this.path, `results-${Date.now()}.${this.format}`);
 
     writeFileSync(filePath, await this.formatter.format(results));
 

--- a/qase-javascript-commons/src/writer/index.ts
+++ b/qase-javascript-commons/src/writer/index.ts
@@ -1,3 +1,3 @@
 export { type WriterInterface } from './writer-interface';
 export { FsWriter, type FsWriterOptionsType } from './fs-writer';
-export { DriverEnum } from './driver-enum';
+export { DriverEnum, FormatEnum } from './driver-enum';


### PR DESCRIPTION
qase-javascript-commons: add support for standard config
--
The following changes:
- renamed some ENV variables
- added chunk, fallback, plan and defect fields to the config
- renamed ext to format
- removed duplicates