### PR TITLE
qase-javascript-commons: support different step types

### DIFF
--- a/qase-javascript-commons/src/models/index.ts
+++ b/qase-javascript-commons/src/models/index.ts
@@ -1,6 +1,6 @@
 export { type TestResultType, Relation, Suite, SuiteData } from './test-result';
 export { TestExecution, TestStatusEnum } from './test-execution';
-export { type TestStepType } from './test-step';
+export { type TestStepType, StepType } from './test-step';
 export { StepStatusEnum } from './step-execution';
 export { Attachment } from './attachment';
 export { Report } from './report';

--- a/qase-javascript-commons/src/models/step-data.ts
+++ b/qase-javascript-commons/src/models/step-data.ts
@@ -1,4 +1,10 @@
-export interface StepData {
+export interface StepTextData {
   action: string;
   expected_result: string | null;
+}
+
+export interface StepGherkinData {
+  keyword: string;
+  name: string;
+  line: number;
 }

--- a/qase-javascript-commons/src/models/test-step.ts
+++ b/qase-javascript-commons/src/models/test-step.ts
@@ -1,26 +1,18 @@
-import { StepData } from './step-data';
+import { StepGherkinData, StepTextData } from './step-data';
 import { StepExecution } from './step-execution';
 
 import { Attachment } from './attachment';
 
 
-
-// export type TestStepType = {
-//   id: string;
-//   title: string;
-//   status: `${StepStatusEnum}`;
-//   duration?: number | undefined;
-//   error?: Error | undefined;
-//   steps?: TestStepType[] | undefined;
-//   attachments?: string[] | undefined;
-// };
-
-
+export enum StepType {
+  TEXT = 'text',
+  GHERKIN = 'gherkin',
+}
 
 export type TestStepType = {
   id: string;
-  step_type: string;
-  data: StepData;
+  step_type: StepType;
+  data: StepTextData | StepGherkinData;
   parent_id: string | null;
   execution: StepExecution;
   attachments: Attachment[];

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -23,6 +23,7 @@ import {
   TestExecution,
   Relation,
   SuiteData,
+  StepType,
 } from '../models';
 
 import { QaseError } from '../utils/qase-error';
@@ -403,13 +404,25 @@ export class TestOpsReporter extends AbstractReporter {
 
       const resultStep: ResultStep = {
         data: {
-          action: step.data.action,
+          action: '',
           attachments: attachmentHashes,
         },
         execution: {
           status: TestOpsReporter.stepStatusMap[step.execution.status],
         },
       };
+
+      if (step.step_type === StepType.TEXT) {
+        if ('action' in step.data && resultStep.data != undefined) {
+          resultStep.data.action = step.data.action;
+        }
+      }
+
+      if (step.step_type === StepType.GHERKIN) {
+        if ('keyword' in step.data && resultStep.data != undefined) {
+          resultStep.data.action = step.data.keyword;
+        }
+      }
 
       if (step.steps.length > 0) {
         resultStep.steps = await this.transformSteps(step.steps);
@@ -434,9 +447,20 @@ export class TestOpsReporter extends AbstractReporter {
 
       const resultStep: TestStepResultCreate = {
         status: TestOpsReporter.stepStatusMapV1[step.execution.status],
-        action: step.data.action,
         attachments: attachmentHashes,
       };
+
+      if (step.step_type === StepType.TEXT) {
+        if ('action' in step.data) {
+          resultStep.action = step.data.action;
+        }
+      }
+
+      if (step.step_type === StepType.GHERKIN) {
+        if ('keyword' in step.data) {
+          resultStep.action = step.data.keyword;
+        }
+      }
 
       if (step.steps.length > 0) {
         resultStep.steps = await this.transformStepsV1(step.steps);

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -3,15 +3,17 @@ import { v4 as uuidv4 } from 'uuid';
 import chalk from 'chalk';
 
 import {
+  Attachment,
   composeOptions,
   ConfigLoader,
   ConfigType,
   QaseReporter,
   ReporterInterface,
   StepStatusEnum,
+  StepType,
+  TestResultType,
   TestStatusEnum,
   TestStepType,
-  Attachment, TestResultType,
 } from 'qase-javascript-commons';
 import { MetadataMessage, ReporterContentType } from './playwright';
 
@@ -197,7 +199,7 @@ export class PlaywrightQaseReporter implements Reporter {
       const id = uuidv4();
       const step: TestStepType = {
         id: id,
-        step_type: 'text',
+        step_type: StepType.TEXT,
         data: {
           action: testStep.title,
           expected_result: null,


### PR DESCRIPTION
qase-javascript-commons: support different step types
--
Add support of different step types:
- StepTextData - use for ordinary steps
- StepGherkinData - use for gherkin steps