### PR TITLE
release: qase-javascript-commons 2.0.3 and qase-testcafe 2.0.0-beta.2

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.0.3
+
+## What's new
+
+Fixed an issue when the reporter would run tests before creating a test run.
+Now the reporter will create a test run before running tests.
+
 # qase-javascript-commons@2.0.2
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -538,6 +538,7 @@ export class TestOpsReporter extends AbstractReporter {
         description,
         is_autotest: true,
         cases: [],
+        start_time: this.getDate(),
       };
 
       if (environment !== undefined) {
@@ -553,6 +554,23 @@ export class TestOpsReporter extends AbstractReporter {
     } catch (error) {
       throw new QaseError('Cannot create run', { cause: error });
     }
+  }
+
+  /**
+   * @returns {string}
+   * @private
+   */
+  private getDate(): string {
+    const date = new Date();
+    date.setSeconds(-10);
+    const year = date.getUTCFullYear();
+    const month = ('0' + (date.getUTCMonth() + 1).toString()).slice(-2); // Months are zero indexed, so we add 1
+    const day = ('0' + date.getUTCDate().toString()).slice(-2);
+    const hours = date.getUTCHours().toString();
+    const minutes = date.getUTCMinutes().toString();
+    const seconds = date.getUTCSeconds().toString();
+
+    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
   }
 
   /**

--- a/qase-testcafe/README.md
+++ b/qase-testcafe/README.md
@@ -9,6 +9,13 @@ To install the latest beta version, run:
 npm install -D testcafe-reporter-qase@beta
 ```
 
+## Updating from v1
+
+To update a test project using testcafe-reporter-qaser@v1 to version 2:
+
+1. Update reporter configuration in `qase.config.json` and/or environment variables —
+   see the [configuration reference](#configuration) below.
+
 ## Example of usage
 
 The TestCafe reporter has the ability to auto-generate test cases
@@ -23,7 +30,12 @@ test.meta('CID', [1])('Text typing basics', async (t) => {
   await t;
 });
 
-test.meta({ CID: [2, 3] })(
+const q = qase.id(1)
+  .title('Text typing basics')
+  .field({ 'severity': 'high' })
+  .parameters({ 'browser': 'chrome' })
+  .create();
+test.meta({ ...q })(
   'Click check boxes and then verify their state',
   async (t) => {
     await t;
@@ -61,36 +73,28 @@ https://app.qase.io/run/QASE_PROJECT_CODE
 
 ## Configuration
 
-Qase reporter supports passing parameters using two ways:
-using `.qaserc`/`qase.config.json` file and using ENV variables.
+Qase Testcafe reporter can be configured in multiple ways:
 
-`.qaserc` parameters, (* - required):
+- using a separate config file `qase.config.json`,
+- using environment variables (they override the values from the configuration files).
 
-- `mode` - `testops`/`off` Enables reporter, default - `off`
-- `debug` - Enables debug logging, defaule - `false`
-- `environment` - To execute with the sending of the envinroment information 
-- *`testops.api.token` - Token for API access, you can find more information
-  [here](https://developers.qase.io/#authentication)
-- *`testops.project` - Code of your project (can be extracted from main
-  page of your project: `https://app.qase.io/project/DEMOTR` -
-  `DEMOTR` is project code here)
-- `testops.uploadAttachments` - Permission to send screenshots to Qase TMS
-- `testops.run.id` - Pass Run ID
-- `testops.run.title` - Set custom Run name, when new run is created
-- `testops.run.description` - Set custom Run description, when new run is created
-- `testops.run.complete` - Whether the run should be completed
+For a full list of configuration options, see
+the [Configuration reference](../qase-javascript-commons/README.md#configuration).
 
-Example configuration file:
+Example `qase.config.json` file:
 
 ```json
 {
+  "mode": "testops",
   "debug": true,
-  "environment": 1,
   "testops": {
     "api": {
       "token": "api_key"
     },
-    "project": "project_code"
+    "project": "project_code",
+    "run": {
+      "complete": true
+    }
   }
 }
 ```
@@ -99,7 +103,7 @@ Supported ENV variables:
 
 - `QASE_MODE` - Same as `mode`
 - `QASE_DEBUG` - Same as `debug`
-- `QASE_ENVIRONMENT` - Same as `environment` 
+- `QASE_ENVIRONMENT` - Same as `environment`
 - `QASE_TESTOPS_API_TOKEN` - Same as `testops.api.token`
 - `QASE_TESTOPS_PROJECT` - Same as `testops.project`
 - `QASE_TESTOPS_RUN_ID` - Pass Run ID from ENV and override reporter option `testops.run.id`
@@ -108,7 +112,7 @@ Supported ENV variables:
 
 ## Requirements
 
-We maintain the reporter on LTS versions of Node. You can find the current versions by following the [link](https://nodejs.org/en/about/releases/)
+We maintain the reporter on [LTS versions of Node](https://nodejs.org/en/about/releases/).
 
 `testcafe >= 2.0.0`
 

--- a/qase-testcafe/changelog.md
+++ b/qase-testcafe/changelog.md
@@ -1,0 +1,18 @@
+# qase-testcafe@2.0.0-beta.2
+
+## What's new
+
+Add new syntax to annotate the following fields: `QaseID`, `QaseTitle`, `QaseFields`, `QaseParameters`:
+
+```diff
++ import { qase } from 'testcafe-reporter-qase/qase';
+- test.meta('CID', '2')('Test name', async t => {...});
++ const q = qase.id(2).title('Test name').fields('field1', 'field2').parameters('param1', 'param2').create();
++ test.meta(q)('Test name', async t => {...});
+```
+
+# qase-testcafe@2.0.0-beta.1
+
+## What's new
+
+First major beta release for the version 2 series of the Qase TestCafe reporter.

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -6,6 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./qase": "./dist/qase.js",
     "./reporter": "./dist/reporter.js",
     "./package.json": "./package.json"
   },

--- a/qase-testcafe/src/factory.ts
+++ b/qase-testcafe/src/factory.ts
@@ -2,7 +2,7 @@ import { TestcafeQaseOptionsType, TestcafeQaseReporter, TestRunInfoType } from '
 
 /**
  * @param {TestcafeQaseOptionsType} options
- * @returns {object}
+ * @returns
  */
 export const factory = (options: TestcafeQaseOptionsType) => {
   const reporter = new TestcafeQaseReporter(options);

--- a/qase-testcafe/src/qase.ts
+++ b/qase-testcafe/src/qase.ts
@@ -1,0 +1,100 @@
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export class qase {
+  private static _qaseID = '';
+  private static _qaseTitle = '';
+  private static _qaseFields = '';
+  private static _qaseParameters = '';
+
+  /**
+   * Set a Qase ID for the test case
+   * Don't forget to call `create` method after setting all the necessary parameters
+   * @param {number | number[]} value
+   * @example
+   * const q = qase.id(1).create();
+   * test.meta(q)('Test case title', async t => { ... });
+   * or
+   * test.meta({userField: 123, ...q})('Test case title', async t => { ... });
+   */
+  public static id = (value: number | number[]) => {
+    this._qaseID = Array.isArray(value) ? value.join(',') : String(value);
+    return this;
+  };
+
+  /**
+   * Set a title for the test case
+   * Don't forget to call `create` method after setting all the necessary parameters
+   * @param {string} value
+   * @example
+   * const q = qase.title('Test case title').create();
+   * test.meta(q)('Test case title', async t => { ... });
+   * or
+   * test.meta({userField: 123, ...q})('Test case title', async t => { ... });
+   */
+  public static title = (value: string) => {
+    this._qaseTitle = value;
+    return this;
+  };
+
+  /**
+   * Set a fields for the test case
+   * Don't forget to call `create` method after setting all the necessary parameters
+   * @param {Record<string, string>} values
+   * @example
+   * const q = qase.fields({ 'severity': 'high', 'priority': 'medium' }).create();
+   * test.meta(q)('Test case title', async t => { ... });
+   * or
+   * test.meta({userField: 123, ...q})('Test case title', async t => { ... });
+   */
+  public static fields = (values: Record<string, string>) => {
+    this._qaseFields = this.toNormalizeRecord(values);
+    return this;
+  };
+
+  /**
+   * Set a parameters for the test case
+   * Don't forget to call `create` method after setting all the necessary parameters
+   * @param {Record<string, string>} values
+   * @example
+   * const q = qase.parameters({ 'severity': 'high', 'priority': 'medium' }).create();
+   * test.meta(q)('Test case title', async t => { ... });
+   * or
+   * test.meta({userField: 123, ...q})('Test case title', async t => { ... });
+   */
+  public static parameters = (values: Record<string, string>) => {
+    this._qaseParameters = this.toNormalizeRecord(values);
+    return this;
+  };
+
+  /**
+   * Create a Qase metadata
+   * Call this method after setting all the necessary parameters
+   * @example
+   * const q = qase.id(1).title('Test case title').fields({ 'severity': 'high', 'priority': 'medium' }).create();
+   * test.meta(q)('Test case title', async t => { ... });
+   * or
+   * test.meta({userField: 123, ...q})('Test case title', async t => { ... });
+   */
+  public static create = () => {
+    const meta = {
+      QaseID: this._qaseID,
+      QaseTitle: this._qaseTitle,
+      QaseFields: this._qaseFields,
+      QaseParameters: this._qaseParameters,
+    };
+
+    this._qaseID = '';
+    this._qaseTitle = '';
+    this._qaseFields = '';
+    this._qaseParameters = '';
+
+    return meta;
+  };
+
+  private static toNormalizeRecord = (record: Record<string, string>) => {
+    const stringRecord: Record<string, string> = {};
+    for (const [key, value] of Object.entries(record)) {
+      stringRecord[String(key)] = String(value);
+    }
+    return JSON.stringify(stringRecord);
+  };
+}

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -10,15 +10,15 @@ import {
   Attachment,
 } from 'qase-javascript-commons';
 
-type CallsiteRecordType = {
+interface CallsiteRecordType {
   filename?: string;
   lineNum?: number;
   callsiteFrameIdx?: number;
-  stackFrames?: Array<unknown>;
+  stackFrames?: unknown[];
   isV8Frames?: boolean;
-};
+}
 
-type TestRunErrorFormattableAdapterType = {
+interface TestRunErrorFormattableAdapterType {
   userAgent: string;
   screenshotPath: string;
   testRunId: string;
@@ -29,22 +29,22 @@ type TestRunErrorFormattableAdapterType = {
   errMsg?: string;
   diff?: boolean;
   id?: string;
-};
+}
 
-type ScreenshotType = {
+interface ScreenshotType {
   screenshotPath: string;
   thumbnailPath: string;
   userAgent: string;
   quarantineAttempt: number;
   takenOnFail: boolean;
-};
+}
 
-type FixtureType = {
+interface FixtureType {
   id: string;
   name: string;
   path?: string;
   meta: Record<string, unknown>;
-};
+}
 
 enum metadataEnum {
   id = 'QaseID',
@@ -61,7 +61,7 @@ interface MetadataType {
   [metadataEnum.parameters]: Record<string, string>;
 }
 
-export type TestRunInfoType = {
+export interface TestRunInfoType {
   errs: TestRunErrorFormattableAdapterType[];
   warnings: string[];
   durationMs: number;
@@ -71,7 +71,7 @@ export type TestRunInfoType = {
   quarantine: Record<string, Record<'passed', boolean>>;
   skipped: boolean;
   fixture: FixtureType;
-};
+}
 
 export type TestcafeQaseOptionsType = ConfigType;
 
@@ -170,7 +170,7 @@ export class TestcafeQaseReporter {
    * @returns {Promise<void>}
    */
   public startTestRun = (): void => {
-    void this.reporter.startTestRun();
+      this.reporter.startTestRun();
   };
 
   /**


### PR DESCRIPTION
release: qase-javascript-commons 2.0.3
--
Fixed an issue when the reporter would run tests before creating a test run.

---

qase-testcafe: add a new syntax
--
- add new syntax to annotate the following fields: `QaseID`, `QaseTitle`, `QaseFields`, `QaseParameters`
- add support suites

---

release: qase-testcafe 2.0.0-beta.2
--
Add changelog and update readme
