### PR TITLE
qase-playwright: release 2.0.0-beta.13

### DIFF
--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,19 @@
+# playwright-qase-reporter@2.0.0-beta.13
+
+## What's new
+
+Fixed the issue with the `qase.parameters` annotation if you use not string values for parameters.
+
+```log
+[ERROR] qase: Unable to add the result to the upstream reporter:
+Message: Data is invalid.
+ results.0.param.test_case: The param.test_case must be a string.
+
+Error: Request failed with status code 400
+```
+
+Right now, the reporter will convert all parameters to strings before sending them to the Qase API.
+
 # playwright-qase-reporter@2.0.0-beta.11
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -90,23 +90,28 @@ qase.title = function(value: string) {
 
 /**
  * Set fields for the test case
- * @param {Record<string, string>[]} value
+ * @param {Record<string, string>[]} values
  * @example
  * test('test', async ({ page }) => {
  *    qase.fields({ 'severity': 'high', 'priority': 'medium' });
  *    await page.goto('https://example.com');
  * });
  */
-qase.fields = function(value: Record<string, string>) {
+qase.fields = function(values: Record<string, string>) {
+  const stringRecord: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    stringRecord[String(key)] = String(value);
+  }
+
   addMetadata({
-    fields: value,
+    fields: stringRecord,
   });
   return this;
 };
 
 /**
  * Set parameters for the test case
- * @param {Record<string, string>[]} value
+ * @param {Record<string, string>[]} values
  * @example
  * for (const value of values) {
  *    test('test', async ({ page }) => {
@@ -115,9 +120,13 @@ qase.fields = function(value: Record<string, string>) {
  *    });
  * )
  */
-qase.parameters = function(value: Record<string, string>) {
+qase.parameters = function(values: Record<string, string>) {
+  const stringRecord: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    stringRecord[String(key)] = String(value);
+  }
   addMetadata({
-    parameters: value,
+    parameters: stringRecord,
   });
   return this;
 };


### PR DESCRIPTION
qase-playwright: release 2.0.0-beta.13
--
Fixed the issue with the `qase.parameters` annotation if you use not string values for parameters. Right now, the reporter will convert all parameters to strings before sending them to the Qase API.