### PR TITLE
ci: adapt workflows to publishing both release and beta versions

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -20,6 +20,7 @@ jobs:
     - run: npm run build -ws --if-present
     - run: npm run lint -w ${{ matrix.prefix }}
     - run: npm run test -w ${{ matrix.prefix }}
+
   build-n-publish:
     runs-on: ubuntu-latest
     needs: test
@@ -36,11 +37,23 @@ jobs:
       with:
         node-version: '16'
         registry-url: 'https://registry.npmjs.org'
-    - if: contains(github.event.ref, matrix.prefix)
+
+    - name: Install dependencies
+      if: contains(github.event.ref, matrix.prefix)
       run: npm ci
-    - if: contains(github.event.ref, matrix.prefix)
+
+    - name: Build a Node package
+      if: contains(github.event.ref, matrix.prefix)
       run: npm run build -ws --if-present
-    - if: contains(github.event.ref, matrix.prefix)
-      run: npm publish -w ${{ matrix.prefix }} --tag beta
+
+    - name: Publish a release version
+      if: contains(github.event.ref, matrix.prefix) && !contains(github.event.ref, 'beta')
+      run: echo 'release' # && npm publish -w ${{ matrix.prefix }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Publish a beta version
+      if: contains(github.event.ref, matrix.prefix) && contains(github.event.ref, 'beta')
+      run: echo 'beta' # && npm publish -w ${{ matrix.prefix }} --tag beta
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We have come to the point of release for several packages. At the same time, we need to be able to release beta versions with new features.

Test workflow runs:

# beta, tag `qase-jest-v2.0.0-beta.3`

https://github.com/qase-tms/qase-javascript/actions/runs/9078010015

<img width="314" alt="Screenshot 2024-05-14 at 14 42 38" src="https://github.com/qase-tms/qase-javascript/assets/8015154/d9b5c17b-2a9c-426e-844b-27f440fcda86">


# release, tag `qase-jest-v2.0.0`

https://github.com/qase-tms/qase-javascript/actions/runs/9078014678

<img width="330" alt="Screenshot 2024-05-14 at 14 43 06" src="https://github.com/qase-tms/qase-javascript/assets/8015154/9d78d474-3a89-4b22-b1e9-4de0a881f651">
