### PR TITLE
qase-javascript-commons: Add models which supports the v2 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15274,7 +15274,8 @@
       "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.0.0-beta.1"
+        "qase-javascript-commons": "^2.0.0-beta.1",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@jest/globals": "^29.5.0",
@@ -15314,6 +15315,18 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "qase-cypress/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "qase-javascript-commons": {
       "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
@@ -15325,7 +15338,7 @@
         "lodash.get": "^4.4.2",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
-        "qaseio": "^2.0.3-beta.1",
+        "qaseio": "^2.0.4-beta.1",
         "strip-ansi": "^6.0.1",
         "uuid": "^9.0.0"
       },
@@ -15458,7 +15471,7 @@
       }
     },
     "qaseio": {
-      "version": "2.0.3-beta.1",
+      "version": "2.0.4-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.21.4",
@@ -20595,7 +20608,8 @@
         "jest": "^29.5.0",
         "mocha": "^10.2.0",
         "qase-javascript-commons": "^2.0.0-beta.1",
-        "ts-jest": "^29.1.0"
+        "ts-jest": "^29.1.0",
+        "uuid": "^9.0.1"
       },
       "dependencies": {
         "ajv": {
@@ -20615,6 +20629,11 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
         }
       }
     },
@@ -25721,7 +25740,7 @@
         "lodash.get": "^4.4.2",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
-        "qaseio": "^2.0.3-beta.1",
+        "qaseio": "^2.0.4-beta.1",
         "strip-ansi": "^6.0.1",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"

--- a/qase-cucumberjs/src/reporter.ts
+++ b/qase-cucumberjs/src/reporter.ts
@@ -233,20 +233,32 @@ export class CucumberQaseReporter extends Formatter {
         }
 
         this.reporter.addTestResult({
-          id: tcs.id,
-          testOpsId: info.caseIds,
-          title: info.name,
-          suiteTitle: info.lastAstNodeId && this.scenarios[info.lastAstNodeId],
-          status:
-            this.testCaseStartedResult[
+          attachments: [],
+          author: null,
+          execution: {
+            status: this.testCaseStartedResult[
               envelope.testCaseFinished.testCaseStartedId
-            ] ?? TestStatusEnum.passed,
-          startTime: tcs.timestamp.seconds,
-          endTime: envelope.testCaseFinished.timestamp.seconds,
-          duration: Math.abs(
-            envelope.testCaseFinished.timestamp.seconds - tcs.timestamp.seconds,
-          ),
-          error,
+              ] ?? TestStatusEnum.passed,
+            start_time: tcs.timestamp.seconds,
+            end_time: envelope.testCaseFinished.timestamp.seconds,
+            duration: Math.abs(
+              envelope.testCaseFinished.timestamp.seconds - tcs.timestamp.seconds,
+            ),
+            stacktrace: error?.stack ?? null,
+            thread: null,
+          },
+          fields: new Map<string, string>(),
+          message: null,
+          muted: false,
+          params: new Map<string, string>(),
+          relations: [],
+          run_id: null,
+          signature: '',
+          steps: [],
+          testops_id: info.caseIds[0] ?? null,
+          id: tcs.id,
+          title: info.name,
+          // suiteTitle: info.lastAstNodeId && this.scenarios[info.lastAstNodeId],
         });
       }
     });

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -44,7 +44,8 @@
   "author": "Nikita Fedorov <nik333r@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.1"
