### PR TITLE
qase-playwright: Updated a message about deprecated annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15378,7 +15378,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/messages": "^22.0.0",
-        "qase-javascript-commons": "^2.0.0-beta.4"
+        "qase-javascript-commons": "^2.0.0-beta.5"
       },
       "devDependencies": {
         "@jest/globals": "^29.5.0",
@@ -15398,7 +15398,7 @@
       "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.0.0-beta.4",
+        "qase-javascript-commons": "^2.0.0-beta.5",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -15521,7 +15521,7 @@
       "dependencies": {
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "qase-javascript-commons": "^2.0.0-beta.4",
+        "qase-javascript-commons": "^2.0.0-beta.5",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -15546,7 +15546,7 @@
       "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.0.0-beta.4",
+        "qase-javascript-commons": "^2.0.0-beta.5",
         "semver": "^7.5.1"
       },
       "devDependencies": {
@@ -15567,10 +15567,11 @@
     },
     "qase-playwright": {
       "name": "playwright-qase-reporter",
-      "version": "2.0.0-beta.5",
+      "version": "2.0.0-beta.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.0.0-beta.4",
+        "chalk": "^5.3.0",
+        "qase-javascript-commons": "^2.0.0-beta.5",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -15586,12 +15587,23 @@
         "@playwright/test": ">=1.16.3"
       }
     },
+    "qase-playwright/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "qase-testcafe": {
       "name": "testcafe-reporter-qase",
       "version": "2.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.0.0-beta.4",
+        "qase-javascript-commons": "^2.0.0-beta.5",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -20612,7 +20624,7 @@
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
         "jest": "^29.5.0",
-        "qase-javascript-commons": "^2.0.0-beta.4",
+        "qase-javascript-commons": "^2.0.0-beta.5",
         "ts-jest": "^29.1.0"
       }
     },
@@ -20771,7 +20783,7 @@
         "ajv": "^8.12.0",
         "jest": "^29.5.0",
         "mocha": "^10.2.0",
-        "qase-javascript-commons": "^2.0.0-beta.4",
+        "qase-javascript-commons": "^2.0.0-beta.5",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.1"
       },
@@ -23826,7 +23838,7 @@
         "jest": "^29.5.0",
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "qase-javascript-commons": "^2.0.0-beta.4",
+        "qase-javascript-commons": "^2.0.0-beta.5",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"
       }
@@ -25076,7 +25088,7 @@
         "@types/postman-collection": "^3.5.7",
         "jest": "^29.5.0",
         "postman-collection": "^4.1.7",
-        "qase-javascript-commons": "^2.0.0-beta.4",
+        "qase-javascript-commons": "^2.0.0-beta.5",
         "semver": "^7.5.1",
         "ts-jest": "^29.1.0"
       }
@@ -25515,10 +25527,18 @@
       "requires": {
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
+        "chalk": "^5.3.0",
         "jest": "^29.5.0",
-        "qase-javascript-commons": "^2.0.0-beta.4",
+        "qase-javascript-commons": "^2.0.0-beta.5",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
+        }
       }
     },
     "pn": {
@@ -28444,7 +28464,7 @@
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
         "jest": "^29.5.0",
-        "qase-javascript-commons": "^2.0.0-beta.4",
+        "qase-javascript-commons": "^2.0.0-beta.5",
         "ts-jest": "^29.1.0",
         "uuid": "^9.0.0"
       }

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,19 @@
+# playwright-qase-reporter@2.0.0-beta.7
+
+## What's new
+
+Previously, we logged a message about the use of an outdated annotation immediately when running the test. 
+Now we will log the message after all tests are completed. Like this:
+
+```log
+qase: qase(caseId) is deprecated. Use qase.id() and qase.title() inside the test body
+The following tests are using the old annotation:
+at /Users/gda/Documents/github/qase-javascript/examples/playwright/test/arith.test.js:12:8
+at /Users/gda/Documents/github/qase-javascript/examples/playwright/test/arith.test.js:16:7
+at /Users/gda/Documents/github/qase-javascript/examples/playwright/test/arith.test.js:7:7
+
+```
+
 # playwright-qase-reporter@2.0.0-beta.6
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,6 +43,7 @@
   "author": "Aleksei Galagan <alexneo2003@gmail.com> (https://github.com/alexneo2003/)",
   "license": "Apache-2.0",
   "dependencies": {
+    "chalk": "^5.3.0",
     "qase-javascript-commons": "^2.0.0-beta.5",
     "uuid": "^9.0.0"
   },

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -29,8 +29,6 @@ export const qase = (
   caseId: number | string | number[] | string[],
   name: string,
 ): string => {
-  console.log(`qase: qase(${caseId as string}) is deprecated. Use qase.id() and qase.title() inside the test body`);
-
   const caseIds = Array.isArray(caseId) ? caseId : [caseId];
   const ids: number[] = [];
 


### PR DESCRIPTION
qase-playwright: Updated a message about deprecated annotations
--
Previously, we logged a message about the use of an outdated annotation immediately when running the test. Now we will log the message after all tests are completed.