### PR TITLE
release: qase-newman 2.0.0

### DIFF
--- a/qase-newman/README.md
+++ b/qase-newman/README.md
@@ -2,11 +2,10 @@
 
 Publish results simple and easy.
 
-The Newman reporter is currently in the closed beta stage.
-To install the latest beta version, run:
+To install the latest version, run:
 
 ```bash
-npm install newman-reporter-qase@beta
+npm install newman-reporter-qase
 ```
 
 ## Example of usage

--- a/qase-newman/changelog.md
+++ b/qase-newman/changelog.md
@@ -1,3 +1,15 @@
+# qase-newman@2.0.0
+
+## What's new
+
+This is the first release in the 2.x series of the Newman reporter.
+It brings new and more flexible configs, uploading results in parallel with running tests,
+and other powerful features.
+
+This changelog entry will be updated soon.
+For more information about the new features and a guide for migration from v1, refer to the
+[reporter documentation](https://github.com/qase-tms/qase-javascript/tree/main/qase-newman#readme)
+
 # qase-newman@2.0.0-beta.2
 
 ## What's new

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-qase",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0",
   "description": "Qase TMS Newman Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -36,10 +36,10 @@
     "test": "jest --passWithNoTests",
     "clean": "rm -rf dist"
   },
-  "author": "Parviz Khavari <havaripa@gmail.com>",
+  "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.8",
+    "qase-javascript-commons": "^2.0.9",
     "semver": "^7.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
release: qase-newman 2.0.0
--
This is the first release in the 2.x series of the Newman reporter. It brings new and more flexible configs, uploading results in parallel with running tests, and other powerful features.