### PR TITLE
qase-javascript-commons: Update the reporter for attaching stdout and stderr as attachments 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qase-javascript",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qase-javascript",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "workspaces": [
         "qaseio",
@@ -40,7 +40,7 @@
       "name": "examples-cucumberjs",
       "devDependencies": {
         "@cucumber/cucumber": "^7.3.2",
-        "cucumberjs-qase-reporter": "^2.0.0-beta.1",
+        "cucumberjs-qase-reporter": "^2.0.0-beta.2",
         "zombie": "^6.1.4"
       }
     },
@@ -50,7 +50,7 @@
         "cypress": "^12.13.0",
         "cypress-mochawesome-reporter": "^3.5.0",
         "cypress-multi-reporters": "^1.6.3",
-        "cypress-qase-reporter": "^2.0.0-beta.1",
+        "cypress-qase-reporter": "^2.0.0-beta.2",
         "eslint-plugin-cypress": "^2.13.3"
       }
     },
@@ -140,21 +140,21 @@
         "@jest/globals": "^29.5.0",
         "babel-jest": "^29.5.0",
         "jest": "^29.5.0",
-        "jest-qase-reporter": "^2.0.0-beta.1"
+        "jest-qase-reporter": "^2.0.0-beta.2"
       }
     },
     "examples/newman": {
       "name": "examples-newman",
       "devDependencies": {
         "newman": "^5.3.2",
-        "newman-reporter-qase": "^2.0.0-beta.1"
+        "newman-reporter-qase": "^2.0.0-beta.2"
       }
     },
     "examples/playwright": {
       "name": "examples-playwright",
       "devDependencies": {
         "@playwright/test": "^1.34.3",
-        "playwright-qase-reporter": "^2.0.0-beta.1"
+        "playwright-qase-reporter": "^2.0.0-beta.5"
       }
     },
     "examples/testcafe": {
@@ -162,7 +162,7 @@
       "devDependencies": {
         "eslint-plugin-testcafe": "^0.2.1",
         "testcafe": "^2.6.0",
-        "testcafe-reporter-qase": "^2.0.0-beta.1"
+        "testcafe-reporter-qase": "^2.0.0-beta.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3483,6 +3483,12 @@
       "dependencies": {
         "@types/lodash": "*"
       }
+    },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -14428,6 +14434,12 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/uni-global": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
@@ -15362,11 +15374,11 @@
     },
     "qase-cucumberjs": {
       "name": "cucumberjs-qase-reporter",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/messages": "^22.0.0",
-        "qase-javascript-commons": "^2.1.0-beta.0"
+        "qase-javascript-commons": "^2.0.0-beta.4"
       },
       "devDependencies": {
         "@jest/globals": "^29.5.0",
@@ -15383,10 +15395,10 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.1.0-beta.0",
+        "qase-javascript-commons": "^2.0.0-beta.4",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -15440,7 +15452,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.1.0-beta.0",
+      "version": "2.0.0-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -15451,7 +15463,8 @@
         "lodash.get": "^4.4.2",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
-        "qaseio": "^2.1.0-beta.0",
+        "mime-types": "^2.1.33",
+        "qaseio": "^2.1.0-beta.1",
         "strip-ansi": "^6.0.1",
         "uuid": "^9.0.0"
       },
@@ -15461,6 +15474,8 @@
         "@types/lodash.get": "^4.4.7",
         "@types/lodash.merge": "^4.6.7",
         "@types/lodash.mergewith": "^4.6.7",
+        "@types/mime-types": "^2.1.4",
+        "@types/node": "^20.12.5",
         "@types/uuid": "^9.0.1",
         "axios": "^0.21.4",
         "jest": "^29.5.0",
