### PR TITLE
release: qase-cypress 2.0.2

### DIFF
--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,12 @@
+# cypress-qase-reporter@2.0.2
+
+## What's new
+
+1. Cypress kills the process after the last tests. 
+The reporter will wait for all results to be sent to Qase and will not block the process after sending.
+
+2. The reporter will collect suites and add them to results.
+
 # cypress-qase-reporter@2.0.1
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -144,7 +144,7 @@ export class CypressQaseReporter extends reporters.Base {
     runner.on(EVENT_TEST_FAIL, (test: Test) => this.addTestResult(test));
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    runner.on(EVENT_RUN_BEGIN,  () => this.reporter.startTestRun());
+    runner.on(EVENT_RUN_BEGIN, () => this.reporter.startTestRun());
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     runner.once(EVENT_RUN_END, async () => {
@@ -168,6 +168,23 @@ export class CypressQaseReporter extends reporters.Base {
       ? CypressQaseReporter.findAttachments(ids, this.screenshotsFolder)
       : undefined;
 
+    let relations = {};
+    if (test.parent !== undefined) {
+      const data = [];
+      for (const suite of test.parent.titlePath()) {
+        data.push({
+          title: suite,
+          public_id: null,
+        });
+      }
+
+      relations = {
+        suite: {
+          data: data,
+        },
+      };
+    }
+
     const result: TestResultType = {
       attachments: attachments ?? [],
       author: null,
@@ -175,7 +192,7 @@ export class CypressQaseReporter extends reporters.Base {
       message: test.err?.message ?? null,
       muted: false,
       params: {},
-      relations: {},
+      relations: relations,
       run_id: null,
       signature: '',
       steps: [],
@@ -192,7 +209,6 @@ export class CypressQaseReporter extends reporters.Base {
       },
       testops_id: ids.length > 0 ? ids : null,
       title: test.title,
-      // suiteTitle: test.parent?.titlePath(),
     };
 
     void this.reporter.addTestResult(result);

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -25,6 +25,9 @@ const {
 
 type CypressState = 'failed' | 'passed' | 'pending';
 
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const _exit = process.exit;
+
 export type CypressQaseOptionsType = Omit<MochaOptions, 'reporterOptions'> & {
   reporterOptions: ReporterOptionsType;
 };
@@ -199,9 +202,6 @@ export class CypressQaseReporter extends reporters.Base {
    * @private
    */
   private preventExit() {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const _exit = process.exit;
-
     const mutableProcess: Record<'exit', (code: number) => void> = process;
 
     mutableProcess.exit = (code: number) => {


### PR DESCRIPTION
release: qase-cypress 2.0.2
--
Bump version

---

qase-cypress: add support suites
--
The reporter will collect suites and add them to results.

---

qase-cypress: fixed problem when completing tests
--
Cypress kills the process after the last tests. The reporter will wait for all results to be sent to Qase and will not block the  process after sending.