### PR TITLE
cypress: release 2.0.0-beta.3

### DIFF
--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,0 +1,8 @@
+# cypress-qase-reporter@2.0.0-beta.3
+
+Fixed an issue with multiple test runs created when Cypress is running 
+multiple tests in parallel.
+
+# cypress-qase-reporter@2.0.0-beta.2
+
+First major beta release for the version 2 series of the Qase Cypress reporter.

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -44,7 +44,7 @@
   "author": "Nikita Fedorov <nik333r@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.8",
+    "qase-javascript-commons": "^2.0.0-beta.9",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
* Use qase-javascript-commons@2.0.0-beta.9 with an important bugfix.
* Add a minimal changelog.