### PR TITLE
release: qaseio 2.1.0-beta.0, others 2.0.0-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-# [Qase TMS](https://qase.io) JavaScript
+# [Qase TestOps](https://qase.io) reporters for JavaScript
 
-This is a monorepo for all JavaScript-related projects
+Monorepo with [Qase TestOps](https://qase.io) reporters for JavaScript testing frameworks.
 
-## Projects
-
-- [qaseio](/qaseio) - JavaScript API
-- [qase-core-reporter](/qase-core-reporter) - Core reporter
 - [qase-cypress](/qase-cypress) - Cypress reporter
 - [qase-cucumberjs](/qase-cucumberjs) - CucumberJS reporter
 - [qase-newman](/qase-newman) - Newman reporter
 - [qase-testcafe](/qase-testcafe) - TestCafe reporter
 - [qase-jest](/qase-jest) - Jest reporter
 - [qase-playwright](/qase-playwright) - Playwright reporter
+- [qaseio](/qaseio) - JavaScript API client
+- [qase-javascript-commons](/qase-javascript-commons) - Common functions library

--- a/examples/cucumberjs/package.json
+++ b/examples/cucumberjs/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^7.3.2",
-    "cucumberjs-qase-reporter": "^2.0.0-beta.1",
+    "cucumberjs-qase-reporter": "^2.0.0-beta.2",
     "zombie": "^6.1.4"
   }
 }

--- a/examples/cypress/package.json
+++ b/examples/cypress/package.json
@@ -8,7 +8,7 @@
     "cypress": "^12.13.0",
     "cypress-mochawesome-reporter": "^3.5.0",
     "cypress-multi-reporters": "^1.6.3",
-    "cypress-qase-reporter": "^2.0.0-beta.1",
+    "cypress-qase-reporter": "^2.0.0-beta.2",
     "eslint-plugin-cypress": "^2.13.3"
   }
 }

--- a/examples/jest/package.json
+++ b/examples/jest/package.json
@@ -9,6 +9,6 @@
     "@jest/globals": "^29.5.0",
     "babel-jest": "^29.5.0",
     "jest": "^29.5.0",
-    "jest-qase-reporter": "^2.0.0-beta.1"
+    "jest-qase-reporter": "^2.0.0-beta.2"
   }
 }

--- a/examples/newman/package.json
+++ b/examples/newman/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "newman": "^5.3.2",
-    "newman-reporter-qase": "^2.0.0-beta.1"
+    "newman-reporter-qase": "^2.0.0-beta.2"
   }
 }

--- a/examples/playwright/package.json
+++ b/examples/playwright/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.34.3",
-    "playwright-qase-reporter": "^2.0.0-beta.1"
+    "playwright-qase-reporter": "^2.0.0-beta.2"
   }
 }

--- a/examples/testcafe/package.json
+++ b/examples/testcafe/package.json
@@ -7,6 +7,6 @@
   "devDependencies": {
     "eslint-plugin-testcafe": "^0.2.1",
     "testcafe": "^2.6.0",
-    "testcafe-reporter-qase": "^2.0.0-beta.1"
+    "testcafe-reporter-qase": "^2.0.0-beta.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15366,7 +15366,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/messages": "^22.0.0",
-        "qase-javascript-commons": "^2.0.0-beta.1"
+        "qase-javascript-commons": "^2.1.0-beta.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.5.0",
@@ -15386,7 +15386,7 @@
       "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.0.0-beta.1",
+        "qase-javascript-commons": "^2.1.0-beta.0",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -15440,7 +15440,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.0.0-beta.1",
+      "version": "2.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -15451,7 +15451,7 @@
         "lodash.get": "^4.4.2",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
-        "qaseio": "^2.0.4-beta.1",
+        "qaseio": "^2.1.0-beta.0",
         "strip-ansi": "^6.0.1",
         "uuid": "^9.0.0"
       },