@@ -15468,6 +15483,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "qase-javascript-commons/node_modules/@types/node": {
+      "version": "20.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.5.tgz",
+      "integrity": "sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "qase-javascript-commons/node_modules/ajv": {
@@ -15492,12 +15516,12 @@
     },
     "qase-jest": {
       "name": "jest-qase-reporter",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "qase-javascript-commons": "^2.1.0-beta.0",
+        "qase-javascript-commons": "^2.0.0-beta.4",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -15519,10 +15543,10 @@
     },
     "qase-newman": {
       "name": "newman-reporter-qase",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.1.0-beta.0",
+        "qase-javascript-commons": "^2.0.0-beta.4",
         "semver": "^7.5.1"
       },
       "devDependencies": {
@@ -15543,10 +15567,10 @@
     },
     "qase-playwright": {
       "name": "playwright-qase-reporter",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.1.0-beta.0",
+        "qase-javascript-commons": "^2.0.0-beta.4",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -15564,10 +15588,10 @@
     },
     "qase-testcafe": {
       "name": "testcafe-reporter-qase",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.1.0-beta.0",
+        "qase-javascript-commons": "^2.0.0-beta.4",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -15584,7 +15608,7 @@
       }
     },
     "qaseio": {
-      "version": "2.1.0-beta.0",
+      "version": "2.1.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.21.4",
@@ -19254,6 +19278,12 @@
         "@types/lodash": "*"
       }
     },
+    "@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
@@ -20582,7 +20612,7 @@
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
         "jest": "^29.5.0",
-        "qase-javascript-commons": "^2.1.0-beta.0",
+        "qase-javascript-commons": "^2.0.0-beta.4",
         "ts-jest": "^29.1.0"
       }
     },
@@ -20741,7 +20771,7 @@
         "ajv": "^8.12.0",
         "jest": "^29.5.0",
         "mocha": "^10.2.0",
-        "qase-javascript-commons": "^2.1.0-beta.0",
+        "qase-javascript-commons": "^2.0.0-beta.4",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.1"
       },
@@ -21603,7 +21633,7 @@
       "version": "file:examples/cucumberjs",
       "requires": {
         "@cucumber/cucumber": "^7.3.2",
-        "cucumberjs-qase-reporter": "^2.0.0-beta.1",
+        "cucumberjs-qase-reporter": "^2.0.0-beta.2",
         "zombie": "^6.1.4"
       }
     },
@@ -21613,7 +21643,7 @@
         "cypress": "^12.13.0",
         "cypress-mochawesome-reporter": "^3.5.0",
         "cypress-multi-reporters": "^1.6.3",
-        "cypress-qase-reporter": "^2.0.0-beta.1",
+        "cypress-qase-reporter": "^2.0.0-beta.2",
         "eslint-plugin-cypress": "^2.13.3"
       },
       "dependencies": {
@@ -21692,21 +21722,21 @@
         "@jest/globals": "^29.5.0",
         "babel-jest": "^29.5.0",
         "jest": "^29.5.0",
-        "jest-qase-reporter": "^2.0.0-beta.1"
+        "jest-qase-reporter": "^2.0.0-beta.2"
       }
     },
     "examples-newman": {
       "version": "file:examples/newman",
       "requires": {
         "newman": "^5.3.2",
-        "newman-reporter-qase": "^2.0.0-beta.1"
+        "newman-reporter-qase": "^2.0.0-beta.2"
       }
     },
     "examples-playwright": {
       "version": "file:examples/playwright",
       "requires": {
         "@playwright/test": "^1.34.3",
-        "playwright-qase-reporter": "^2.0.0-beta.1"
+        "playwright-qase-reporter": "^2.0.0-beta.5"
       }
     },
     "examples-testcafe": {
@@ -21714,7 +21744,7 @@
       "requires": {
         "eslint-plugin-testcafe": "^0.2.1",
         "testcafe": "^2.6.0",
-        "testcafe-reporter-qase": "^2.0.0-beta.1"
+        "testcafe-reporter-qase": "^2.0.0-beta.2"
       }
     },
     "execa": {
@@ -23796,7 +23826,7 @@
         "jest": "^29.5.0",
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "qase-javascript-commons": "^2.1.0-beta.0",
+        "qase-javascript-commons": "^2.0.0-beta.4",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"
       }
