### PR TITLE
qase-javascript-commons: add support v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15058,7 +15058,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.0.0-beta.5",
+      "version": "2.0.0-beta.6",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -15170,11 +15170,11 @@
     },
     "qase-playwright": {
       "name": "playwright-qase-reporter",
-      "version": "2.0.0-beta.7",
+      "version": "2.0.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
-        "qase-javascript-commons": "^2.0.0-beta.5",
+        "qase-javascript-commons": "^2.0.0-beta.6",
         "uuid": "^9.0.0"
       },
       "devDependencies": {

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/messages": "^22.0.0",
-    "qase-javascript-commons": "^2.0.0-beta.5"
+    "qase-javascript-commons": "^2.0.0-beta.6"
   },
   "peerDependencies": {
     "@cucumber/cucumber": ">=7.0.0"

--- a/qase-cucumberjs/src/reporter.ts
+++ b/qase-cucumberjs/src/reporter.ts
@@ -251,7 +251,7 @@ export class CucumberQaseReporter extends Formatter {
           message: null,
           muted: false,
           params: {},
-          relations: [],
+          relations: {},
           run_id: null,
           signature: '',
           steps: [],

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -44,7 +44,7 @@
   "author": "Nikita Fedorov <nik333r@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.5",
+    "qase-javascript-commons": "^2.0.0-beta.6",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -168,7 +168,7 @@ export class CypressQaseReporter extends reporters.Base {
       message: test.err?.message ?? null,
       muted: false,
       params: {},
-      relations: [],
+      relations: {},
       run_id: null,
       signature: '',
       steps: [],

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,18 @@
+# qase-javascript-commons@2.0.0-beta.6
+
+## What's new
+### Support adding test suite description to a test report.
+
+Test reporters can now test suite description to test results.
+Such description can be collected from test's location and attributes
+or explicitly declared in the test.
+
+Add new data models:
+- Relation
+- Suite
+- SuiteData
+
+
 # qase-javascript-commons@2.0.0-beta.5
 
 ## What's new

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,6 +1,30 @@
 # qase-javascript-commons@2.0.0-beta.6
 
 ## What's new
+
+### Select the API version to use for reporting
+
+Qase TestOps API has two endpoints for reporting test results:
+
+- Version 1, stable and used my most test reporters.
+  https://developers.qase.io/reference/create-result-bulk
+- Version 2, currently in beta access, and currently supported only
+  in the `playwright-qase-reporter`.
+  https://developers.qase.io/v2.0/reference/create-results-v2
+
+This commit introduces a way to select the API version to use.
+It enables using all new features of v2 JS reporters with the stable v1 API,
+and elso experimenting with the new v2 API.
+
+**Warning**: v2 API is still in beta. 
+If you want to try the v2 JS reporters, you don't have to enable the new API.
+
+To enable using API v2, set an environment variable before running the tests:
+
+```bash
+QASE_TESTOPS_API_V2=true
+```
+
 ### Support adding test suite description to a test report.
 
 Test reporters can now test suite description to test results.

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/config/config-validation-schema.ts
+++ b/qase-javascript-commons/src/config/config-validation-schema.ts
@@ -132,6 +132,11 @@ export const configValidationSchema: JSONSchemaType<ConfigType> = {
           type: 'boolean',
           nullable: true,
         },
+
+        useV2: {
+          type: 'boolean',
+          nullable: true,
+        },
       },
     },
 

--- a/qase-javascript-commons/src/env/env-enum.ts
+++ b/qase-javascript-commons/src/env/env-enum.ts
@@ -17,6 +17,7 @@ export enum EnvTestOpsEnum {
   uploadAttachments = 'QASE_TESTOPS_UPLOAD_ATTACHMENTS',
   chunk = 'QASE_TESTOPS_CHUNK',
   defect = 'QASE_TESTOPS_DEFECT',
+  useV2 = 'QASE_TESTOPS_API_V2',
 }
 
 /**

--- a/qase-javascript-commons/src/env/env-to-config.ts
+++ b/qase-javascript-commons/src/env/env-to-config.ts
@@ -43,6 +43,7 @@ export const envToConfig = (env: EnvType): ConfigType => ({
 
     chunk: env[EnvTestOpsEnum.chunk],
     defect: env[EnvTestOpsEnum.defect],
+    useV2: env[EnvTestOpsEnum.useV2],
   },
 
   report: {

--- a/qase-javascript-commons/src/env/env-type.ts
+++ b/qase-javascript-commons/src/env/env-type.ts
@@ -21,6 +21,7 @@ export type EnvType = {
   [EnvTestOpsEnum.uploadAttachments]?: boolean;
   [EnvTestOpsEnum.chunk]?: number;
   [EnvTestOpsEnum.defect]?: boolean;
+  [EnvTestOpsEnum.useV2]?: boolean;
 
   [EnvApiEnum.token]?: string;
   [EnvApiEnum.baseUrl]?: string;

--- a/qase-javascript-commons/src/env/env-validation-schema.ts
+++ b/qase-javascript-commons/src/env/env-validation-schema.ts
@@ -59,6 +59,10 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
       type: 'boolean',
       nullable: true,
     },
+    [EnvTestOpsEnum.useV2]: {
+      type: 'boolean',
+      nullable: true,
+    },
 
     [EnvApiEnum.token]: {
       type: 'string',

--- a/qase-javascript-commons/src/models/index.ts
+++ b/qase-javascript-commons/src/models/index.ts
@@ -1,4 +1,4 @@
-export { type TestResultType } from './test-result';
+export { type TestResultType, Relation, Suite, SuiteData } from './test-result';
 export { TestExecution, TestStatusEnum } from './test-execution';
 export { type TestStepType } from './test-step';
 export { StepStatusEnum } from './step-execution';

--- a/qase-javascript-commons/src/models/test-result.ts
+++ b/qase-javascript-commons/src/models/test-result.ts
@@ -14,8 +14,20 @@ export type TestResultType = {
   steps: TestStepType[]
   params: Record<string, string>
   author: string | null
-  relations: any[]
+  relations: Relation | null
   muted: boolean
   message: string | null
 }
 
+export type Relation = {
+  suite?: Suite
+}
+
+export type Suite = {
+  data: SuiteData[]
+}
+
+export type SuiteData = {
+  title: string
+  public_id: number | null
+}

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -47,6 +47,7 @@ export type TestOpsOptionsType = {
   plan: TestOpsPlanType;
   chunk?: number | undefined;
   defect?: boolean | undefined;
+  useV2?: boolean | undefined;
 };
 
 /**
@@ -107,6 +108,12 @@ export class TestOpsReporter extends AbstractReporter {
   private readonly chunk: number;
 
   /**
+   * @type {boolean | undefined}
+   * @private
+   */
+  private readonly useV2: boolean;
+
+  /**
    * @param {ReporterOptionsType & TestOpsOptionsType} options
    * @param {QaseApiInterface} api
    * @param {LoggerInterface} logger
@@ -136,6 +143,7 @@ export class TestOpsReporter extends AbstractReporter {
     this.run = { complete: true, ...run };
     this.environment = environment;
     this.chunk = options.chunk ?? defaultChunkSize;
+    this.useV2 = options.useV2 ?? false;
   }
 
   /**
@@ -168,6 +176,10 @@ export class TestOpsReporter extends AbstractReporter {
       );
 
       return;
+    }
+
+    if (this.useV2){
+      //
     }
 
     const results: ResultCreateV2[] = [];

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -6,6 +6,7 @@ import {
   QaseApiInterface,
   ResultCreateV2,
   ResultExecution,
+  ResultRelations,
   ResultStep,
   ResultStepStatus,
   RunCreate,
@@ -13,7 +14,16 @@ import {
 
 import { AbstractReporter, LoggerInterface, ReporterOptionsType } from './abstract-reporter';
 
-import { StepStatusEnum, TestResultType, TestStatusEnum, TestStepType, Attachment, TestExecution } from '../models';
+import {
+  StepStatusEnum,
+  TestResultType,
+  TestStatusEnum,
+  TestStepType,
+  Attachment,
+  TestExecution,
+  Relation,
+  SuiteData,
+} from '../models';
 
 import { QaseError } from '../utils/qase-error';
 
@@ -207,11 +217,7 @@ export class TestOpsReporter extends AbstractReporter {
       attachments: attachments,
       steps: steps,
       params: result.params,
-      relations: {
-        // suite: {
-        //   data: result.suiteTitle ? this.getSuites(result.suiteTitle) : [],
-        // },
-      },
+      relations: this.getRelation(result.relations),
       message: result.message,
     };
   }
@@ -229,6 +235,31 @@ export class TestOpsReporter extends AbstractReporter {
       duration: exec.duration,
       stacktrace: exec.stacktrace,
       thread: exec.thread,
+    };
+  }
+
+  /**
+   * @param {Relation | null} relation
+   * @returns {ResultRelations}
+   * @private
+   */
+  private getRelation(relation: Relation | null): ResultRelations {
+    if (!relation || !relation.suite) {
+      return {};
+    }
+
+    const suiteData: SuiteData[] = [];
+    for (const data of relation.suite.data) {
+      suiteData.push({
+        public_id: null,
+        title: data.title,
+      });
+    }
+
+    return {
+      suite: {
+        data: suiteData,
+      },
     };
   }
 

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
-    "qase-javascript-commons": "^2.0.0-beta.5",
+    "qase-javascript-commons": "^2.0.0-beta.6",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/qase-jest/src/reporter.ts
+++ b/qase-jest/src/reporter.ts
@@ -126,7 +126,7 @@ export class JestQaseReporter implements Reporter {
           message: error?.message ?? null,
           muted: false,
           params: {},
-          relations: [],
+          relations: {},
           run_id: null,
           signature: '',
           steps: [],

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -39,7 +39,7 @@
   "author": "Parviz Khavari <havaripa@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.5",
+    "qase-javascript-commons": "^2.0.0-beta.6",
     "semver": "^7.5.1"
   },
   "devDependencies": {

--- a/qase-newman/src/reporter.ts
+++ b/qase-newman/src/reporter.ts
@@ -140,7 +140,7 @@ export class NewmanQaseReporter {
           message: null,
           muted: false,
           params: {},
-          relations: [],
+          relations: {},
           run_id: null,
           signature: '',
           steps: [],

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,8 +1,25 @@
+# playwright-qase-reporter@2.0.0-beta.9
+
+## What's new
+
+### Collect test suite information
+
+Collect the following information as the test's suite:
+
+- path to the file which contains the test;
+- value of the `test.describe()` declaration, if it exists.
+
+The resulting test suite will be added to the test metadata.
+If Qase workspace is configured to update test cases from reported
+tests results, the newly created cases will be structured by their
+suites, derived from file path and `test.describe()`.
+
+
 # playwright-qase-reporter@2.0.0-beta.8
 
 ## What's new
 
-Fix problem with dependencies.
+Fix the problem with dependencies, introduced in `2.0.0-beta.7`
 
 
 # playwright-qase-reporter@2.0.0-beta.7

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.2",
-    "qase-javascript-commons": "^2.0.0-beta.5",
+    "qase-javascript-commons": "^2.0.0-beta.6",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -286,11 +286,21 @@ export class PlaywrightQaseReporter implements Reporter {
         : null,
       muted: false,
       params: testCaseMetadata.parameters,
-      relations: [],
+      relations: {
+        suite: {
+          data: suites.filter((suite) => {
+            return suite != test.title;
+          }).map((suite) => {
+            return {
+              title: suite,
+              public_id: null,
+            };
+          }),
+        },
+      },
       run_id: null,
       signature: suites.join(':'),
       steps: this.transformSteps(result.steps, null),
-      // suiteTitle: PlaywrightQaseReporter.transformSuiteTitle(test),
       testops_id: null,
       title: testCaseMetadata.title === '' ? test.title : testCaseMetadata.title,
     };

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -39,7 +39,7 @@
   "author": "Parviz Khavari <havaripa@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.5",
+    "qase-javascript-commons": "^2.0.0-beta.6",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -194,7 +194,7 @@ export class TestcafeQaseReporter {
       message: error.message,
       muted: false,
       params: {},
-      relations: [],
+      relations: {},
       run_id: null,
       signature: '',
       steps: [],


### PR DESCRIPTION
qase-javascript-commons: support suites
--
Add new models for support suites:
- Relation
- Suite
- SuiteData

---

qase-playwright: support suites
--
Collect the following information about suites:
- file what contains test
- test describe (if exists)

---

qase-javascript-commons: add new parameter useV2
--
Add new parameter useV2. If the parameter is true, then the testops reporter will use APIv2 methods for sending results.

---

qase-javascript-commons: add support v1
--
Add support APIv1.

---

qase-reporters: bump version of qase-javascript-commons
--