### PR TITLE
release: qase-javascript-commons 2.0.1

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,15 @@
+# qase-javascript-commons@2.0.1
+
+## What's new
+
+Remove ANSI escape codes from the message and stack trace.
+Before this fix, the reporter added ANSI escape codes to the message and stack trace.
+
+```diff
+- Error: [2mexpect([22m[31mreceived[39m[2m).[22mtoBe[2m([22m[32mexpected[39m[2m) // Object.is equality[22m
++ Error: expect(received).toBe(expected) // Object.is equality
+```
+
 # qase-javascript-commons@2.0.0
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/abstract-reporter.ts
+++ b/qase-javascript-commons/src/reporters/abstract-reporter.ts
@@ -64,6 +64,14 @@ export abstract class AbstractReporter implements InternalReporterInterface {
   public async addTestResult(result: TestResultType) {
     this.logger.logDebug(`Adding test result: ${JSON.stringify(result)}`);
 
+    if (result.execution.stacktrace) {
+      result.execution.stacktrace = this.removeAnsiEscapeCodes(result.execution.stacktrace);
+    }
+
+    if (result.message) {
+      result.message = this.removeAnsiEscapeCodes(result.message);
+    }
+
     if (result.testops_id === null || !Array.isArray(result.testops_id)) {
       this.results.push(result);
       return;
@@ -91,5 +99,13 @@ export abstract class AbstractReporter implements InternalReporterInterface {
    */
   public setTestResults(results: TestResultType[]): void {
     this.results = results;
+  }
+
+  private removeAnsiEscapeCodes(str: string): string {
+    const ansiEscapeSequences = new RegExp([
+      '\x1B[[(?);]{0,2}(;?\\d)*.',
+    ].join('|'), 'g');
+
+    return str.replace(ansiEscapeSequences, '');
   }
 }


### PR DESCRIPTION
release: qase-javascript-commons 2.0.1
--
Remove ANSI escape codes from the message and stack trace.