### PR TITLE
release: qaseio 2.1.1 and qase-javascript-commons 2.0.8

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,8 +1,14 @@
+# qase-javascript-commons@2.0.8
+
+## What's new
+
+Fixed an issue with creating a test run with environment when the reporter ignored the `environment` parameter in the configuration.
+
 # qase-javascript-commons@2.0.7
 
 ## What's new
 
-Fixed an issue with creating a defect for failed tests when the report generator ignored the `defect` parameter in the configuration.
+Fixed an issue with creating a defect for failed tests when the reporter ignored the `defect` parameter in the configuration.
 
 # qase-javascript-commons@2.0.6
 

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/config/config-validation-schema.ts
+++ b/qase-javascript-commons/src/config/config-validation-schema.ts
@@ -26,7 +26,7 @@ export const configValidationSchema: JSONSchemaType<ConfigType> = {
       nullable: true,
     },
     environment: {
-      type: ['string', 'number'],
+      type: 'string',
       nullable: true,
     },
     captureLogs: {

--- a/qase-javascript-commons/src/env/env-type.ts
+++ b/qase-javascript-commons/src/env/env-type.ts
@@ -14,7 +14,7 @@ export type EnvType = {
   [EnvEnum.mode]?: `${ModeEnum}`;
   [EnvEnum.fallback]?: `${ModeEnum}`;
   [EnvEnum.debug]?: boolean;
-  [EnvEnum.environment]?: string | number;
+  [EnvEnum.environment]?: string;
   [EnvEnum.captureLogs]?: boolean;
 
   [EnvTestOpsEnum.project]?: string;

--- a/qase-javascript-commons/src/env/env-validation-schema.ts
+++ b/qase-javascript-commons/src/env/env-validation-schema.ts
@@ -35,7 +35,7 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
       nullable: true,
     },
     [EnvEnum.environment]: {
-      type: ['string', 'number'],
+      type: 'string',
       nullable: true,
     },
     [EnvEnum.captureLogs]: {

--- a/qase-javascript-commons/src/options/options-type.ts
+++ b/qase-javascript-commons/src/options/options-type.ts
@@ -30,7 +30,7 @@ export type OptionsType = {
   fallback?: `${ModeEnum}` | undefined;
   captureLogs?: boolean | undefined;
   debug?: boolean | undefined;
-  environment?: string | number | undefined;
+  environment?: string | undefined;
   testops?:
     | (RecursivePartial<TestOpsOptionsType> & AdditionalTestOpsOptionsType)
     | undefined;

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -407,7 +407,7 @@ export class QaseReporter implements ReporterInterface {
             defect,
           },
           apiClient,
-          typeof environment === 'number' ? environment : undefined,
+          environment,
         );
       }
 
@@ -418,7 +418,8 @@ export class QaseReporter implements ReporterInterface {
         return new ReportReporter(
           this.logger,
           writer,
-          typeof environment === 'number' ? environment.toString() : environment, testops.run?.id);
+          environment,
+          testops.run?.id);
       }
 
       case ModeEnum.off:

--- a/qaseio/changelog.md
+++ b/qaseio/changelog.md
@@ -1,3 +1,9 @@
+# qaseio@2.1.1
+
+## What's new
+
+Add environment API support. Now you can create, update, delete and list environments for your projects.
+
 # qaseio@2.1.0
 
 ## What's new

--- a/qaseio/package.json
+++ b/qaseio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qaseio",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Qase TMS Javascript API Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qaseio/src/qaseio.ts
+++ b/qaseio/src/qaseio.ts
@@ -15,7 +15,7 @@ import {
   DefectsApi,
   CustomFieldsApi,
   AuthorsApi,
-  Configuration,
+  Configuration, EnvironmentsApi,
 } from './generated';
 
 export type QaseApiOptionsType = {
@@ -40,6 +40,7 @@ export interface QaseApiInterface {
   defects: DefectsApi;
   customFields: CustomFieldsApi;
   authors: AuthorsApi;
+  environment: EnvironmentsApi;
 }
 
 /**
@@ -60,6 +61,7 @@ export class QaseApi implements QaseApiInterface {
   public defects: DefectsApi;
   public customFields: CustomFieldsApi;
   public authors: AuthorsApi;
+  public environment: EnvironmentsApi;
 
   /**
    * @param {QaseApiOptionsType} options
@@ -108,5 +110,6 @@ export class QaseApi implements QaseApiInterface {
     this.defects = new DefectsApi(configuration, baseUrl, transport);
     this.customFields = new CustomFieldsApi(configuration, baseUrl, transport);
     this.authors = new AuthorsApi(configuration, baseUrl, transport);
+    this.environment = new EnvironmentsApi(configuration, baseUrl, transport);
   }
 }


### PR DESCRIPTION
release: qaseio 2.1.1
--
Add environment API support. Now you can create, update, delete and list environments for your projects.

---

release: qase-javascript-commons 2.0.8
--
Fixed an issue with creating a test run with environment when the reporter ignored the `environment` parameter in the configuration.