@@ -15497,7 +15497,7 @@
       "dependencies": {
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "qase-javascript-commons": "^2.0.0-beta.1",
+        "qase-javascript-commons": "^2.1.0-beta.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -15522,7 +15522,7 @@
       "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.0.0-beta.1",
+        "qase-javascript-commons": "^2.1.0-beta.0",
         "semver": "^7.5.1"
       },
       "devDependencies": {
@@ -15546,7 +15546,7 @@
       "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.0.0-beta.1",
+        "qase-javascript-commons": "^2.1.0-beta.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -15567,7 +15567,7 @@
       "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.0.0-beta.1",
+        "qase-javascript-commons": "^2.1.0-beta.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -15584,7 +15584,7 @@
       }
     },
     "qaseio": {
-      "version": "2.0.4-beta.1",
+      "version": "2.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.21.4",
@@ -20582,7 +20582,7 @@
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
         "jest": "^29.5.0",
-        "qase-javascript-commons": "^2.0.0-beta.1",
+        "qase-javascript-commons": "^2.1.0-beta.0",
         "ts-jest": "^29.1.0"
       }
     },
@@ -20741,7 +20741,7 @@
         "ajv": "^8.12.0",
         "jest": "^29.5.0",
         "mocha": "^10.2.0",
-        "qase-javascript-commons": "^2.0.0-beta.1",
+        "qase-javascript-commons": "^2.1.0-beta.0",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.1"
       },
@@ -23796,7 +23796,7 @@
         "jest": "^29.5.0",
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "qase-javascript-commons": "^2.0.0-beta.1",
+        "qase-javascript-commons": "^2.1.0-beta.0",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"
       }
@@ -25046,7 +25046,7 @@
         "@types/postman-collection": "^3.5.7",
         "jest": "^29.5.0",
         "postman-collection": "^4.1.7",
-        "qase-javascript-commons": "^2.0.0-beta.1",
+        "qase-javascript-commons": "^2.1.0-beta.0",
         "semver": "^7.5.1",
         "ts-jest": "^29.1.0"
       }
@@ -25486,7 +25486,7 @@
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
         "jest": "^29.5.0",
-        "qase-javascript-commons": "^2.0.0-beta.1",
+        "qase-javascript-commons": "^2.1.0-beta.0",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"
       }
@@ -25905,7 +25905,7 @@
         "lodash.get": "^4.4.2",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
-        "qaseio": "^2.0.4-beta.1",
+        "qaseio": "^2.1.0-beta.0",
         "strip-ansi": "^6.0.1",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"
@@ -28402,7 +28402,7 @@
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
         "jest": "^29.5.0",
