### PR TITLE
ci: use command `npm ci` to install packages in CI

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm ci
     - run: npm run build -ws --if-present
     - run: npm run lint -w ${{ matrix.prefix }}
     - run: npm run test -w ${{ matrix.prefix }}
@@ -37,7 +37,7 @@ jobs:
         node-version: '16'
         registry-url: 'https://registry.npmjs.org'
     - if: contains(github.event.ref, matrix.prefix)
-      run: npm install
+      run: npm ci
     - if: contains(github.event.ref, matrix.prefix)
       run: npm run build -ws --if-present
     - if: contains(github.event.ref, matrix.prefix)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3771,6 +3771,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/2-thenable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/2-thenable/-/2-thenable-1.0.0.tgz",
+      "integrity": "sha512-HqiDzaLDFCXkcCO/SwoyhRwqYtINFHF7t9BDRq4x90TOKNAJpiqUt9X5lQ08bwxYzc067HUywDjGySpebHcUpw==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.47"
+      }
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -4906,6 +4915,21 @@
       "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/child-process-ext": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/child-process-ext/-/child-process-ext-3.0.2.tgz",
+      "integrity": "sha512-oBePsLbQpTJFxzwyCvs9yWWF0OEM6vGGepHwt1stqmX7QQqOuDc8j2ywdvAs9Tvi44TT7d9ackqhR4Q10l1u8w==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "es5-ext": "^0.10.62",
+        "log": "^6.3.1",
+        "split2": "^3.2.2",
+        "stream-promise": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/chokidar": {
@@ -6493,6 +6517,15 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/eventemitter2": {
@@ -9954,6 +9987,20 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
     },
+    "node_modules/log": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
+      "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "duration": "^0.2.2",
+        "es5-ext": "^0.10.53",
+        "event-emitter": "^0.3.5",
+        "sprintf-kit": "^2.0.1",
+        "type": "^2.5.0",
+        "uni-global": "^1.0.0"
+      }
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -10044,6 +10091,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/log/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -12833,11 +12885,40 @@
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated"
     },
+    "node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
+    },
+    "node_modules/split2/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/sprintf-kit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.1.tgz",
+      "integrity": "sha512-2PNlcs3j5JflQKcg4wpdqpZ+AjhQJ2OZEo34NXDtlB0tIPG84xaaXhpA8XFacFiwjKA4m49UOYG83y3hbMn/gQ==",
+      "dependencies": {
+        "es5-ext": "^0.10.53"
+      }
     },
     "node_modules/sshpk": {
       "version": "1.17.0",
@@ -12958,6 +13039,24 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ=="
+    },
+    "node_modules/stream-promise": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-promise/-/stream-promise-3.2.0.tgz",
+      "integrity": "sha512-P+7muTGs2C8yRcgJw/PPt61q7O517tDHiwYEzMWo1GSBCcZedUMT/clz7vUNsSxFphIlJ6QUL4GexQKlfJoVtA==",
+      "dependencies": {
+        "2-thenable": "^1.0.0",
+        "es5-ext": "^0.10.49",
+        "is-stream": "^1.1.0"
+      }
+    },
+    "node_modules/stream-promise/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -14329,6 +14428,19 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
+    "node_modules/uni-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
+      "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
+      "dependencies": {
+        "type": "^2.5.0"
+      }
+    },
+    "node_modules/uni-global/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -15333,6 +15445,7 @@
       "dependencies": {
         "ajv": "^8.12.0",
         "chalk": "^4.1.2",
+        "child-process-ext": "^3.0.2",
         "env-schema": "^5.2.0",
         "form-data": "^4.0.0",
         "lodash.get": "^4.4.2",
@@ -19339,6 +19452,15 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "2-thenable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/2-thenable/-/2-thenable-1.0.0.tgz",
+      "integrity": "sha512-HqiDzaLDFCXkcCO/SwoyhRwqYtINFHF7t9BDRq4x90TOKNAJpiqUt9X5lQ08bwxYzc067HUywDjGySpebHcUpw==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.47"
+      }
+    },
     "abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -20169,6 +20291,18 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
       "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA=="
+    },
+    "child-process-ext": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/child-process-ext/-/child-process-ext-3.0.2.tgz",
+      "integrity": "sha512-oBePsLbQpTJFxzwyCvs9yWWF0OEM6vGGepHwt1stqmX7QQqOuDc8j2ywdvAs9Tvi44TT7d9ackqhR4Q10l1u8w==",
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "es5-ext": "^0.10.62",
+        "log": "^6.3.1",
+        "split2": "^3.2.2",
+        "stream-promise": "^3.2.0"
+      }
     },
     "chokidar": {
       "version": "3.5.3",
@@ -21439,6 +21573,15 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "eventemitter2": {
       "version": "6.4.7",
@@ -24166,6 +24309,27 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
     },
+    "log": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
+      "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
+      "requires": {
+        "d": "^1.0.1",
+        "duration": "^0.2.2",
+        "es5-ext": "^0.10.53",
+        "event-emitter": "^0.3.5",
+        "sprintf-kit": "^2.0.1",
+        "type": "^2.5.0",
+        "uni-global": "^1.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+        }
+      }
+    },
     "log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -25734,6 +25898,7 @@
         "ajv": "^8.12.0",
         "axios": "^0.21.4",
         "chalk": "^4.1.2",
+        "child-process-ext": "^3.0.2",
         "env-schema": "^5.2.0",
         "form-data": "^4.0.0",
         "jest": "^29.5.0",
@@ -27337,11 +27502,39 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
     },
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "requires": {
+        "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "sprintf-kit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.1.tgz",
+      "integrity": "sha512-2PNlcs3j5JflQKcg4wpdqpZ+AjhQJ2OZEo34NXDtlB0tIPG84xaaXhpA8XFacFiwjKA4m49UOYG83y3hbMn/gQ==",
+      "requires": {
+        "es5-ext": "^0.10.53"
+      }
     },
     "sshpk": {
       "version": "1.17.0",
@@ -27443,6 +27636,23 @@
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ=="
+        }
+      }
+    },
+    "stream-promise": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-promise/-/stream-promise-3.2.0.tgz",
+      "integrity": "sha512-P+7muTGs2C8yRcgJw/PPt61q7O517tDHiwYEzMWo1GSBCcZedUMT/clz7vUNsSxFphIlJ6QUL4GexQKlfJoVtA==",
+      "requires": {
+        "2-thenable": "^1.0.0",
+        "es5-ext": "^0.10.49",
+        "is-stream": "^1.1.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
         }
       }
     },
@@ -28524,6 +28734,21 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    },
+    "uni-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
+      "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
+      "requires": {
+        "type": "^2.5.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+        }
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",


### PR DESCRIPTION
# ci: use command `npm ci` to install packages in CI

Run CI precisely on packages saved in package-lock.json. All package updates will now be done and tested manually. Otherwise, we get updated versions of packages every time CI runs, and we're unable to say what's packaged in particular version.

This commit also updates package-lock.json.

See https://docs.npmjs.com/cli/v10/commands/npm-ci