### PR TITLE
release: qase-playwright 2.0.4

### DIFF
--- a/qase-playwright/README.md
+++ b/qase-playwright/README.md
@@ -101,22 +101,32 @@ import { qase } from 'playwright-qase-reporter';
 describe('Test suite', () => {
   test('Simple test', () => {
     qase.id(1);
-    qase.title('Example of simple test')
+    qase.title('Example of simple test');
     expect(true).toBe(true);
   });
 
   test('Test with annotated fields', () => {
     qase.id(2);
-    qase.fields({ 'severity': 'high', 'priority': 'medium' })
+    qase.fields({ 'severity': 'high', 'priority': 'medium' });
     expect(true).toBe(true);
   });
 
   test(qase(2, 'This syntax is still supported'), () => {
     expect(true).toBe(true);
   });
-  
+
   test('Running, but not reported to Qase', () => {
     qase.ignore();
+    expect(true).toBe(true);
+  });
+
+  test('Test with steps', async () => {
+    await test.step('Step 1', async () => {
+      expect(true).toBe(true);
+    });
+    await test.step('Step 2', async () => {
+      expect(true).toBe(true);
+    });
     expect(true).toBe(true);
   });
 });

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,17 @@
+# playwright-qase-reporter@2.0.4
+
+## What's new
+
+Added new annotation `qase.comment()`.
+Tests marked with it will be reported with the specified comment in the Qase.
+
+```js
+test('test', async ({ page }) => {
+  qase.comment("Custom comment");
+  await page.goto('https://example.com');
+});
+```
+
 # playwright-qase-reporter@2.0.3
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -14,6 +14,7 @@ export interface MetadataMessage {
   parameters?: Record<string, string>;
   ignore?: boolean;
   suite?: string;
+  comment?: string;
 }
 
 /**
@@ -195,6 +196,22 @@ qase.ignore = function() {
 qase.suite = function(value: string) {
   addMetadata({
     suite: value,
+  });
+  return this;
+};
+
+/**
+ * Set a comment for the test case
+ * @param {string} value
+ * @example
+ * test('test', async ({ page }) => {
+ *    qase.comment("Comment");
+ *    await page.goto('https://example.com');
+ * });
+ */
+qase.comment = function(value: string) {
+  addMetadata({
+    comment: value,
   });
   return this;
 };

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -31,6 +31,7 @@ interface TestCaseMetadata {
   attachments: Attachment[];
   ignore: boolean;
   suite: string;
+  comment: string;
 }
 
 export type PlaywrightQaseOptionsType = ConfigType;
@@ -100,6 +101,7 @@ export class PlaywrightQaseReporter implements Reporter {
       attachments: [],
       ignore: false,
       suite: '',
+      comment: '',
     };
     const attachments: Attachment[] = [];
 
@@ -135,6 +137,10 @@ export class PlaywrightQaseReporter implements Reporter {
 
         if (message.suite) {
           metadata.suite = message.suite;
+        }
+
+        if (message.comment) {
+          metadata.comment = message.comment;
         }
 
         continue;
@@ -314,6 +320,22 @@ export class PlaywrightQaseReporter implements Reporter {
 
     const error = result.error ? PlaywrightQaseReporter.transformError(result.error) : null;
     const suites = testCaseMetadata.suite != '' ? [testCaseMetadata.suite] : PlaywrightQaseReporter.transformSuiteTitle(test);
+
+    let message: string | null = null;
+    if (testCaseMetadata.comment !== '') {
+      message = testCaseMetadata.comment;
+    }
+
+    if (error) {
+      if (message) {
+        message += '\n\n';
+      } else {
+        message = '';
+      }
+
+      message += error.message;
+    }
+
     const testResult: TestResultType = {
       attachments: testCaseMetadata.attachments,
       author: null,
@@ -329,7 +351,7 @@ export class PlaywrightQaseReporter implements Reporter {
       },
       fields: testCaseMetadata.fields,
       id: uuidv4(),
-      message: error === null ? null : error.message,
+      message: message,
       muted: false,
       params: testCaseMetadata.parameters,
       relations: {


### PR DESCRIPTION
feature: add `qase.comment` annotation
--
Tests marked with it will be reported with the specified comment in the Qase.

Implement #590

---

docs: update examples
--
Add the example with steps