### PR TITLE
release: qase-javascript-commons 2.0.4

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.0.4
+
+## What's new
+
+Fixed an issue when the reporter created a test run:
+`The start time does not match the format Y-m-d H:i:s.`
+
 # qase-javascript-commons@2.0.3
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -566,9 +566,9 @@ export class TestOpsReporter extends AbstractReporter {
     const year = date.getUTCFullYear();
     const month = ('0' + (date.getUTCMonth() + 1).toString()).slice(-2); // Months are zero indexed, so we add 1
     const day = ('0' + date.getUTCDate().toString()).slice(-2);
-    const hours = date.getUTCHours().toString();
-    const minutes = date.getUTCMinutes().toString();
-    const seconds = date.getUTCSeconds().toString();
+    const hours = ('0' + date.getUTCHours().toString()).slice(-2);
+    const minutes = ('0' +date.getUTCMinutes().toString()).slice(-2);
+    const seconds = ('0' +date.getUTCSeconds().toString()).slice(-2);
 
     return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
   }


### PR DESCRIPTION
release: qase-javascript-commons 2.0.4
--
Fixed an issue when the reporter created a test run: `The start time does not match the format Y-m-d H:i:s.`