### PR TITLE
release: qase-cucumberjs 2.0.0

### DIFF
--- a/qase-cucumberjs/README.md
+++ b/qase-cucumberjs/README.md
@@ -5,7 +5,7 @@ Publish results simple and easy.
 ## How to install
 
 ```sh
-npm install -D cucumberjs-qase-reporter@beta
+npm install -D cucumberjs-qase-reporter
 ```
 
 ## Updating from v1

--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,16 @@
+# qase-cucumberjs@2.0.0
+
+## What's new
+
+This is the first release in the 2.x series of the Cucumber JS reporter.
+It brings a new annotation syntax with field values,
+new and more flexible configs, uploading results in parallel with running tests,
+and other powerful features.
+
+This changelog entry will be updated soon.
+For more information about the new features and a guide for migration from v1, refer to the
+[reporter documentation](https://github.com/qase-tms/qase-javascript/tree/main/qase-cucumberjs#readme)
+
 # qase-cucumberjs@2.0.0-beta.3
 
 ## What's new

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",


### PR DESCRIPTION
release: qase-cucumberjs 2.0.0
--
This is the first release in the 2.x series of the Cucumber JS reporter.