### PR TITLE
release: qase-playwright 2.0.2

### DIFF
--- a/qase-playwright/README.md
+++ b/qase-playwright/README.md
@@ -114,6 +114,11 @@ describe('Test suite', () => {
   test(qase(2, 'This syntax is still supported'), () => {
     expect(true).toBe(true);
   });
+  
+  test('Running, but not reported to Qase', () => {
+    qase.ignore();
+    expect(true).toBe(true);
+  });
 });
 ```
 

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,17 @@
+# playwright-qase-reporter@2.0.2
+
+## What's new
+
+Added new annotation `qase.ignore()`.
+Tests marked with it will run as usual but won't appear in the Qase report.
+
+```js
+test('test', async ({ page }) => {
+  qase.ignore();
+  await page.goto('https://example.com');
+});
+```
+
 # playwright-qase-reporter@2.0.1
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.2",
-    "qase-javascript-commons": "^2.0.0",
+    "qase-javascript-commons": "^2.0.8",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -12,6 +12,7 @@ export interface MetadataMessage {
   title?: string;
   fields?: Record<string, string>;
   parameters?: Record<string, string>;
+  ignore?: boolean;
 }
 
 /**
@@ -163,6 +164,21 @@ qase.attach = function(attach: {
   const contentType = attach.contentType ?? defaultContentType;
   addAttachment(attachmentName, contentType, undefined, attach.content);
 
+  return this;
+};
+
+/**
+ * Ignore the test case result in Qase
+ * @example
+ * test('test', async ({ page }) => {
+ *   qase.ignore();
+ *   await page.goto('https://example.com');
+ * });
+ */
+qase.ignore = function() {
+  addMetadata({
+    ignore: true,
+  });
   return this;
 };
 

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -29,6 +29,7 @@ interface TestCaseMetadata {
   fields: Record<string, string>;
   parameters: Record<string, string>;
   attachments: Attachment[];
+  ignore: boolean;
 }
 
 export type PlaywrightQaseOptionsType = ConfigType;
@@ -96,6 +97,7 @@ export class PlaywrightQaseReporter implements Reporter {
       fields: {},
       parameters: {},
       attachments: [],
+      ignore: false,
     };
     const attachments: Attachment[] = [];
 
@@ -123,6 +125,10 @@ export class PlaywrightQaseReporter implements Reporter {
 
         if (message.parameters) {
           metadata.parameters = message.parameters;
+        }
+
+        if (message.ignore) {
+          metadata.ignore = message.ignore;
         }
 
         continue;
@@ -295,6 +301,11 @@ export class PlaywrightQaseReporter implements Reporter {
    */
   public async onTestEnd(test: TestCase, result: TestResult) {
     const testCaseMetadata = this.transformAttachments(result.attachments);
+
+    if (testCaseMetadata.ignore) {
+      return;
+    }
+
     const error = result.error ? PlaywrightQaseReporter.transformError(result.error) : null;
     const suites = PlaywrightQaseReporter.transformSuiteTitle(test);
     const testResult: TestResultType = {


### PR DESCRIPTION
release: qase-playwright 2.0.2
--
Added new annotation for test case ignoring `qase.ignore()`. 
This annotation will mark the test as ignored in the Qase.io test run.