### PR TITLE
qase-javascript-commons: send results strictly after creating test run

### DIFF
--- a/qase-cucumberjs/src/reporter.ts
+++ b/qase-cucumberjs/src/reporter.ts
@@ -167,7 +167,7 @@ export class CucumberQaseReporter extends Formatter {
             envelope.attachment.fileName;
         }
       } else if (envelope.testRunStarted) {
-        void this.startTestRun();
+        this.startTestRun();
       } else if (envelope.testRunFinished) {
         void this.publishResults();
       } else if (envelope.testCase) {
@@ -278,7 +278,7 @@ export class CucumberQaseReporter extends Formatter {
    * @returns {Promise<void>}
    * @private
    */
-  private async startTestRun(): Promise<void> {
-    await this.reporter.startTestRun();
+  private startTestRun(): void {
+    void this.reporter.startTestRun();
   }
 }

--- a/qase-cucumberjs/src/reporter.ts
+++ b/qase-cucumberjs/src/reporter.ts
@@ -124,7 +124,7 @@ export class CucumberQaseReporter extends Formatter {
 
     super(formatterOptions);
 
-    this.reporter = new QaseReporter({
+    this.reporter = QaseReporter.getInstance({
       ...composeOptions(qase, config),
       frameworkPackage: '@cucumber/cucumber',
       frameworkName: 'cucumberjs',

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -44,7 +44,7 @@
   "author": "Nikita Fedorov <nik333r@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.9",
+    "qase-javascript-commons": "^2.0.0-beta.10",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -121,7 +121,7 @@ export class CypressQaseReporter extends reporters.Base {
 
     this.screenshotsFolder = framework?.cypress?.screenshotsFolder;
 
-    this.reporter = new QaseReporter({
+    this.reporter = QaseReporter.getInstance({
       ...composedOptions,
       frameworkPackage: 'cypress',
       frameworkName: 'cypress',

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.0.0-beta.10
+
+## What's new
+
+Fixed an issue when the results published before the test run creation.
+
 # qase-javascript-commons@2.0.0-beta.9
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -51,6 +51,8 @@ export interface ReporterInterface {
  * @implements AbstractReporter
  */
 export class QaseReporter implements ReporterInterface {
+  private static instance: QaseReporter;
+
   /**
    * @param {string} frameworkPackage
    * @param {string} frameworkName
@@ -134,7 +136,7 @@ export class QaseReporter implements ReporterInterface {
   /**
    * @param {OptionsType} options
    */
-  constructor(options: OptionsType) {
+  private constructor(options: OptionsType) {
     const env = envToConfig(envSchema({ schema: envValidationSchema }));
     const composedOptions = composeOptions(options, env);
 
@@ -211,6 +213,18 @@ export class QaseReporter implements ReporterInterface {
         }
       }
     }
+  }
+
+  /**
+   * @param {OptionsType} options
+   * @returns {QaseReporter}
+   */
+  public static getInstance(options: OptionsType): QaseReporter {
+    if (!QaseReporter.instance) {
+      QaseReporter.instance = new QaseReporter(options);
+    }
+
+    return QaseReporter.instance;
   }
 
   /**

--- a/qase-javascript-commons/src/reporters/abstract-reporter.ts
+++ b/qase-javascript-commons/src/reporters/abstract-reporter.ts
@@ -1,21 +1,8 @@
 import { TestResultType } from '../models';
 import { v4 as uuidv4 } from 'uuid';
-import { Logger } from '../utils/logger';
+import { LoggerInterface } from '../utils/logger';
 
-export interface LoggerInterface {
-  log(message: string): void;
-
-  logError(message: string, error?: unknown): void;
-
-  logDebug(message: string): void;
-}
-
-export interface ReporterOptionsType {
-  debug?: boolean | undefined;
-  captureLogs?: boolean | undefined;
-}
-
-export interface ReporterInterface {
+export interface InternalReporterInterface {
   addTestResult(result: TestResultType): Promise<void>;
 
   publish(): Promise<void>;
@@ -25,22 +12,14 @@ export interface ReporterInterface {
   getTestResults(): TestResultType[];
 
   setTestResults(results: TestResultType[]): void;
-
-  isCaptureLogs(): boolean;
 }
 
 /**
  * @abstract
  * @class AbstractReporter
- * @implements ReporterInterface
+ * @implements InternalReporterInterface
  */
-export abstract class AbstractReporter implements ReporterInterface {
-  /**
-   * @type {boolean | undefined}
-   * @private
-   */
-  private readonly captureLogs: boolean | undefined;
-
+export abstract class AbstractReporter implements InternalReporterInterface {
   /**
    * @type {LoggerInterface}
    * @private
@@ -64,16 +43,11 @@ export abstract class AbstractReporter implements ReporterInterface {
   abstract startTestRun(): Promise<void>;
 
   /**
-   * @param {ReporterOptionsType} options
    * @protected
+   * @param {LoggerInterface} logger
    */
-  protected constructor(
-    options: ReporterOptionsType | undefined,
-  ) {
-    const { debug, captureLogs } = options ?? {};
-
-    this.captureLogs = captureLogs;
-    this.logger = new Logger({ debug });
+  protected constructor(logger: LoggerInterface) {
+    this.logger = logger;
   }
 
   /**
@@ -81,13 +55,6 @@ export abstract class AbstractReporter implements ReporterInterface {
    */
   public getTestResults(): TestResultType[] {
     return this.results;
-  }
-
-  /**
-   * @returns {boolean}
-   */
-  public isCaptureLogs(): boolean {
-    return this.captureLogs ?? false;
   }
 
   /**

--- a/qase-javascript-commons/src/reporters/index.ts
+++ b/qase-javascript-commons/src/reporters/index.ts
@@ -1,8 +1,6 @@
 export {
   AbstractReporter,
-  type ReporterInterface,
-  type ReporterOptionsType,
-  type LoggerInterface,
+  type InternalReporterInterface,
 } from './abstract-reporter';
 export { ReportReporter } from './report-reporter';
 export { TestOpsReporter, type TestOpsOptionsType } from './testops-reporter';

--- a/qase-javascript-commons/src/reporters/report-reporter.ts
+++ b/qase-javascript-commons/src/reporters/report-reporter.ts
@@ -1,10 +1,11 @@
-import { AbstractReporter, ReporterOptionsType } from './abstract-reporter';
+import { AbstractReporter } from './abstract-reporter';
 import { Report, TestStatusEnum, TestStepType } from '../models';
 import { WriterInterface } from '../writer';
 import { HostData } from '../models/host-data';
 import * as os from 'os';
 import * as cp from 'child_process';
 import * as process from 'process';
+import { LoggerInterface } from '../utils/logger';
 
 /**
  * @class ReportReporter
@@ -16,18 +17,18 @@ export class ReportReporter extends AbstractReporter {
   private startTime: number = Date.now();
 
   /**
-   * @param {ReporterOptionsType} options
+   * @param {LoggerInterface} logger
    * @param {WriterInterface} writer
    * @param {string | undefined} environment
    * @param {number | undefined} runId
    */
   constructor(
-    options: ReporterOptionsType | undefined,
+    logger: LoggerInterface,
     private writer: WriterInterface,
     environment?: string,
     runId?: number,
   ) {
-    super(options);
+    super(logger);
     this.environment = environment;
     this.runId = runId;
   }
@@ -115,7 +116,7 @@ export class ReportReporter extends AbstractReporter {
 
     const path = await this.writer.writeReport(report);
 
-    this.logger.log(`Report saved to ${path}`)
+    this.logger.log(`Report saved to ${path}`);
   }
 
   /**

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -12,7 +12,7 @@ import {
   RunCreate, TestStepResultCreate, TestStepResultCreateStatusEnum,
 } from 'qaseio';
 
-import { AbstractReporter, ReporterOptionsType } from './abstract-reporter';
+import { AbstractReporter } from './abstract-reporter';
 
 import {
   StepStatusEnum,
@@ -27,6 +27,7 @@ import {
 } from '../models';
 
 import { QaseError } from '../utils/qase-error';
+import { LoggerInterface } from '../utils/logger';
 
 const defaultChunkSize = 200;
 
@@ -146,12 +147,14 @@ export class TestOpsReporter extends AbstractReporter {
   private isTestRunReady = false;
 
   /**
+   * @param {LoggerInterface} logger
    * @param {ReporterOptionsType & TestOpsOptionsType} options
    * @param {QaseApiInterface} api
    * @param {number} environment
    */
   constructor(
-    options: ReporterOptionsType & TestOpsOptionsType,
+    logger: LoggerInterface,
+    options: TestOpsOptionsType,
     private api: QaseApiInterface,
     environment?: number,
   ) {
@@ -159,11 +162,9 @@ export class TestOpsReporter extends AbstractReporter {
       project,
       uploadAttachments,
       run,
-
-      ...restOptions
     } = options;
 
-    super(restOptions);
+    super(logger);
 
     const baseUrl = 'https://app.qase.io';
 

--- a/qase-javascript-commons/src/utils/logger.ts
+++ b/qase-javascript-commons/src/utils/logger.ts
@@ -5,7 +5,15 @@ import { QaseError } from './qase-error';
 import { AxiosError } from 'axios';
 import get from 'lodash.get';
 
-export class Logger {
+export interface LoggerInterface {
+  log(message: string): void;
+
+  logError(message: string, error?: unknown): void;
+
+  logDebug(message: string): void;
+}
+
+export class Logger implements LoggerInterface {
   private readonly debug: boolean | undefined;
   private readonly filePath: string;
 

--- a/qase-jest/src/reporter.ts
+++ b/qase-jest/src/reporter.ts
@@ -69,7 +69,7 @@ export class JestQaseReporter implements Reporter {
   ) {
     const config = configLoader.load();
 
-    this.reporter = new QaseReporter({
+    this.reporter = QaseReporter.getInstance({
       ...composeOptions(options, config),
       frameworkPackage: 'jest',
       frameworkName: 'jest',

--- a/qase-newman/src/reporter.ts
+++ b/qase-newman/src/reporter.ts
@@ -103,7 +103,7 @@ export class NewmanQaseReporter {
   ) {
     const config = configLoader.load();
 
-    this.reporter = new QaseReporter({
+    this.reporter = QaseReporter.getInstance({
       ...composeOptions(options, config),
       frameworkPackage: 'newman',
       frameworkName: 'newman',

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.12",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.2",
-    "qase-javascript-commons": "^2.0.0-beta.8",
+    "qase-javascript-commons": "^2.0.0-beta.10",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -237,7 +237,7 @@ export class PlaywrightQaseReporter implements Reporter {
   ) {
     const config = configLoader.load();
 
-    this.reporter = new QaseReporter({
+    this.reporter = QaseReporter.getInstance({
       ...composeOptions(options, config),
       frameworkPackage: '@playwright/test',
       frameworkName: 'playwright',

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -261,7 +261,7 @@ export class PlaywrightQaseReporter implements Reporter {
   }
 
   public onBegin(): void {
-    void this.reporter.startTestRun();
+    this.reporter.startTestRun();
   }
 
   /**

--- a/qase-testcafe/src/factory.ts
+++ b/qase-testcafe/src/factory.ts
@@ -9,8 +9,8 @@ export const factory = (options: TestcafeQaseOptionsType) => {
 
   return {
     noColors: false,
-    reportTaskStart: async () => {
-      await reporter.startTestRun();
+    reportTaskStart: () => {
+      reporter.startTestRun();
     },
     reportFixtureStart: () => {
       /* empty */

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -171,8 +171,8 @@ export class TestcafeQaseReporter {
   /**
    * @returns {Promise<void>}
    */
-  public startTestRun = async (): Promise<void> => {
-    await this.reporter.startTestRun();
+  public startTestRun = (): void => {
+    void this.reporter.startTestRun();
   };
 
   /**

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -160,7 +160,7 @@ export class TestcafeQaseReporter {
   ) {
     const config = configLoader.load();
 
-    this.reporter = new QaseReporter({
+    this.reporter = QaseReporter.getInstance({
       ...composeOptions(options, config),
       frameworkPackage: 'testcafe',
       frameworkName: 'testcafe',


### PR DESCRIPTION
qase-javascript-commons: send results strictly after creating test run
--
Fix a problem where reporter could send results before a test run in Qase was successfully created,
which resulted in a validation error and reporter switching to fallback mode.

The following changes:
- move the logger interface to the logger file
- rename ReporterInterface to InternalReporterInterface
- refactor AbstractReporter
- add a new ReporterInterface for QaseReporter

---

qase-javascript-commons: made the QaseReporter a singleton
--
The following changes:
- add `getInstance` method for creating QaseReporter
- update all reporters

---

release: qase-cypress, qase-playwright, qase-javascript-commons
--
Release the following packages:
- qase-cypress 2.0.0-beta.4
- qase-playwright 2.0.0-beta.12
- qase-javascript-commons 2.0.0-beta.10
