### PR TITLE
release: qase-javascript-commons 2.0.0-beta.12

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.0.0-beta.12
+
+## What's new
+
+Fixed an issue when the result has empty step action. Now the reporter will mark such steps as "Unnamed step" and will
+log a warning message.
+
 # qase-javascript-commons@2.0.0-beta.11
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.12",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Fixed an issue when the result has empty step action. Now the reporter will mark such steps as "Unnamed step" and will log a warning message.