### PR TITLE
qase-javascript-commons: remove old results

### DIFF
--- a/qase-javascript-commons/src/reporters/report-reporter.ts
+++ b/qase-javascript-commons/src/reporters/report-reporter.ts
@@ -47,6 +47,8 @@ export class ReportReporter extends AbstractReporter {
    *
    */
   public async publish(): Promise<void> {
+    this.writer.clearPreviousResults();
+
     const report: Report = {
       title: 'Test report',
       execution: {

--- a/qase-javascript-commons/src/writer/fs-writer.ts
+++ b/qase-javascript-commons/src/writer/fs-writer.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync, copyFileSync } from 'fs';
+import { mkdirSync, writeFileSync, copyFileSync, existsSync, readdirSync, lstatSync, unlinkSync, rmdirSync } from 'fs';
 import * as path from 'path';
 
 import { WriterInterface } from './writer-interface';
@@ -40,6 +40,13 @@ export class FsWriter implements WriterInterface {
     } else {
       this.formatter = new JsonpFormatter();
     }
+  }
+
+  /**
+   * @returns {void}
+   */
+  clearPreviousResults(): void {
+    this.deleteFolderRecursive(this.path);
   }
 
   /**
@@ -108,5 +115,19 @@ export class FsWriter implements WriterInterface {
 
     writeFileSync(filePath, await this.formatter.format(result));
 
+  }
+
+  private deleteFolderRecursive(directoryPath: string) {
+    if (existsSync(directoryPath)) {
+      readdirSync(directoryPath).forEach((file) => {
+        const curPath = path.join(directoryPath, file);
+        if (lstatSync(curPath).isDirectory()) { // recurse
+          this.deleteFolderRecursive(curPath);
+        } else { // delete file
+          unlinkSync(curPath);
+        }
+      });
+      rmdirSync(directoryPath);
+    }
   }
 }

--- a/qase-javascript-commons/src/writer/writer-interface.ts
+++ b/qase-javascript-commons/src/writer/writer-interface.ts
@@ -4,4 +4,5 @@ export interface WriterInterface {
   writeReport(results: Report): Promise<string>;
   writeTestResult(result: TestResultType): Promise<void>;
   writeAttachment(attachments: Attachment[]): Attachment[];
+  clearPreviousResults(): void;
 }


### PR DESCRIPTION
qase-javascript-commons: remove old results
--
- Updated the writer interface.
- Add a method which removes old results for the file reporter