### PR TITLE
qase-javascript-commons: add fallback reporter

### DIFF
--- a/qase-javascript-commons/src/config/config-validation-schema.ts
+++ b/qase-javascript-commons/src/config/config-validation-schema.ts
@@ -159,7 +159,7 @@ export const configValidationSchema: JSONSchemaType<ConfigType> = {
 
                 format: {
                   type: 'string',
-                  enum: [FormatEnum.json, FormatEnum.jsonb],
+                  enum: [FormatEnum.json, FormatEnum.jsonp],
                   nullable: true,
                 },
               },

--- a/qase-javascript-commons/src/env/env-validation-schema.ts
+++ b/qase-javascript-commons/src/env/env-validation-schema.ts
@@ -93,7 +93,7 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
     },
     [EnvLocalEnum.format]: {
       type: 'string',
-      enum: [FormatEnum.json, FormatEnum.jsonb],
+      enum: [FormatEnum.json, FormatEnum.jsonp],
       nullable: true,
     },
   },

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -292,6 +292,7 @@ export class QaseReporter extends AbstractReporter {
             ...run
           } = {},
           plan = {},
+          chunk,
           uploadAttachments,
         } = testops;
 
@@ -330,6 +331,7 @@ export class QaseReporter extends AbstractReporter {
               ...run,
             },
             plan,
+            chunk,
             ...commonOptions,
           },
           apiClient,

--- a/qase-javascript-commons/src/reporters/abstract-reporter.ts
+++ b/qase-javascript-commons/src/reporters/abstract-reporter.ts
@@ -19,6 +19,8 @@ export type ReporterOptionsType = {
 export interface ReporterInterface {
   addTestResult(result: TestResultType): void;
   publish(): Promise<void>;
+  getTestResults(): TestResultType[];
+  setTestResults(results: TestResultType[]): void;
 }
 
 /**
@@ -32,6 +34,8 @@ export abstract class AbstractReporter implements ReporterInterface {
    * @private
    */
   private debug: boolean | undefined;
+
+  protected results: TestResultType[] = [];
 
   /**
    * @param {TestResultType} result
@@ -55,6 +59,20 @@ export abstract class AbstractReporter implements ReporterInterface {
     const { debug } = options ?? {};
 
     this.debug = debug;
+  }
+
+  /**
+   * @returns {TestResultType[]}
+   */
+  public getTestResults(): TestResultType[] {
+    return this.results;
+  }
+
+  /**
+   * @param {TestResultType[]} results
+   */
+  public setTestResults(results: TestResultType[]): void {
+    this.results = results;
   }
 
   /**

--- a/qase-javascript-commons/src/reporters/abstract-reporter.ts
+++ b/qase-javascript-commons/src/reporters/abstract-reporter.ts
@@ -104,13 +104,13 @@ export abstract class AbstractReporter implements ReporterInterface {
     this.logger.group();
 
     if (error instanceof Error) {
-      this.logger.log(`${error.stack || `${error.name}: ${error.message}`}`);
-
       if (isAxiosError(error)) {
         this.logApiError(error);
       } else if (error instanceof QaseError && error.cause) {
         this.doLogError('Caused by:', error.cause);
       }
+
+      this.logger.log(`${error.stack || `${error.name}: ${error.message}`}`);
     } else {
       this.logger.log(String(error));
     }
@@ -132,7 +132,7 @@ export abstract class AbstractReporter implements ReporterInterface {
       get(error, 'response.data.errorFields'),
     );
 
-    this.logger.log(String(errorMessage));
+    this.logger.log(`Message: ${String(errorMessage)}`);
 
     if (errorFields) {
       this.logger.group();

--- a/qase-javascript-commons/src/reporters/report-reporter.ts
+++ b/qase-javascript-commons/src/reporters/report-reporter.ts
@@ -12,11 +12,6 @@ import { WriterInterface } from '../writer';
  * @extends AbstractReporter
  */
 export class ReportReporter extends AbstractReporter {
-  /**
-   * @type {TestResultType[]}
-   * @private
-   */
-  private results: TestResultType[] = [];
 
   /**
    * @param {ReporterOptionsType} options

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -104,11 +104,6 @@ export class TestOpsReporter extends AbstractReporter {
   private environment: number | undefined;
 
   /**
-   * @type {TestResultType[]}
-   * @private
-   */
-  private results: TestResultType[] = [];
-  /**
    * @type {Record<string, string[]>}
    * @private
    */

--- a/qase-javascript-commons/src/writer/driver-enum.ts
+++ b/qase-javascript-commons/src/writer/driver-enum.ts
@@ -11,5 +11,5 @@ export enum DriverEnum {
  */
 export enum FormatEnum {
   json = 'json',
-  jsonb = 'jsonb',
+  jsonp = 'jsonp',
 }


### PR DESCRIPTION
qase-javascript-commons: add fallback reporter
--
- Add suport the fallback reporter. If the upstream reporter throws any error then the listener will try to use the fallback reporter.
- Also fix the format enum.

---
qase-javascript-commons: add support for loading results in chunks
--
Add support for loading results in chunks to testops reporter. Default chunk size is 200.

---
qase-javascript-commons: update the error message format
--
First show the reason for the error. After show the stack trace