### PR TITLE
qaseio: add support uploading attachments from a string or buffer

### DIFF
--- a/examples/playwright/package.json
+++ b/examples/playwright/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.34.3",
-    "playwright-qase-reporter": "^2.0.0-beta.4"
+    "playwright-qase-reporter": "^2.0.0-beta.5"
   }
 }

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/messages": "^22.0.0",
-    "qase-javascript-commons": "^2.0.0-beta.3"
+    "qase-javascript-commons": "^2.0.0-beta.4"
   },
   "peerDependencies": {
     "@cucumber/cucumber": ">=7.0.0"

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -44,7 +44,7 @@
   "author": "Nikita Fedorov <nik333r@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.3",
+    "qase-javascript-commons": "^2.0.0-beta.4",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -76,7 +76,7 @@ export class CypressQaseReporter extends reporters.Base {
           )
         ) {
           attachments.push({
-            content: undefined,
+            content: '',
             id: uuidv4(),
             mime_type: '', size: 0,
             file_name: path.basename(filePath),

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.0.0-beta.4
+
+## What's new
+
+* Added support for uploading attachments from strings and buffers in the testops reporter.
+* Changed data type of `content` in the attachment data from `any` to `string | Buffer`.
+
 # qase-javascript-commons@2.0.0-beta.3
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
-    "qaseio": "^2.1.0-beta.0",
+    "qaseio": "^2.1.0-beta.1",
     "strip-ansi": "^6.0.1",
     "uuid": "^9.0.0",
     "child-process-ext": "^3.0.2"

--- a/qase-javascript-commons/src/models/attachment.ts
+++ b/qase-javascript-commons/src/models/attachment.ts
@@ -2,7 +2,7 @@ export type Attachment = {
   file_name: string;
   mime_type: string;
   file_path: string | null;
-  content: any;
+  content: string | Buffer;
   size: number;
   id: string;
 }

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -329,9 +329,13 @@ export class TestOpsReporter extends AbstractReporter {
       try {
         let data: unknown;
         if (attachment.file_path) {
-          data = createReadStream(attachment.file_path);
+          data = { name: attachment.file_name, value: createReadStream(attachment.file_path) };
         } else {
-          data = attachment.content;
+          if (typeof attachment.content === 'string') {
+            data = { name: attachment.file_name, value: Buffer.from(attachment.content) };
+          } else {
+            data = { name: attachment.file_name, value: attachment.content };
+          }
         }
 
         const response = await this.api.attachments.uploadAttachment(

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
-    "qase-javascript-commons": "^2.0.0-beta.3",
+    "qase-javascript-commons": "^2.0.0-beta.4",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -39,7 +39,7 @@
   "author": "Parviz Khavari <havaripa@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.3",
+    "qase-javascript-commons": "^2.0.0-beta.4",
     "semver": "^7.5.1"
   },
   "devDependencies": {

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,9 @@
+# playwright-qase-reporter@2.0.0-beta.5
+
+## What's new
+
+Added support for the version of qase-javascript-commons@2.0.0-beta.4.
+
 # playwright-qase-reporter@2.0.0-beta.4
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,7 +43,7 @@
   "author": "Aleksei Galagan <alexneo2003@gmail.com> (https://github.com/alexneo2003/)",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.3",
+    "qase-javascript-commons": "^2.0.0-beta.4",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -112,7 +112,8 @@ export class PlaywrightQaseReporter implements Reporter {
         continue;
       }
 
-      if (attachment.name.match(stepAttachRegexp)) {
+      const matches = attachment.name.match(stepAttachRegexp);
+      if (matches) {
         const step = [...this.stepCache.keys()].find((step: TestStep) => step.title === attachment.name);
 
         if (step) {
@@ -120,8 +121,8 @@ export class PlaywrightQaseReporter implements Reporter {
         }
 
         const attachmentModel: Attachment = {
-          content: attachment.body,
-          file_name: attachment.name,
+          content: attachment.body == undefined ? '' : attachment.body,
+          file_name: decodeURIComponent(attachment.name.substring(matches[0].length)),
           file_path: attachment.path == undefined ? null : attachment.path,
           mime_type: attachment.contentType,
           size: 0,

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -39,7 +39,7 @@
   "author": "Parviz Khavari <havaripa@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.3",
+    "qase-javascript-commons": "^2.0.0-beta.4",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -135,7 +135,7 @@ export class TestcafeQaseReporter {
         file_name: screenshot.screenshotPath,
         file_path: screenshot.screenshotPath,
         mime_type: '',
-        content: undefined,
+        content: '',
         size: 0,
         id: uuidv4(),
       });

--- a/qaseio/changelog.md
+++ b/qaseio/changelog.md
@@ -1,3 +1,9 @@
+# qaseio@2.1.0-beta.1
+
+## What's new
+
+* Added support for uploading attachments from strings and buffers. 
+
 # qaseio@2.1.0-beta.0
 
 ## Overview

--- a/qaseio/package.json
+++ b/qaseio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qaseio",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-beta.1",
   "description": "Qase TMS Javascript Api Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qaseio/src/generated/api/attachments-api.ts
+++ b/qaseio/src/generated/api/attachments-api.ts
@@ -179,13 +179,15 @@ export const AttachmentsApiAxiosParamCreator = function (configuration?: Configu
             // authentication TokenAuth required
             await setApiKeyToObject(localVarHeaderParameter, "Token", configuration)
 
-            if (file) {
-                file.forEach((element) => {
-                    localVarFormParams.append('file', element as any);
-                })
-            }
-
-
+      if (file) {
+        file.forEach((element) => {
+          if (element?.name !== undefined && element?.value !== undefined) {
+            localVarFormParams.append('file', element.value, element.name);
+          } else {
+            localVarFormParams.append('file', element as any);
+          }
+        });
+      }
 
             localVarHeaderParameter['Content-Type'] = 'multipart/form-data; boundary=' + localVarFormParams.getBoundary();
 


### PR DESCRIPTION
qaseio: add support uploading attachments from a string or buffer
--
Add support uploading attachments from a string or buffer. In the previous version it was possible to upload only if ReadStream was used.

---

qase-javascript-commons: Updated the process of working with attachments
--
Updated the attachment model: the content should be string or buffer.
Changed an object what describes a type of attachment and sends to qaseio.

---

qase-playwright: corrected file names for attachments
--
File names will look correct. Removed technical information from the title.
Before update: step_attach_6472eb92e81220adff0cebd05ec7beff6e160b47_ attachment.txt
After update: attachment.txt

---

release: commons 2.0.0-beta.4, playwright 2.0.0-beta.5
--
* Bump version of qase-javascript-commons to 2.0.0-beta.4
* Update dependency version in all reporters
* Bump version of playwright-qase-reporter to 2.0.0-beta.5