### PR TITLE
release: qase-javascript-commons 2.0.6

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.0.6
+
+## What's new
+
+Fixed an issue with a race condition when the reporter added test results to the test run.
+
 # qase-javascript-commons@2.0.5
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -201,8 +201,9 @@ export class TestOpsReporter extends AbstractReporter {
     const countOfResults = this.batchSize + this.firstIndex;
 
     if (this.results.length >= countOfResults) {
-      await this.publishResults(this.results.slice(this.firstIndex, countOfResults));
+      const firstIndex = this.firstIndex;
       this.firstIndex = countOfResults;
+      await this.publishResults(this.results.slice(firstIndex, countOfResults));
     }
   }
 


### PR DESCRIPTION
release: qase-javascript-commons 2.0.6
--
Fixed an issue with a race condition when the reporter added test results to the test run.