+    "qase-javascript-commons": "^2.0.0-beta.1",
+    "uuid": "^9.0.1"
   },
   "peerDependencies": {
     "cypress": ">=8.0.0"

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -33,7 +33,8 @@
     "lodash.mergewith": "^4.6.2",
     "qaseio": "^2.0.4-beta.1",
     "strip-ansi": "^6.0.1",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "child-process-ext": "^3.0.2"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/qase-javascript-commons/src/formatter/index.ts
+++ b/qase-javascript-commons/src/formatter/index.ts
@@ -1,2 +1,3 @@
 export { type FormatterInterface } from './formatter-interface';
 export { JsonFormatter } from './json-formatter';
+export { JsonpFormatter } from './jsonp-formatter';

--- a/qase-javascript-commons/src/formatter/jsonp-formatter.ts
+++ b/qase-javascript-commons/src/formatter/jsonp-formatter.ts
@@ -1,0 +1,38 @@
+import stripAnsi from 'strip-ansi';
+
+import { FormatterInterface } from './formatter-interface';
+
+export type JsonpFormatterOptionsType = {
+  space?: number | undefined;
+};
+
+/**
+ * @class JsonFormatter
+ * @implements FormatterInterface
+ */
+export class JsonpFormatter implements FormatterInterface {
+  private space: number | undefined;
+
+  constructor(options: JsonpFormatterOptionsType = {}) {
+    const { space = 4 } = options;
+
+    this.space = space;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async format(object: unknown) {
+    const json: string = JSON.stringify(
+      object,
+      (key, value: unknown) => {
+        if (key === 'error' && value instanceof Error) {
+          return stripAnsi(String(value));
+        }
+
+        return value;
+      },
+      this.space,
+    );
+
+    return `qaseJsonp(${json});`;
+  }
+}

--- a/qase-javascript-commons/src/models/attachment.ts
+++ b/qase-javascript-commons/src/models/attachment.ts
@@ -1,0 +1,8 @@
+export type Attachment = {
+  file_name: string;
+  mime_type: string;
+  file_path: string | null;
+  content: any;
+  size: number;
+  id: string;
+}

--- a/qase-javascript-commons/src/models/execution-sum.ts
+++ b/qase-javascript-commons/src/models/execution-sum.ts
@@ -1,0 +1,6 @@
+export type ExecutionSum = {
+  start_time: number
+  end_time: number
+  duration: number
+  cumulative_duration: number
+}

--- a/qase-javascript-commons/src/models/host-data.ts
+++ b/qase-javascript-commons/src/models/host-data.ts
@@ -1,0 +1,9 @@
+export type HostData = {
+  system: string
+  node: string
+  release: string
+  version: string
+  machine: string
+  python: string
+  pip: string
+}

--- a/qase-javascript-commons/src/models/host-data.ts
+++ b/qase-javascript-commons/src/models/host-data.ts
@@ -6,4 +6,6 @@ export type HostData = {
   machine: string
   python: string
   pip: string
+  node_version: string
+  npm: string
 }

--- a/qase-javascript-commons/src/models/index.ts
+++ b/qase-javascript-commons/src/models/index.ts
@@ -1,5 +1,6 @@
-export {
-  type TestResultType,
-  TestStatusEnum as TestStatusEnum,
-} from './test-result';
-export { type TestStepType, StepStatusEnum } from './test-step';
+export { type TestResultType } from './test-result';
+export { TestExecution, TestStatusEnum } from './test-execution';
+export { type TestStepType } from './test-step';
+export { StepStatusEnum } from './step-execution';
+export { Attachment } from './attachment';
+export { Report } from './report';

--- a/qase-javascript-commons/src/models/report.ts
+++ b/qase-javascript-commons/src/models/report.ts
@@ -1,0 +1,16 @@
+import { HostData } from './host-data';
+import { ShortResult } from './short-result';
+import { Stats } from './stats';
+import { ExecutionSum } from './execution-sum';
+
+export type Report = {
+    environment: string
+    execution: ExecutionSum
+    host_data: HostData
+    results: ShortResult[]
+    stats: Stats
+    suites: any[]
+    threads: string[]
+    title: string
+}
+

--- a/qase-javascript-commons/src/models/short-result.ts
+++ b/qase-javascript-commons/src/models/short-result.ts
@@ -1,0 +1,7 @@
+export type ShortResult = {
+  id: string
+  title: string
+  status: string
+  duration: number
+  thread: string | null
+}

--- a/qase-javascript-commons/src/models/stats.ts
+++ b/qase-javascript-commons/src/models/stats.ts
@@ -1,0 +1,8 @@
+export type Stats = {
+  passed: number
+  failed: number
+  skipped: number
+  broken: number
+  muted: number
+  total: number
+}

--- a/qase-javascript-commons/src/models/step-data.ts
+++ b/qase-javascript-commons/src/models/step-data.ts
@@ -1,0 +1,4 @@
+export interface StepData {
+  action: string;
+  expected_result: string | null;
+}

--- a/qase-javascript-commons/src/models/step-execution.ts
+++ b/qase-javascript-commons/src/models/step-execution.ts
@@ -1,0 +1,12 @@
+export enum StepStatusEnum {
+  passed = 'passed',
+  failed = 'failed',
+  blocked = 'blocked',
+}
+
+export interface StepExecution {
+  start_time: number | null;
+  status: StepStatusEnum;
+  end_time: number | null;
+  duration: number | null;
+}

--- a/qase-javascript-commons/src/models/test-execution.ts
+++ b/qase-javascript-commons/src/models/test-execution.ts
@@ -1,0 +1,20 @@
+/**
+ * @enum {string}
+ */
+export enum TestStatusEnum {
+  passed = 'passed',
+  failed = 'failed',
+  skipped = 'skipped',
+  disabled = 'disabled',
+  blocked = 'blocked',
+  invalid = 'invalid',
+}
+
+export interface TestExecution {
+  start_time: number | null;
+  status: TestStatusEnum;
+  end_time: number | null;
+  duration: number | null;
+  stacktrace: string | null;
+  thread: string | null;
+}

--- a/qase-javascript-commons/src/models/test-result.ts
+++ b/qase-javascript-commons/src/models/test-result.ts
@@ -1,27 +1,37 @@
 import { TestStepType } from './test-step';
+import { Attachment } from './attachment';
+import { TestExecution } from './test-execution';
 
-/**
- * @enum {string}
- */
-export enum TestStatusEnum {
-  passed = 'passed',
-  failed = 'failed',
-  skipped = 'skipped',
-  disabled = 'disabled',
-  blocked = 'blocked',
-  invalid = 'invalid',
-}
+
+
+// export type TestResultType = {
+//   id: string;
+//   testOpsId: number[];
+//   title: string;
+//   status: `${TestStatusEnum}`;
+//   suiteTitle?: string | string[] | undefined;
+//   error?: Error | undefined;
+//   startTime?: number | undefined;
+//   duration?: number | undefined;
+//   endTime?: number | undefined;
+//   steps?: TestStepType[] | undefined;
+//   attachments?: string[] | undefined;
+// };
 
 export type TestResultType = {
-  id: string;
-  testOpsId: number[];
-  title: string;
-  status: `${TestStatusEnum}`;
-  suiteTitle?: string | string[] | undefined;
-  error?: Error | undefined;
-  startTime?: number | undefined;
-  duration?: number | undefined;
-  endTime?: number | undefined;
-  steps?: TestStepType[] | undefined;
-  attachments?: string[] | undefined;
-};
+  id: string
+  title: string
+  signature: string
+  run_id: number | null
+  testops_id: number | null
+  execution: TestExecution
+  fields: Map<string, string>
+  attachments: Attachment[]
+  steps: TestStepType[]
+  params: Map<string, string>
+  author: string | null
+  relations: any[]
+  muted: boolean
+  message: string | null
+}
+

--- a/qase-javascript-commons/src/models/test-step.ts
+++ b/qase-javascript-commons/src/models/test-step.ts
@@ -1,15 +1,28 @@
-export enum StepStatusEnum {
-  passed = 'passed',
-  failed = 'failed',
-  blocked = 'blocked',
-}
+import { StepData } from './step-data';
+import { StepExecution } from './step-execution';
+
+import { Attachment } from './attachment';
+
+
+
+// export type TestStepType = {
+//   id: string;
+//   title: string;
+//   status: `${StepStatusEnum}`;
+//   duration?: number | undefined;
+//   error?: Error | undefined;
+//   steps?: TestStepType[] | undefined;
+//   attachments?: string[] | undefined;
+// };
+
+
 
 export type TestStepType = {
   id: string;
-  title: string;
-  status: `${StepStatusEnum}`;
-  duration?: number | undefined;
-  error?: Error | undefined;
-  steps?: TestStepType[] | undefined;
-  attachments?: string[] | undefined;
-};
+  step_type: string;
+  data: StepData;
+  parent_id: string | null;
+  execution: StepExecution;
+  attachments: Attachment[];
+  steps: TestStepType[];
+}

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -20,7 +20,6 @@ import {
 } from './env';
 import { TestStatusEnum, TestResultType } from './models';
 import { DriverEnum, FsWriter } from './writer';
