### PR TITLE
release: qase-testcafe 2.0.0

### DIFF
--- a/qase-testcafe/README.md
+++ b/qase-testcafe/README.md
@@ -2,11 +2,10 @@
 
 Publish results simple and easy.
 
-The TestCafe reporter is currently in the closed beta stage.
-To install the latest beta version, run:
+To install the latest version, run:
 
 ```sh
-npm install -D testcafe-reporter-qase@beta
+npm install -D testcafe-reporter-qase
 ```
 
 ## Updating from v1

--- a/qase-testcafe/changelog.md
+++ b/qase-testcafe/changelog.md
@@ -1,3 +1,16 @@
+# qase-testcafe@2.0.0
+
+## What's new
+
+This is the first release in the 2.x series of the TestCafe reporter.
+It brings a new annotation syntax with test parametrization and field values,
+new and more flexible configs, uploading results in parallel with running tests,
+and other powerful features.
+
+This changelog entry will be updated soon.
+For more information about the new features and a guide for migration from v1, refer to the
+[reporter documentation](https://github.com/qase-tms/qase-javascript/tree/main/qase-testcafe#readme)
+
 # qase-testcafe@2.0.0-beta.2
 
 ## What's new

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-qase",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0",
   "description": "Qase TMS TestCafe Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -37,10 +37,10 @@
     "test": "jest --passWithNoTests",
     "clean": "rm -rf dist"
   },
-  "author": "Parviz Khavari <havaripa@gmail.com>",
+  "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0-beta.8",
+    "qase-javascript-commons": "^2.0.9",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
release: qase-testcafe 2.0.0
--
This is the first release in the 2.x series of the TestCafe reporter. It brings a new annotation syntax with test parametrization and field values, new and more flexible configs, uploading results in parallel with running tests, and other powerful features.