### PR TITLE
qase-playwright: import from package index, 2.0.0-beta.3

### DIFF
--- a/examples/playwright/package.json
+++ b/examples/playwright/package.json
@@ -2,10 +2,10 @@
   "name": "examples-playwright",
   "private": true,
   "scripts": {
-    "test": "QASE_MODE=testops npx playwright test"
+    "test": "rm -r ./build/qase-report/results && QASE_MODE=testops npx playwright test"
   },
   "devDependencies": {
     "@playwright/test": "^1.34.3",
-    "playwright-qase-reporter": "^2.0.0-beta.2"
+    "playwright-qase-reporter": "^2.0.0-beta.3"
   }
 }

--- a/examples/playwright/test/arith.test.js
+++ b/examples/playwright/test/arith.test.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { qase } from 'playwright-qase-reporter/playwright';
+import { qase } from 'playwright-qase-reporter';
 
 import { add, mul, sub, div } from './arith';
 

--- a/qase-playwright/README.md
+++ b/qase-playwright/README.md
@@ -1,11 +1,11 @@
-> # Qase TMS Playwright reporter
->
-> Publish results simple and easy.
+# Qase TMS Playwright reporter
 
-## How to integrate
+Publish results simple and easy.
+
+## How to install
 
 ```
-npm install playwright-qase-reporter
+npm install playwright-qase-reporter@beta
 ```
 
 ## Example of usage
@@ -17,23 +17,23 @@ But if necessary, you can independently register the ID of already
 existing test cases from TMS before the executing tests. For example:
 
 ```typescript
-import { qase } from 'playwright-qase-reporter/playwright';
+import { qase } from 'playwright-qase-reporter';
 
 describe('Test suite', () => {
-  test(qase([1, 2], 'Several ids'), () => {
+  test('Simple test', () => {
+    qase.id(1);
+    qase.title('Example of simple test')
     expect(true).toBe(true);
   });
 
-  test(qase(3, 'Correct test'), () => {
+  test('Test with annotated fields', () => {
+    qase.id(2);
+    qase.fields({ 'severity': 'high', 'priority': 'medium' })
     expect(true).toBe(true);
   });
-
-  test.skip(qase('4', 'Skipped test'), () => {
+  
+  test(qase(3, 'This syntax is supported, but deprecated'), () => {
     expect(true).toBe(true);
-  });
-
-  test(qase(['5', '6'], 'Failed test'), () => {
-    expect(true).toBe(false);
   });
 });
 ```

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/index.ts
+++ b/qase-playwright/src/index.ts
@@ -2,3 +2,7 @@ export {
   PlaywrightQaseReporter as default,
   type PlaywrightQaseOptionsType,
 } from './reporter';
+
+export {
+  qase
+} from './playwright';


### PR DESCRIPTION
Export the `qase` objet for simpler imports:

```js
import { qase } from 'playwright-qase-reporter';
```

instead of
```js
import { qase } from 'playwright-qase-reporter/playwright';
```

Resolve #538