### PR TITLE
qase-playwright: support new models

### DIFF
--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -79,7 +79,7 @@ export class QaseReporter extends AbstractReporter {
     }
 
     if (qaseApiVersion) {
-      client.push(`qaseapi=${String(qaseApiVersion)}`);
+      client.push(`qaseio=${String(qaseApiVersion)}`);
     }
 
     return {
@@ -92,13 +92,13 @@ export class QaseReporter extends AbstractReporter {
    * @type {ReporterInterface}
    * @private
    */
-  private upstreamReporter?: ReporterInterface;
+  private readonly upstreamReporter?: ReporterInterface;
 
   /**
    * @type {ReporterInterface}
    * @private
    */
-  private fallbackReporter?: ReporterInterface;
+  private readonly fallbackReporter?: ReporterInterface;
 
 
   /**
@@ -125,6 +125,7 @@ export class QaseReporter extends AbstractReporter {
 
     try {
       this.upstreamReporter = this.createReporter(
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         composedOptions.mode as ModeEnum || ModeEnum.off,
         composedOptions,
         logger,
@@ -146,6 +147,7 @@ export class QaseReporter extends AbstractReporter {
 
     try {
       this.fallbackReporter = this.createReporter(
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         composedOptions.fallback as ModeEnum || ModeEnum.off,
         composedOptions,
         logger,
@@ -188,7 +190,7 @@ export class QaseReporter extends AbstractReporter {
         }
 
         if (!this.useFallback) {
-          this.fallbackReporter?.setTestResults(this.upstreamReporter?.getTestResults() ?? []);
+          this.fallbackReporter.setTestResults(this.upstreamReporter?.getTestResults() ?? []);
           this.useFallback = true;
         }
 
@@ -230,7 +232,7 @@ export class QaseReporter extends AbstractReporter {
         }
 
         if (!this.useFallback) {
-          this.fallbackReporter?.setTestResults(this.upstreamReporter?.getTestResults() ?? []);
+          this.fallbackReporter.setTestResults(this.upstreamReporter?.getTestResults() ?? []);
           this.useFallback = true;
         }
 
@@ -253,6 +255,7 @@ export class QaseReporter extends AbstractReporter {
 
   /**
    * @todo implement mode registry
+   * @param {ModeEnum} mode
    * @param {OptionsType} options
    * @param {LoggerInterface} logger
    * @returns {ReporterInterface}
@@ -340,7 +343,8 @@ export class QaseReporter extends AbstractReporter {
         const localOptions = report.connections?.[DriverEnum.local];
         const writer = new FsWriter(localOptions);
 
-        return new ReportReporter(commonOptions, writer, logger);
+        return new ReportReporter(commonOptions, writer, logger,
+          typeof environment === 'number' ? environment.toString() : environment, testops.run?.id);
       }
 
       case ModeEnum.off:

--- a/qase-javascript-commons/src/reporters/report-reporter.ts
+++ b/qase-javascript-commons/src/reporters/report-reporter.ts
@@ -11,18 +11,27 @@ import * as process from 'process';
  * @extends AbstractReporter
  */
 export class ReportReporter extends AbstractReporter {
+  private readonly environment: string | undefined;
+  private readonly runId: number | undefined;
+  private readonly startTime: number = Date.now();
 
   /**
    * @param {ReporterOptionsType} options
    * @param {WriterInterface} writer
    * @param {LoggerInterface} logger
+   * @param {string | undefined} environment
+   * @param {number | undefined} runId
    */
   constructor(
     options: ReporterOptionsType | undefined,
     private writer: WriterInterface,
     logger?: LoggerInterface,
+    environment?: string,
+    runId?: number,
   ) {
     super(options, logger);
+    this.environment = environment;
+    this.runId = runId;
   }
 
   /**
@@ -41,9 +50,9 @@ export class ReportReporter extends AbstractReporter {
     const report: Report = {
       title: 'Test report',
       execution: {
-        start_time: 0,
-        end_time: 0,
-        duration: 0,
+        start_time: this.startTime,
+        end_time: Date.now(),
+        duration: Date.now() - this.startTime,
         cumulative_duration: 0,
       },
       stats: {
@@ -57,7 +66,7 @@ export class ReportReporter extends AbstractReporter {
       results: [],
       threads: [],
       suites: [],
-      environment: '',
+      environment: this.environment ?? '',
       host_data: this.getHostInfo(),
     };
 
@@ -100,7 +109,7 @@ export class ReportReporter extends AbstractReporter {
       }
 
       result.steps = this.copyStepAttachments(result.steps);
-
+      result.run_id = this.runId ?? null;
       await this.writer.writeTestResult(result);
     }
 

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -1,8 +1,189 @@
+import test from '@playwright/test';
+import { v4 as uuidv4 } from 'uuid';
+import { PlaywrightQaseReporter } from './reporter';
+import * as path from 'path';
+
+export const ReporterContentType = 'application/qase.metadata+json';
+const defaultContentType = 'application/octet-stream';
+
+export interface MetadataMessage {
+  ids?: number[];
+  title?: string;
+  fields?: Map<string, string>;
+}
+
+/**
+ * Use `qase.id()` instead. This method is deprecated and kept for reverse compatibility.
+ *
+ * @param caseId
+ * @param name
+ * @example
+ * test(qase(1, 'test'), async ({ page }) => {
+ *  await page.goto('https://example.com');
+ * });
+ * @returns {string}
+ */
 export const qase = (
   caseId: number | string | number[] | string[],
   name: string,
 ): string => {
-  const caseIds = Array.isArray(caseId) ? caseId : [caseId];
+  console.log(`qase: qase(${caseId as string}) is deprecated. Use qase.id() and qase.title() inside the test body`);
 
-  return `${name} (Qase ID: ${caseIds.join(',')})`;
+  const caseIds = Array.isArray(caseId) ? caseId : [caseId];
+  const ids: number[] = [];
+
+  for (const id of caseIds) {
+    if (typeof id === 'number') {
+      ids.push(id);
+      continue;
+    }
+
+    const parsedId = parseInt(id);
+
+    if (!isNaN(parsedId)) {
+      ids.push(parsedId);
+      continue;
+    }
+
+    console.log(`qase: qase ID ${id} should be a number`);
+  }
+
+  PlaywrightQaseReporter.addIds(ids, name);
+
+  return `${name}`;
+};
+
+/**
+ * Set IDs for the test case
+ *
+ * @param {number | number[]} value
+ *
+ * @example
+ * test('test', async ({ page }) => {
+ *    qase.id(1);
+ *    await page.goto('https://example.com');
+ * });
+ *
+ */
+qase.id = function(value: number | number[]) {
+  addMetadata({
+    ids: Array.isArray(value) ? value : [value],
+  });
+};
+
+/**
+ * Set a title for the test case
+ * @param {string} value
+ * @example
+ * test('test', async ({ page }) => {
+ *    qase.title("Title");
+ *    await page.goto('https://example.com');
+ * });
+ */
+qase.title = function(value: string) {
+  addMetadata({
+    title: value,
+  });
+};
+
+/**
+ * Set fields for the test case
+ * @param {Map<string, string>[]} value
+ * @example
+ * test('test', async ({ page }) => {
+ *    qase.fields({ 'severity': 'high', 'priority': 'medium' });
+ *    await page.goto('https://example.com');
+ * });
+ */
+qase.fields = function(value: Map<string, string>) {
+  addMetadata({
+    fields: value,
+  });
+};
+
+/**
+ * Attach a file to the test case or the step
+ * @param attach
+ * @example
+ * test('test', async ({ page }) => {
+ *   qase.attach({ name: 'attachment.txt', content: 'Hello, world!', contentType: 'text/plain' });
+ *   qase.attach({ paths: '/path/to/file'});
+ *   qase.attach({ paths: ['/path/to/file', '/path/to/another/file']});
+ *   await page.goto('https://example.com');
+ *  });
+ */
+qase.attach = function(attach: {
+  name?: string,
+  paths?: string | string[],
+  content?: Buffer | string,
+  contentType?: string,
+}) {
+  if (attach.paths !== undefined) {
+    const files = Array.isArray(attach.paths) ? attach.paths : [attach.paths];
+
+    for (const file of files) {
+      const attachmentName = path.basename(file);
+      const contentType = getContentType(path.extname(file));
+      addAttachment(attachmentName, contentType, file);
+    }
+
+    return;
+  }
+  const attachmentName = attach.name ?? 'attachment';
+  const contentType = attach.contentType ?? defaultContentType;
+  addAttachment(attachmentName, contentType, undefined, attach.content);
+
+};
+
+const addMetadata = (metadata: MetadataMessage): void => {
+  test.info().attach('qase-metadata.json', {
+    contentType: ReporterContentType,
+    body: Buffer.from(JSON.stringify(metadata), 'utf8'),
+  }).catch(() => {/**/
+  });
+};
+
+const getContentType = (extension: string): string => {
+  const types: Record<string, string> = {
+    '.html': 'text/html',
+    '.css': 'text/css',
+    '.js': 'application/javascript',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.svg': 'image/svg+xml',
+    '.wav': 'audio/wav',
+    '.mp4': 'video/mp4',
+    '.woff': 'application/font-woff',
+    '.ttf': 'application/font-ttf',
+    '.eot': 'application/vnd.ms-fontobject',
+    '.otf': 'application/font-otf',
+    '.wasm': 'application/wasm',
+  };
+
+  return types[extension] ?? defaultContentType;
+};
+
+const addAttachment = (name: string, contentType: string, filePath?: string, body?: string | Buffer): void => {
+  const stepName = `step_attach_${uuidv4()}_${name}`;
+
+  test.step(stepName, async () => {
+    if (filePath) {
+      await test.info().attach(stepName, {
+        contentType: contentType,
+        path: filePath,
+      });
+      return;
+    }
+
+    if (body) {
+      await test.info().attach(stepName, {
+        contentType: contentType,
+        body: body,
+      });
+      return;
+    }
+  }).catch(() => {/**/
+  });
 };


### PR DESCRIPTION
qase-playwright: support new models
--
The following changes:
- support new models
- add a new way for set the test case metadata (ids, title, fields)
- add a method what adds attachments to a step or a test case
- support multiple ids. If add multiple ids to a test case, then count of results will be equal count of ids.

---
qase-javascript-commons: improve the file reporter
--
Add the following data to the report:
- environment
- run id
- start and end time