### PR TITLE
qase-javascript-commons: add logic for supporting multiple IDs

### DIFF
--- a/qase-cucumberjs/src/reporter.ts
+++ b/qase-cucumberjs/src/reporter.ts
@@ -255,7 +255,7 @@ export class CucumberQaseReporter extends Formatter {
           run_id: null,
           signature: '',
           steps: [],
-          testops_id: info.caseIds[0] ?? null,
+          testops_id: info.caseIds.length > 0 ? info.caseIds : null,
           id: tcs.id,
           title: info.name,
           // suiteTitle: info.lastAstNodeId && this.scenarios[info.lastAstNodeId],

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -183,7 +183,7 @@ export class CypressQaseReporter extends reporters.Base {
         stacktrace: test.err?.stack ?? null,
         thread: null,
       },
-      testops_id: ids[0] ?? null,
+      testops_id: ids.length > 0 ? ids : null,
       title: test.title,
       // suiteTitle: test.parent?.titlePath(),
     };

--- a/qase-javascript-commons/src/models/test-result.ts
+++ b/qase-javascript-commons/src/models/test-result.ts
@@ -3,7 +3,6 @@ import { Attachment } from './attachment';
 import { TestExecution } from './test-execution';
 
 
-
 // export type TestResultType = {
 //   id: string;
 //   testOpsId: number[];
@@ -23,7 +22,7 @@ export type TestResultType = {
   title: string
   signature: string
   run_id: number | null
-  testops_id: number | null
+  testops_id: number | number[] | null
   execution: TestExecution
   fields: Map<string, string>
   attachments: Attachment[]

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -170,7 +170,7 @@ export class QaseReporter extends AbstractReporter {
   /**
    * @param {TestResultType} result
    */
-  public addTestResult(result: TestResultType) {
+  public override addTestResult(result: TestResultType) {
     if (!this.disabled) {
       this.logTestItem(result);
 

--- a/qase-javascript-commons/src/reporters/report-reporter.ts
+++ b/qase-javascript-commons/src/reporters/report-reporter.ts
@@ -1,5 +1,5 @@
 import { AbstractReporter, LoggerInterface, ReporterOptionsType } from './abstract-reporter';
-import { Report, TestResultType, TestStatusEnum, TestStepType } from '../models';
+import { Report, TestStatusEnum, TestStepType } from '../models';
 import { WriterInterface } from '../writer';
 import { HostData } from '../models/host-data';
 import * as os from 'os';
@@ -32,13 +32,6 @@ export class ReportReporter extends AbstractReporter {
     super(options, logger);
     this.environment = environment;
     this.runId = runId;
-  }
-
-  /**
-   * @param {TestResultType} result
-   */
-  public addTestResult(result: TestResultType) {
-    this.results.push(result);
   }
 
   /**

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -129,13 +129,6 @@ export class TestOpsReporter extends AbstractReporter {
   }
 
   /**
-   * @param {TestResultType} result
-   */
-  public addTestResult(result: TestResultType) {
-    this.results.push(result);
-  }
-
-  /**
    * @returns {Promise<void>}
    */
   public async publish(): Promise<void> {
@@ -210,7 +203,7 @@ export class TestOpsReporter extends AbstractReporter {
     return {
       title: result.title,
       execution: this.getExecution(result.execution),
-      testops_id: result.testops_id,
+      testops_id: Array.isArray(result.testops_id) ? null : result.testops_id,
       attachments: attachments,
       steps: steps,
       params: {},

--- a/qase-jest/src/reporter.ts
+++ b/qase-jest/src/reporter.ts
@@ -110,6 +110,7 @@ export class JestQaseReporter implements Reporter {
           error.stack = failureMessages.join('\n\n');
         }
 
+        const ids = JestQaseReporter.getCaseId(title);
         this.reporter.addTestResult({
           attachments: [],
           author: null,
@@ -129,7 +130,7 @@ export class JestQaseReporter implements Reporter {
           run_id: null,
           signature: '',
           steps: [],
-          testops_id: JestQaseReporter.getCaseId(title)[0] ?? null,
+          testops_id: ids.length > 0 ? ids : null,
           id: uuidv4(),
           title: title,
           // suiteTitle: ancestorTitles,

--- a/qase-newman/src/reporter.ts
+++ b/qase-newman/src/reporter.ts
@@ -124,7 +124,7 @@ export class NewmanQaseReporter {
       (_err: Error | undefined, exec: NewmanRunExecution) => {
         const { item } = exec;
         // const parent = item.parent();
-
+        const ids = NewmanQaseReporter.getCaseIds(item.events);
         this.pendingResultMap.set(item.id, {
           attachments: [],
           author: null,
@@ -144,7 +144,7 @@ export class NewmanQaseReporter {
           run_id: null,
           signature: '',
           steps: [],
-          testops_id: NewmanQaseReporter.getCaseIds(item.events)[0] ?? null,
+          testops_id: ids.length > 0 ? ids : null,
           id: item.id,
           title: item.name,
           // suiteTitle: parent ? NewmanQaseReporter.getParentTitles(parent) : [],

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -275,32 +275,13 @@ export class PlaywrightQaseReporter implements Reporter {
       title: testCaseMetadata.title === '' ? test.title : testCaseMetadata.title,
     };
 
-    let ids: number[];
     if (testCaseMetadata.ids.length > 0) {
-      ids = testCaseMetadata.ids;
+      testResult.testops_id = testCaseMetadata.ids;
     } else {
-      ids = PlaywrightQaseReporter.qaseIds.get(test.title) ?? [];
+      testResult.testops_id = PlaywrightQaseReporter.qaseIds.get(test.title) ?? null;
     }
 
-    if (ids.length == 0) {
-      this.reporter.addTestResult(testResult);
-      return;
-    }
-
-    // if we have multiple ids, we need to create multiple test results and set duration to 0 for all but the first one
-    let firstCase = true;
-    for (const id of ids) {
-      const testResultCopy = { ...testResult };
-      testResultCopy.testops_id = id;
-      testResultCopy.id = uuidv4();
-
-      if (!firstCase) {
-        testResultCopy.execution.duration = 0;
-      }
-      firstCase = false;
-
-      this.reporter.addTestResult(testResultCopy);
-    }
+    this.reporter.addTestResult(testResult);
   }
 
   /**

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -179,6 +179,7 @@ export class TestcafeQaseReporter {
     meta: Record<string, string>,
   ) => {
     const error = TestcafeQaseReporter.transformErrors(testRunInfo.errs);
+    const ids = TestcafeQaseReporter.getCaseId(meta);
     this.reporter.addTestResult({
       author: null,
       execution: {
@@ -198,7 +199,7 @@ export class TestcafeQaseReporter {
       signature: '',
       steps: [],
       id: uuidv4(),
-      testops_id: TestcafeQaseReporter.getCaseId(meta)[0] ?? null,
+      testops_id: ids.length > 0 ? ids : null,
       title: title,
       // suiteTitle: testRunInfo.fixture.name,
       attachments: TestcafeQaseReporter.transformAttachments(


### PR DESCRIPTION
qase-javascript-commons: add logic for supporting multiple IDs
--
Move this logic from the Playwright reporter to the abstract reporter

---

qase-reporters: support a new logic of commons
--
Support a new logic of the qase-javascript-commons package.