### PR TITLE
qase-javascript-commons: fixing a problem with duplicate test runs

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.0.0-beta.9
+
+## What's new
+
+Fixed an issue with duplicate test runs if the testing framework (such as Cypress) uses more than one instance of the Qase reporter.
+The Qase reporter stores the test run ID in the ENV variable `QASE_TESTOPS_RUN_ID` after creating the first test run.
+
 # qase-javascript-commons@2.0.0-beta.8
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -227,6 +227,7 @@ export class TestOpsReporter extends AbstractReporter {
     }
 
     this.run.id = result.id;
+    process.env['QASE_TESTOPS_RUN_ID'] = String(result.id);
     this.isTestRunReady = true;
   }
 


### PR DESCRIPTION
qase-javascript-commons: fixing a problem with duplicate test runs
--
Store the test run ID in the ENV variable `QASE_TESTOPS_RUN_ID` after creating a test run.