-        "qase-javascript-commons": "^2.0.0-beta.1",
+        "qase-javascript-commons": "^2.1.0-beta.0",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qase-javascript",
   "private": true,
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "This is a monorepo for all JavaScript-related projects",
   "repository": {
     "type": "git",

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/messages": "^22.0.0",
-    "qase-javascript-commons": "^2.0.0-beta.1"
+    "qase-javascript-commons": "^2.0.0-beta.2"
   },
   "peerDependencies": {
     "@cucumber/cucumber": ">=7.0.0"

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -44,7 +44,7 @@
   "author": "Nikita Fedorov <nik333r@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.1",
+    "qase-javascript-commons": "^2.0.0-beta.2",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,0 +1,23 @@
+# qase-javascript-commons@2.0.0-beta.2
+
+## Overview
+
+Package `qase-javascript-commons` contains common functions, used by all Qase JavaScript reporters.
+
+This is a beta channel release.
+Don't install this package explicitly.
+Instead, install the test reporter for your framework, for example:
+
+```bash
+npm install playwright-qase-reporter@beta
+```
+
+## What's new
+
+* Set a fallback reporter when the primary reporter can't be used,
+  such as when the `testops` reporter can't authenticate with the Qase API.
+* Rename some environment variables to keep naming consistent between reporters in all languages.
+* Add several environment variables for new config options.
+* Write outputs in JSONP format, which can be used with
+  [Qase Report](https://github.com/qase-tms/qase-report).
+* Logic for handling test with multiple case IDs moved to the commons package.

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
-    "qaseio": "^2.0.4-beta.1",
+    "qaseio": "^2.1.0-beta.0",
     "strip-ansi": "^6.0.1",
     "uuid": "^9.0.0",
     "child-process-ext": "^3.0.2"

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-qase-reporter",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Qase TMS Jest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
-    "qase-javascript-commons": "^2.0.0-beta.1",
+    "qase-javascript-commons": "^2.0.0-beta.2",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-qase",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Qase TMS Newman Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -39,7 +39,7 @@
   "author": "Parviz Khavari <havaripa@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.1",
+    "qase-javascript-commons": "^2.0.0-beta.2",
     "semver": "^7.5.1"
   },
   "devDependencies": {

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,0 +1,41 @@
+# playwright-qase-reporter@2.0.0-beta.2
+
+## Overview
+Qase reporter for the Playwright test framework.
+
+This is a beta channel release.
+To try the new features, install it with:
+
+```bash
+npm install playwright-qase-reporter@beta
+```
+
+To switch back to the stable releases, run:
+
+```bash
+npm install playwright-qase-reporter@latest
+```
+
+## What's new
+### New syntax for annotating tests
+
+This release brings a major syntax change for specifying more test parameters.
+
+Old syntax allowed only test ID and title, and wasn't improving code readability:
+
+```js
+test(qase(42, 'Ultimate Question of Life, The Universe, and Everything'), async ({ page }) => {
+    ...  
+})
+```
+
+New syntax allows for adding information on separate lines, keeping the code readable:
+
+```js
+test('Ultimate Question of Life, The Universe, and Everything', async ({ page }) => {
+    qase.id(42);
+    qase.fields({ severity: high, priority: medium });
+    qase.attach({ paths: '/path/to/file'});
+    ...
+})
+```

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,7 +43,7 @@
   "author": "Aleksei Galagan <alexneo2003@gmail.com> (https://github.com/alexneo2003/)",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.1",
+    "qase-javascript-commons": "^2.0.0-beta.2",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-qase",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Qase TMS TestCafe Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -39,7 +39,7 @@
   "author": "Parviz Khavari <havaripa@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.1",
+    "qase-javascript-commons": "^2.0.0-beta.2",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qaseio/changelog.md
+++ b/qaseio/changelog.md
@@ -1,0 +1,11 @@
+# qaseio@2.1.0-beta.0
+
+## Overview
+
+This is a beta channel release, supporting the v2 series of the Qase JavaScript reporters.
+
+## What's new
+
+* Supporting the latest version of the [Qase API](https://developers.qase.io/reference).
+* Significant updates to the `v2/results` endpoint.
+* New endpoints: `v1/system-fields/` and `v1/configurations/`.

--- a/qaseio/package.json
+++ b/qaseio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qaseio",
-  "version": "2.0.4-beta.1",
+  "version": "2.1.0-beta.0",
   "description": "Qase TMS Javascript Api Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
* qaseio has changed API, and there is qaseio@2.0.4 already released, for v1 reporters, so it's heading towards a 2.1.0 release. It may change to 3.0.0 due to backwards-incompatible changes.
* Other packages didn't have a release in the 2.x.y series yet, so they are all now 2.0.0-beta.2 and heading towards 2.0.0.
* Examples have been updated to use 2.0.0-beta.2 reporters, but haven't been tested yet. It should be done is a separate task.
* Docs were not updated. They will follow the release.

Part of #536

Changelog drafts:

* https://github.com/qase-tms/qase-javascript/blob/release-beta-versions/qaseio/changelog.md
* https://github.com/qase-tms/qase-javascript/blob/release-beta-versions/qase-javascript-commons/changelog.md
* https://github.com/qase-tms/qase-javascript/blob/release-beta-versions/qase-playwright/changelog.md

For reference, the previous release commit is 186a2cf