### PR TITLE
release: qase-javascript-commons 2.0.0-beta.11

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,13 @@
+# qase-javascript-commons@2.0.0-beta.11
+
+## What's new
+
+* The `useV2` option in the reporter's configuration will now enable using the experimental v2 API.
+  Before this fix, v1 API was used despite the configuration.
+
+* Attachments from test steps will now be uploaded to Qase.
+  Before this fix, the reporter uploaded only the attachments made outside of any step scope.
+
 # qase-javascript-commons@2.0.0-beta.10
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -361,6 +361,7 @@ export class QaseReporter implements ReporterInterface {
           } = {},
           plan = {},
           batch = {},
+          useV2,
           uploadAttachments,
         } = testops;
 
@@ -401,6 +402,7 @@ export class QaseReporter implements ReporterInterface {
             },
             plan,
             batch,
+            useV2,
           },
           apiClient,
           typeof environment === 'number' ? environment : undefined,

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -418,10 +418,10 @@ export class TestOpsReporter extends AbstractReporter {
       const resultStep: ResultStep = {
         data: {
           action: '',
-          attachments: attachmentHashes,
         },
         execution: {
           status: TestOpsReporter.stepStatusMap[step.execution.status],
+          attachments: attachmentHashes,
         },
       };
 


### PR DESCRIPTION
- Fixed an issue when you use the `useV2` option in the reporter's configuration. This options doesn't work correctly and always uses the v1 API. 
- Fixed an issue when the step has an attachment. The attachment was not uploaded to the Qase.