@@ -25046,7 +25076,7 @@
         "@types/postman-collection": "^3.5.7",
         "jest": "^29.5.0",
         "postman-collection": "^4.1.7",
-        "qase-javascript-commons": "^2.1.0-beta.0",
+        "qase-javascript-commons": "^2.0.0-beta.4",
         "semver": "^7.5.1",
         "ts-jest": "^29.1.0"
       }
@@ -25486,7 +25516,7 @@
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
         "jest": "^29.5.0",
-        "qase-javascript-commons": "^2.1.0-beta.0",
+        "qase-javascript-commons": "^2.0.0-beta.4",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"
       }
@@ -25894,6 +25924,8 @@
         "@types/lodash.get": "^4.4.7",
         "@types/lodash.merge": "^4.6.7",
         "@types/lodash.mergewith": "^4.6.7",
+        "@types/mime-types": "^2.1.4",
+        "@types/node": "^20.12.5",
         "@types/uuid": "^9.0.1",
         "ajv": "^8.12.0",
         "axios": "^0.21.4",
@@ -25905,12 +25937,22 @@
         "lodash.get": "^4.4.2",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
-        "qaseio": "^2.1.0-beta.0",
+        "mime-types": "^2.1.33",
+        "qaseio": "^2.1.0-beta.1",
         "strip-ansi": "^6.0.1",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "20.12.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.5.tgz",
+          "integrity": "sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "ajv": {
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -28402,7 +28444,7 @@
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
         "jest": "^29.5.0",
-        "qase-javascript-commons": "^2.1.0-beta.0",
+        "qase-javascript-commons": "^2.0.0-beta.4",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"
       }
