### PR TITLE
 qase-javascript-commons: improve debug logging

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -2,8 +2,23 @@
 
 ## What's new
 
-Fixed an issue with duplicate test runs if the testing framework (such as Cypress) uses more than one instance of the Qase reporter.
-The Qase reporter stores the test run ID in the ENV variable `QASE_TESTOPS_RUN_ID` after creating the first test run.
+Improved debug logging for better testing and reporting errors.
+
+-   Separate `logger` class for use in reporters, supporting logging to console and files.
+-   Extra debug logs in both reporter modes: TestOps and Local.
+
+Fixed an issue with duplicate test runs created when the testing framework
+(such as Cypress) uses more than one instance of the Qase reporter.
+Now reporter handles Qase test runs in the following way:
+
+1.  The first instance of the reporter creates a Qase test run and stores the run ID 
+    in the ENV variable `QASE_TESTOPS_RUN_ID`.
+2.  Other instances of the reporter read this variable and report test results 
+    to the existing test run.
+
+Nothing has changed in cases when there is a single instance of a reporter or
+when it is using a test run, created with other tools, such as with an API request
+or manually in the Qase app.
 
 # qase-javascript-commons@2.0.0-beta.8
 

--- a/qase-javascript-commons/src/reporters/report-reporter.ts
+++ b/qase-javascript-commons/src/reporters/report-reporter.ts
@@ -1,4 +1,4 @@
-import { AbstractReporter, LoggerInterface, ReporterOptionsType } from './abstract-reporter';
+import { AbstractReporter, ReporterOptionsType } from './abstract-reporter';
 import { Report, TestStatusEnum, TestStepType } from '../models';
 import { WriterInterface } from '../writer';
 import { HostData } from '../models/host-data';
@@ -18,18 +18,16 @@ export class ReportReporter extends AbstractReporter {
   /**
    * @param {ReporterOptionsType} options
    * @param {WriterInterface} writer
-   * @param {LoggerInterface} logger
    * @param {string | undefined} environment
    * @param {number | undefined} runId
    */
   constructor(
     options: ReporterOptionsType | undefined,
     private writer: WriterInterface,
-    logger?: LoggerInterface,
     environment?: string,
     runId?: number,
   ) {
-    super(options, logger);
+    super(options);
     this.environment = environment;
     this.runId = runId;
   }
@@ -117,7 +115,7 @@ export class ReportReporter extends AbstractReporter {
 
     const path = await this.writer.writeReport(report);
 
-    this.log(`Report saved to ${path}`);
+    this.logger.log(`Report saved to ${path}`)
   }
 
   /**

--- a/qase-javascript-commons/src/utils/logger.ts
+++ b/qase-javascript-commons/src/utils/logger.ts
@@ -1,0 +1,116 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { isAxiosError } from './is-axios-error';
+import { QaseError } from './qase-error';
+import { AxiosError } from 'axios';
+import get from 'lodash.get';
+
+export class Logger {
+  private readonly debug: boolean | undefined;
+  private readonly filePath: string;
+
+  constructor(options: { debug?: boolean | undefined, dir?: string }) {
+    this.debug = options.debug;
+
+    const dir = options.dir ?? './logs';
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
+
+    this.filePath = path.join(dir, 'log.txt');
+  }
+
+  public log(message: string): void {
+    const logMessage = `[INFO] qase: ${message}`;
+    console.log(logMessage);
+    if (this.debug) {
+      this.logToFile(logMessage);
+    }
+  }
+
+  public logError(message: string, error?: unknown): void {
+    const logMessage = `[ERROR] qase: ${this.doLogError(message, error)}`;
+    console.error(logMessage);
+    if (this.debug) {
+      this.logToFile(logMessage);
+    }
+  }
+
+  public logDebug(message: string): void {
+    if (this.debug) {
+      const logMessage = `[DEBUG] qase: ${message}`;
+      console.log(logMessage);
+      this.logToFile(logMessage);
+    }
+  }
+
+  private logToFile(message: string): void {
+    const formattedMessage = `[${new Date().toISOString()}] ${message}\n`;
+    fs.appendFileSync(this.filePath, formattedMessage);
+  }
+
+  private doLogError(message: string, error?: unknown): string {
+    let logMessage: string = message;
+
+    if (error instanceof Error) {
+      if (isAxiosError(error)) {
+        logMessage += this.logApiError(error);
+      } else if (error instanceof QaseError && error.cause) {
+        logMessage += this.doLogError('\n Caused by:', error.cause);
+      }
+
+      logMessage += `\n ${error.stack || `${error.name}: ${error.message}`}`;
+    } else {
+      logMessage += `\n ${String(error)}`;
+    }
+
+    return logMessage;
+  }
+
+  /**
+   * @param {AxiosError} error
+   * @private
+   */
+  private logApiError(error: AxiosError): string {
+    let logMessage = '\n';
+
+    const errorMessage: unknown = get(error, 'response.data.errorMessage')
+      ?? get(error, 'response.data.error')
+      ?? get(error, 'response.statusText')
+      ?? 'Unknown error';
+
+    const errorFields = this.formatErrorFields(
+      get(error, 'response.data.errorFields'),
+    );
+
+    logMessage += `Message: ${String(errorMessage)}`;
+
+    if (errorFields) {
+      logMessage += `\n ${errorFields}`;
+    }
+
+    return logMessage;
+  }
+
+  /**
+   * @param errorFields
+   * @returns {string | undefined}
+   * @private
+   */
+  private formatErrorFields(errorFields: unknown): string | undefined {
+    if (Array.isArray(errorFields)) {
+      return errorFields.reduce<string>((acc, item: unknown) => {
+        const field: unknown = get(item, 'field');
+        const error: unknown = get(item, 'error');
+
+        if (field && error) {
+          return acc + `${String(field)}: ${String(error)}\n`;
+        }
+
+        return acc;
+      }, '');
+    }
+
+    return undefined;
+  }
+}


### PR DESCRIPTION
Improved debug logging for better testing and reporting errors.

-   Separate `logger` class for use in reporters, supporting logging to console and files.
-   Extra debug logs in both reporter modes: TestOps and Local.
