### PR TITLE
release: qase-playwright 2.0.0-beta.14

### DIFF
--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,10 @@
+# playwright-qase-reporter@2.0.0-beta.14
+
+## What's new
+
+Fixed the issue with attachments that the Playwright would create if the test failed.
+We have not uploaded these attachments before. This problem has now been fixed.
+
 # playwright-qase-reporter@2.0.0-beta.13
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -1,6 +1,7 @@
 import { Reporter, TestCase, TestError, TestResult, TestStatus, TestStep } from '@playwright/test/reporter';
 import { v4 as uuidv4 } from 'uuid';
 import chalk from 'chalk';
+import * as path from 'path';
 
 import {
   Attachment,
@@ -159,7 +160,19 @@ export class PlaywrightQaseReporter implements Reporter {
         }
 
         attachments.push(attachmentModel);
+        continue;
       }
+
+      const attachmentModel: Attachment = {
+        content: attachment.body == undefined ? '' : attachment.body,
+        file_name: attachment.path == undefined ? attachment.name : path.basename(attachment.path),
+        file_path: attachment.path == undefined ? null : attachment.path,
+        mime_type: attachment.contentType,
+        size: 0,
+        id: uuidv4(),
+      };
+
+      attachments.push(attachmentModel);
     }
     metadata.attachments = attachments;
 


### PR DESCRIPTION
Fixed the issue with attachments that the Playwright would create if the test failed. We have not uploaded these attachments before. This problem has now been fixed.