### PR TITLE
release: qase-playwright 2.0.1 and qase-javascript-commons 2.0.5

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.0.5
+
+## What's new
+
+Improved logging for better debugging and error reporting.
+
 # qase-javascript-commons@2.0.4
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -567,8 +567,8 @@ export class TestOpsReporter extends AbstractReporter {
     const month = ('0' + (date.getUTCMonth() + 1).toString()).slice(-2); // Months are zero indexed, so we add 1
     const day = ('0' + date.getUTCDate().toString()).slice(-2);
     const hours = ('0' + date.getUTCHours().toString()).slice(-2);
-    const minutes = ('0' +date.getUTCMinutes().toString()).slice(-2);
-    const seconds = ('0' +date.getUTCSeconds().toString()).slice(-2);
+    const minutes = ('0' + date.getUTCMinutes().toString()).slice(-2);
+    const seconds = ('0' + date.getUTCSeconds().toString()).slice(-2);
 
     return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
   }
@@ -584,9 +584,12 @@ export class TestOpsReporter extends AbstractReporter {
 
     const acc: string[] = [];
     for (const attachment of attachments) {
+      this.logger.logDebug(`Uploading attachment: ${attachment.file_path ?? attachment.file_name}`);
+
       try {
         let data: unknown;
         if (attachment.file_path) {
+
           data = { name: attachment.file_name, value: createReadStream(attachment.file_path) };
         } else {
           if (typeof attachment.content === 'string') {

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,10 @@
+# playwright-qase-reporter@2.0.1
+
+## What's new
+
+Fixed an issue with using the `qase.attach()` method to add attachments with a file path. 
+The reporter didn't add such attachments to the test.
+
 # playwright-qase-reporter@2.0.0
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -174,16 +174,15 @@ const addMetadata = (metadata: MetadataMessage): void => {
   });
 };
 
-const addAttachment = (name: string, contentType: string, filePath?: string, body?: string | Buffer): void => {
-  const stepName = `step_attach_${uuidv4()}_${name}`;
+const addAttachment = (name: string, contentType: string, filePath?: string, body?: string | Buffer) => {
+  const stepName = filePath != undefined ? `step_attach_file_${uuidv4()}_${name}` : `step_attach_body_${uuidv4()}_${name}`;
 
   test.step(stepName, async () => {
     if (filePath) {
       await test.info().attach(stepName, {
         contentType: contentType,
-        path: filePath,
+        body: filePath,
       });
-      return;
     }
 
     if (body) {
@@ -191,7 +190,6 @@ const addAttachment = (name: string, contentType: string, filePath?: string, bod
         contentType: contentType,
         body: body,
       });
-      return;
     }
   }).catch(() => {/**/
   });


### PR DESCRIPTION
release: qase-javascript-commons 2.0.5
--
Improved logging for better debugging and error reporting.

---

release: qase-playwright 2.0.1
--
Fixed an issue with using the `qase.attach()` method to add attachments with a file path.
The reporter didn't add such attachments to the test.