-import { JsonFormatter } from './formatter';
 
 import { getPackageVersion } from './utils/get-package-version';
 import { CustomBoundaryFormData } from './utils/custom-boundary';
@@ -339,7 +338,7 @@ export class QaseReporter extends AbstractReporter {
 
       case ModeEnum.report: {
         const localOptions = report.connections?.[DriverEnum.local];
-        const writer = new FsWriter(localOptions, new JsonFormatter());
+        const writer = new FsWriter(localOptions);
 
         return new ReportReporter(commonOptions, writer, logger);
       }

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -11,7 +11,7 @@ import {
   ReportReporter,
   LoggerInterface,
 } from './reporters';
-import { composeOptions, ModeEnum, OptionsType } from './options'
+import { composeOptions, ModeEnum, OptionsType } from './options';
 import {
   EnvApiEnum,
   EnvTestOpsEnum,
@@ -30,12 +30,12 @@ import { DisabledException } from './utils/disabled-exception';
  * @type {Record<TestStatusEnum, (test: TestResultType) => string>}
  */
 const resultLogMap: Record<TestStatusEnum, (test: TestResultType) => string> = {
-  [TestStatusEnum.failed]: (test) => chalk`{red Test ${test.title} ${test.status}}`,
-  [TestStatusEnum.passed]: (test) => chalk`{green Test ${test.title} ${test.status}}`,
-  [TestStatusEnum.skipped]: (test) => chalk`{blueBright Test ${test.title} ${test.status}}`,
-  [TestStatusEnum.blocked]: (test) => chalk`{blueBright Test ${test.title} ${test.status}}`,
-  [TestStatusEnum.disabled]: (test) => chalk`{grey Test ${test.title} ${test.status}}`,
-  [TestStatusEnum.invalid]: (test) => chalk`{yellowBright Test ${test.title} ${test.status}}`,
+  [TestStatusEnum.failed]: (test) => chalk`{red Test ${test.title} ${test.execution.status}}`,
+  [TestStatusEnum.passed]: (test) => chalk`{green Test ${test.title} ${test.execution.status}}`,
+  [TestStatusEnum.skipped]: (test) => chalk`{blueBright Test ${test.title} ${test.execution.status}}`,
+  [TestStatusEnum.blocked]: (test) => chalk`{blueBright Test ${test.title} ${test.execution.status}}`,
+  [TestStatusEnum.disabled]: (test) => chalk`{grey Test ${test.title} ${test.execution.status}}`,
+  [TestStatusEnum.invalid]: (test) => chalk`{yellowBright Test ${test.title} ${test.execution.status}}`,
 };
 
 /**
@@ -180,8 +180,7 @@ export class QaseReporter extends AbstractReporter {
 
       try {
         this.upstreamReporter?.addTestResult(result);
-      }
-      catch (error) {
+      } catch (error) {
         this.logError('Unable to add the result to the upstream reporter:', error);
 
         if (this.fallbackReporter == undefined) {
@@ -206,8 +205,7 @@ export class QaseReporter extends AbstractReporter {
   private addTestResultToFallback(result: TestResultType): void {
     try {
       this.fallbackReporter?.addTestResult(result);
-    }
-    catch (error) {
+    } catch (error) {
       this.logError('Unable to add the result to the fallback reporter:', error);
       this.disabled = true;
     }
@@ -248,8 +246,7 @@ export class QaseReporter extends AbstractReporter {
   private async publishFallback(): Promise<void> {
     try {
       await this.fallbackReporter?.publish();
-    }
-    catch (error) {
+    } catch (error) {
       this.logError('Unable to publish the run results to the fallback reporter:', error);
       this.disabled = true;
     }
@@ -318,7 +315,7 @@ export class QaseReporter extends AbstractReporter {
               reporterName,
             ),
           },
-          ...api
+          ...api,
         }, CustomBoundaryFormData);
 
         return new TestOpsReporter(
@@ -336,7 +333,7 @@ export class QaseReporter extends AbstractReporter {
           },
           apiClient,
           logger,
-          typeof environment === 'number' ? environment : undefined
+          typeof environment === 'number' ? environment : undefined,
         );
       }
 
@@ -360,6 +357,6 @@ export class QaseReporter extends AbstractReporter {
    * @private
    */
   private logTestItem(test: TestResultType) {
-    this.log(resultLogMap[test.status](test));
+    this.log(resultLogMap[test.execution.status](test));
   }
 }

--- a/qase-javascript-commons/src/reporters/report-reporter.ts
+++ b/qase-javascript-commons/src/reporters/report-reporter.ts
@@ -1,10 +1,5 @@
-import {
-  AbstractReporter,
-  ReporterOptionsType,
-  LoggerInterface,
-} from './abstract-reporter';
-
-import { TestResultType } from '../models';
+import { AbstractReporter, LoggerInterface, ReporterOptionsType } from './abstract-reporter';
+import { Report, TestResultType, TestStatusEnum, TestStepType } from '../models';
 import { WriterInterface } from '../writer';
 
 /**
@@ -38,9 +33,101 @@ export class ReportReporter extends AbstractReporter {
    *
    * eslint-disable-next-line @typescript-eslint/require-await
    */
-  public async publish() {
-    const path = await this.writer.write(this.results);
+  public async publish(): Promise<void> {
+    const report: Report = {
+      title: 'Test report',
+      execution: {
+        start_time: 0,
+        end_time: 0,
+        duration: 0,
+        cumulative_duration: 0,
+      },
+      stats: {
+        total: 0,
+        passed: 0,
+        failed: 0,
+        skipped: 0,
+        broken: 0,
+        muted: 0,
+      },
+      results: [],
+      threads: [],
+      suites: [],
+      environment: '',
+      host_data: {
+        system: '',
+        node: '',
+        release: '',
+        version: '',
+        machine: '',
+        python: '',
+        pip: '',
+      },
+    };
+
+    for (const result of this.results) {
+      report.stats.total++;
+      switch (result.execution.status) {
+        case TestStatusEnum.passed:
+          report.stats.passed++;
+          break;
+        case TestStatusEnum.failed:
+          report.stats.failed++;
+          break;
+        case TestStatusEnum.skipped:
+          report.stats.skipped++;
+          break;
+        case TestStatusEnum.invalid:
+          report.stats.broken++;
+          break;
+        case TestStatusEnum.blocked:
+          report.stats.muted++;
+          break;
+      }
+
+      if (result.execution.thread && !report.threads.includes(result.execution.thread)) {
+        report.threads.push(result.execution.thread);
+      }
+
+      report.execution.cumulative_duration += result.execution.duration ?? 0;
+
+      report.results.push({
+        duration: result.execution.duration ?? 0,
+        id: result.id,
+        status: result.execution.status,
+        thread: result.execution.thread,
+        title: result.title,
+      });
+
+      if (result.attachments.length > 0) {
+        result.attachments = this.writer.writeAttachment(result.attachments);
+      }
+
+      result.steps = this.copyStepAttachments(result.steps);
+
+      await this.writer.writeTestResult(result);
+    }
+
+    const path = await this.writer.writeReport(report);
 
     this.log(`Report saved to ${path}`);
+  }
+
+  /**
+   * @param {TestStepType[]} steps
+   * @returns {TestStepType[]}
+   */
+  private copyStepAttachments(steps: TestStepType[]): TestStepType[] {
+    for (const step of steps) {
+      if (step.attachments.length > 0) {
+        step.attachments = this.writer.writeAttachment(step.attachments);
+      }
+
+      if (step.steps.length > 0) {
+        step.steps = this.copyStepAttachments(step.steps);
+      }
+    }
+
+    return steps;
   }
 }

--- a/qase-javascript-commons/src/writer/fs-writer.ts
+++ b/qase-javascript-commons/src/writer/fs-writer.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { WriterInterface } from './writer-interface';
 
 import { TestResultType, Attachment, Report } from '../models';
-import { FormatterInterface } from '../formatter';
+import { FormatterInterface, JsonFormatter, JsonpFormatter } from '../formatter';
 import { FormatEnum } from './driver-enum';
 
 export type FsWriterOptionsType = {
@@ -19,22 +19,27 @@ export type FsWriterOptionsType = {
 export class FsWriter implements WriterInterface {
   private readonly path: string;
   private readonly format: string;
+  private formatter: FormatterInterface;
 
   /**
    * @param {FsWriterOptionsType | undefined} options
-   * @param {FormatterInterface} formatter
    */
   constructor(
     options: FsWriterOptionsType | undefined,
-    private formatter: FormatterInterface,
   ) {
     const {
       path: pathOptions = path.join('build', 'qase-report'),
-      format = FormatEnum.json,
+      format = options?.format ?? FormatEnum.json,
     } = options ?? {};
 
     this.path = pathOptions;
     this.format = format;
+
+    if (this.format === FormatEnum.json) {
+      this.formatter = new JsonFormatter();
+    } else {
+      this.formatter = new JsonpFormatter();
+    }
   }
 
   /**

--- a/qase-javascript-commons/src/writer/writer-interface.ts
+++ b/qase-javascript-commons/src/writer/writer-interface.ts
@@ -1,5 +1,7 @@
-import { TestResultType } from '../models';
+import { TestResultType, Attachment, Report } from '../models';
 
 export interface WriterInterface {
-  write(results: TestResultType[]): Promise<string>;
+  writeReport(results: Report): Promise<string>;
+  writeTestResult(result: TestResultType): Promise<void>;
+  writeAttachment(attachments: Attachment[]): Attachment[];
 }

--- a/qase-jest/src/reporter.ts
+++ b/qase-jest/src/reporter.ts
@@ -80,7 +80,8 @@ export class JestQaseReporter implements Reporter {
   /**
    * @see {Reporter.onRunStart}
    */
-  public onRunStart() {/* empty */}
+  public onRunStart() {/* empty */
+  }
 
   /**
    * @param {Test} _
@@ -89,13 +90,12 @@ export class JestQaseReporter implements Reporter {
   public onTestResult(_: Test, result: TestResult) {
     result.testResults.forEach(
       ({
-        ancestorTitles,
-        title,
-        status,
-        duration,
-        failureMessages,
-        failureDetails,
-      }) => {
+         title,
+         status,
+         duration,
+         failureMessages,
+         failureDetails,
+       }) => {
         let error;
 
         if (status === 'failed') {
@@ -111,13 +111,28 @@ export class JestQaseReporter implements Reporter {
         }
 
         this.reporter.addTestResult({
+          attachments: [],
+          author: null,
+          execution: {
+            status: JestQaseReporter.statusMap[status],
+            start_time: null,
+            end_time: null,
+            duration: duration ?? 0,
+            stacktrace: error?.stack ?? null,
+            thread: null,
+          },
+          fields: new Map<string, string>(),
+          message: error?.message ?? null,
+          muted: false,
+          params: new Map<string, string>(),
+          relations: [],
+          run_id: null,
+          signature: '',
+          steps: [],
+          testops_id: JestQaseReporter.getCaseId(title)[0] ?? null,
           id: uuidv4(),
-          testOpsId: JestQaseReporter.getCaseId(title),
           title: title,
-          suiteTitle: ancestorTitles,
-          status: JestQaseReporter.statusMap[status],
-          duration: duration ?? 0,
-          error,
+          // suiteTitle: ancestorTitles,
         });
       },
     );
@@ -126,7 +141,8 @@ export class JestQaseReporter implements Reporter {
   /**
    * @see {Reporter.getLastError}
    */
-  public getLastError() {/* empty */}
+  public getLastError() {/* empty */
+  }
 
   /**
    * @see {Reporter.onRunComplete}


### PR DESCRIPTION
qase-javascript-commons: refactor models
--
Add models which supports the v2 API. The following models:
- Report: stores shot information about run
- TestResultType: stores information about autotest
- TestStepType: stores information about steps
- TestExecution: stores information about test execution
- StepExecution: stores information about step execution
- Stats: stores information about statistics of test statuses
- ExecutionSum: stores information about statistics of test executions

---
qase-javascript-commons: refactor reporters
--
Support the new models in the reporters

---
qase-reporters: refactor listeners
--
Support the new models in the listeners

---
qase-javascript-commons: add support the jsonp format
--
Add support the jsonp format in the file reporter

---
qase-javascript-commons: add host data
--
Add host data information to the file reporter