### PR TITLE
release: qase-cypress-v2.0.1

### DIFF
--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,10 @@
+# cypress-qase-reporter@2.0.1
+
+## What's new
+
+The reporter would mark the test as blocked if the test was skipped in Cypress.
+Now, the reporter will mark the test as skipped.
+
 # cypress-qase-reporter@2.0.0
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -45,7 +45,7 @@ export class CypressQaseReporter extends reporters.Base {
   static statusMap: Record<CypressState, TestStatusEnum> = {
     failed: TestStatusEnum.failed,
     passed: TestStatusEnum.passed,
-    pending: TestStatusEnum.blocked,
+    pending: TestStatusEnum.skipped,
   };
 
   /**


### PR DESCRIPTION
release: qase-cypress-v2.0.1
--
The reporter would mark the test as blocked if the test was skipped in Cypress. Now, the reporter will mark the test as skipped.