@@ -28734,6 +28776,12 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "uni-global": {
       "version": "1.0.0",

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/messages": "^22.0.0",
-    "qase-javascript-commons": "^2.0.0-beta.4"
+    "qase-javascript-commons": "^2.0.0-beta.5"
   },
   "peerDependencies": {
     "@cucumber/cucumber": ">=7.0.0"

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -44,7 +44,7 @@
   "author": "Nikita Fedorov <nik333r@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.4",
+    "qase-javascript-commons": "^2.0.0-beta.5",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.0.0-beta.5
+
+## What's new
+
+* Update the config of reporters. Added `framework.captureLogs` field. If it is set to `true`, the reporter will capture logs from the test framework.
+* Added `getMimeType` function to the commons package. It returns the MIME type of the file by its extension.
+
 # qase-javascript-commons@2.0.0-beta.4
 
 ## What's new

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -2,7 +2,7 @@
 
 ## What's new
 
-* Update the config of reporters. Added `framework.captureLogs` field. If it is set to `true`, the reporter will capture logs from the test framework.
+* Update the config of reporters. Added `captureLogs` field. If it is set to `true`, the reporter will capture logs from the test framework.
 * Added `getMimeType` function to the commons package. It returns the MIME type of the file by its extension.
 
 # qase-javascript-commons@2.0.0-beta.4

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -26,15 +26,16 @@
   "dependencies": {
     "ajv": "^8.12.0",
     "chalk": "^4.1.2",
+    "child-process-ext": "^3.0.2",
     "env-schema": "^5.2.0",
     "form-data": "^4.0.0",
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
+    "mime-types": "^2.1.33",
     "qaseio": "^2.1.0-beta.1",
     "strip-ansi": "^6.0.1",
-    "uuid": "^9.0.0",
-    "child-process-ext": "^3.0.2"
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
@@ -42,6 +43,8 @@
     "@types/lodash.get": "^4.4.7",
     "@types/lodash.merge": "^4.6.7",
     "@types/lodash.mergewith": "^4.6.7",
+    "@types/mime-types": "^2.1.4",
+    "@types/node": "^20.12.5",
     "@types/uuid": "^9.0.1",
     "axios": "^0.21.4",
     "jest": "^29.5.0",

--- a/qase-javascript-commons/src/config/config-validation-schema.ts
+++ b/qase-javascript-commons/src/config/config-validation-schema.ts
@@ -29,6 +29,10 @@ export const configValidationSchema: JSONSchemaType<ConfigType> = {
       type: ['string', 'number'],
       nullable: true,
     },
+    captureLogs: {
+      type: 'boolean',
+      nullable: true,
+    },
 
     testops: {
       type: 'object',

--- a/qase-javascript-commons/src/env/env-enum.ts
+++ b/qase-javascript-commons/src/env/env-enum.ts
@@ -6,6 +6,7 @@ export enum EnvEnum {
   fallback = 'QASE_FALLBACK',
   debug = 'QASE_DEBUG',
   environment = 'QASE_ENVIRONMENT',
+  captureLogs = 'QASE_CAPTURE_LOGS',
 }
 
 /**

--- a/qase-javascript-commons/src/env/env-to-config.ts
+++ b/qase-javascript-commons/src/env/env-to-config.ts
@@ -19,6 +19,7 @@ export const envToConfig = (env: EnvType): ConfigType => ({
   mode: env[EnvEnum.mode],
   debug: env[EnvEnum.debug],
   environment: env[EnvEnum.environment],
+  captureLogs: env[EnvEnum.captureLogs],
 
   testops: {
     project: env[EnvTestOpsEnum.project],

--- a/qase-javascript-commons/src/env/env-type.ts
+++ b/qase-javascript-commons/src/env/env-type.ts
@@ -15,6 +15,7 @@ export type EnvType = {
   [EnvEnum.fallback]?: `${ModeEnum}`;
   [EnvEnum.debug]?: boolean;
   [EnvEnum.environment]?: string | number;
+  [EnvEnum.captureLogs]?: boolean;
 
   [EnvTestOpsEnum.project]?: string;
   [EnvTestOpsEnum.uploadAttachments]?: boolean;

--- a/qase-javascript-commons/src/env/env-validation-schema.ts
+++ b/qase-javascript-commons/src/env/env-validation-schema.ts
@@ -38,6 +38,10 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
       type: ['string', 'number'],
       nullable: true,
     },
+    [EnvEnum.captureLogs]: {
+      type: 'boolean',
+      nullable: true,
+    },
 
     [EnvTestOpsEnum.project]: {
       type: 'string',

--- a/qase-javascript-commons/src/index.ts
+++ b/qase-javascript-commons/src/index.ts
@@ -8,3 +8,4 @@ export * from './reporters';
 export * from './writer';
 
 export * from './utils/get-package-version';
+export * from './utils/mimeTypes';

--- a/qase-javascript-commons/src/models/test-result.ts
+++ b/qase-javascript-commons/src/models/test-result.ts
@@ -2,21 +2,6 @@ import { TestStepType } from './test-step';
 import { Attachment } from './attachment';
 import { TestExecution } from './test-execution';
 
-
-// export type TestResultType = {
-//   id: string;
-//   testOpsId: number[];
-//   title: string;
-//   status: `${TestStatusEnum}`;
-//   suiteTitle?: string | string[] | undefined;
-//   error?: Error | undefined;
-//   startTime?: number | undefined;
-//   duration?: number | undefined;
-//   endTime?: number | undefined;
-//   steps?: TestStepType[] | undefined;
-//   attachments?: string[] | undefined;
-// };
-
 export type TestResultType = {
   id: string
   title: string

--- a/qase-javascript-commons/src/options/options-type.ts
+++ b/qase-javascript-commons/src/options/options-type.ts
@@ -28,6 +28,7 @@ export type OptionsType = {
   reporterName: string;
   mode?: `${ModeEnum}` | undefined;
   fallback?: `${ModeEnum}` | undefined;
+  captureLogs?: boolean | undefined;
   debug?: boolean | undefined;
   environment?: string | number | undefined;
   testops?:

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -121,7 +121,7 @@ export class QaseReporter extends AbstractReporter {
     const env = envToConfig(envSchema({ schema: envValidationSchema }));
     const composedOptions = composeOptions(options, env);
 
-    super({ debug: composedOptions.debug }, logger);
+    super({ debug: composedOptions.debug, captureLogs: composedOptions.captureLogs }, logger);
 
     try {
       this.upstreamReporter = this.createReporter(
@@ -331,7 +331,8 @@ export class QaseReporter extends AbstractReporter {
             },
             plan,
             chunk,
-            ...commonOptions,
+            debug: commonOptions.debug,
+            captureLogs: commonOptions.captureLogs,
           },
           apiClient,
           logger,
@@ -343,7 +344,10 @@ export class QaseReporter extends AbstractReporter {
         const localOptions = report.connections?.[DriverEnum.local];
         const writer = new FsWriter(localOptions);
 
-        return new ReportReporter(commonOptions, writer, logger,
+        return new ReportReporter({
+            debug: commonOptions.debug,
+            captureLogs: commonOptions.captureLogs,
+          }, writer, logger,
           typeof environment === 'number' ? environment.toString() : environment, testops.run?.id);
       }
 

--- a/qase-javascript-commons/src/reporters/abstract-reporter.ts
+++ b/qase-javascript-commons/src/reporters/abstract-reporter.ts
@@ -7,19 +7,27 @@ import { v4 as uuidv4 } from 'uuid';
 
 export interface LoggerInterface {
   log(message: string): void;
+
   group(): void;
+
   groupEnd(): void;
 }
 
 export interface ReporterOptionsType {
   debug?: boolean | undefined;
+  captureLogs?: boolean | undefined;
 }
 
 export interface ReporterInterface {
   addTestResult(result: TestResultType): void;
+
   publish(): Promise<void>;
+
   getTestResults(): TestResultType[];
+
   setTestResults(results: TestResultType[]): void;
+
+  isCaptureLogs(): boolean;
 }
 
 /**
@@ -34,6 +42,16 @@ export abstract class AbstractReporter implements ReporterInterface {
    */
   private readonly debug: boolean | undefined;
 
+  /**
+   * @type {boolean | undefined}
+   * @private
+   */
+  private readonly captureLogs: boolean | undefined;
+
+  /**
+   * @type {TestResultType[]}
+   * @protected
+   */
   protected results: TestResultType[] = [];
 
   /**
@@ -50,9 +68,10 @@ export abstract class AbstractReporter implements ReporterInterface {
     options: ReporterOptionsType | undefined,
     private logger: LoggerInterface = console,
   ) {
-    const { debug } = options ?? {};
+    const { debug, captureLogs } = options ?? {};
 
     this.debug = debug;
+    this.captureLogs = captureLogs;
   }
 
   /**
@@ -60,6 +79,13 @@ export abstract class AbstractReporter implements ReporterInterface {
    */
   public getTestResults(): TestResultType[] {
     return this.results;
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  public isCaptureLogs(): boolean {
+    return this.captureLogs ?? false;
   }
 
   /**

--- a/qase-javascript-commons/src/utils/mimeTypes.ts
+++ b/qase-javascript-commons/src/utils/mimeTypes.ts
@@ -1,0 +1,15 @@
+import * as path from 'path';
+import * as mime from 'mime-types';
+
+/**
+ * Get mime type of the file
+ * @param {string} filePath
+ */
+export function getMimeTypes(filePath: string): string {
+  const fileName: string = path.basename(filePath);
+  const mimeType: string | false = mime.contentType(fileName);
+  if (!mimeType && typeof mimeType !== 'string') {
+    return 'application/octet-stream';
+  }
+  return mimeType;
+}

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
-    "qase-javascript-commons": "^2.0.0-beta.4",
+    "qase-javascript-commons": "^2.0.0-beta.5",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -39,7 +39,7 @@
   "author": "Parviz Khavari <havaripa@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.4",
+    "qase-javascript-commons": "^2.0.0-beta.5",
     "semver": "^7.5.1"
   },
   "devDependencies": {

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,8 +1,38 @@
+# playwright-qase-reporter@2.0.0-beta.6
+
+## What's new
+
+Capture `stdout` and `stderr` logs as attachments.
+To enable this feature, set environment variable `QASE_CAPTURE_LOGS=true` or
+add `captureLogs: true` to the reporter configuration:
+
+```diff
+[
+  'playwright-qase-reporter',
+  {
+    mode: 'testops', 
++   captureLogs: true,
+    ...
+  },
+];
+```
+
 # playwright-qase-reporter@2.0.0-beta.5
 
 ## What's new
 
-Added support for the version of qase-javascript-commons@2.0.0-beta.4.
+Upload test attachments to Qase:
+```js
+test('test', async ({ page }) => {
+  // upload files by path
+  qase.attach({ paths: '/path/to/file'});
+  // list multiple files at once
+  qase.attach({ paths: ['/path/to/file', '/path/to/another/file']});
+  // upload contents directly from your code
+  qase.attach({ name: 'attachment.txt', content: 'Hello, world!', contentType: 'text/plain' });
+  await page.goto('https://example.com');
+});
+```
 
 # playwright-qase-reporter@2.0.0-beta.4
 

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,7 +43,7 @@
   "author": "Aleksei Galagan <alexneo2003@gmail.com> (https://github.com/alexneo2003/)",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.4",
+    "qase-javascript-commons": "^2.0.0-beta.5",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -2,6 +2,7 @@ import test from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 import { PlaywrightQaseReporter } from './reporter';
 import * as path from 'path';
+import { getMimeTypes } from 'qase-javascript-commons';
 
 export const ReporterContentType = 'application/qase.metadata+json';
 const defaultContentType = 'application/octet-stream';
@@ -141,7 +142,7 @@ qase.attach = function(attach: {
 
     for (const file of files) {
       const attachmentName = path.basename(file);
-      const contentType = getContentType(path.extname(file));
+      const contentType: string = getMimeTypes(file);
       addAttachment(attachmentName, contentType, file);
     }
 
@@ -159,28 +160,6 @@ const addMetadata = (metadata: MetadataMessage): void => {
     body: Buffer.from(JSON.stringify(metadata), 'utf8'),
   }).catch(() => {/**/
   });
-};
-
-const getContentType = (extension: string): string => {
-  const types: Record<string, string> = {
-    '.html': 'text/html',
-    '.css': 'text/css',
-    '.js': 'application/javascript',
-    '.json': 'application/json',
-    '.png': 'image/png',
-    '.jpg': 'image/jpeg',
-    '.gif': 'image/gif',
-    '.svg': 'image/svg+xml',
-    '.wav': 'audio/wav',
-    '.mp4': 'video/mp4',
-    '.woff': 'application/font-woff',
-    '.ttf': 'application/font-ttf',
-    '.eot': 'application/vnd.ms-fontobject',
-    '.otf': 'application/font-otf',
-    '.wasm': 'application/wasm',
-  };
-
-  return types[extension] ?? defaultContentType;
 };
 
 const addAttachment = (name: string, contentType: string, filePath?: string, body?: string | Buffer): void => {

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -39,7 +39,7 @@
   "author": "Parviz Khavari <havaripa@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.4",
+    "qase-javascript-commons": "^2.0.0-beta.5",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
qase-javascript-commons: Update the config of reporters.
--
- Update the config of reporters. Added `captureLogs` field. If it is set to `true`, the reporter will capture logs from the test framework.
- Added `getMimeType` function to the commons package. It returns the MIME type of the file by its extension.

---

qase-playwright: add capturing logs
--
Update the reporter for attaching stdout and stderr as attachments .

---

qase-reporters: bump version of qase-javascript-commons
--