### PR TITLE
fix: fix an issue with sending test results duplicates

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,14 @@
+# qase-javascript-commons@2.0.10
+
+## What's new
+
+Fixed an issue with sending test results duplicates when we use the `qase-cypress` reporter.
+Now the reporter will send the test results only once.
+
+The Cypress calls the `publish` method multiple times for the same test results because of the Cypress architecture.
+It calls the `publish` method for each test file.
+
+
 # qase-javascript-commons@2.0.9
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -310,6 +310,9 @@ export class TestOpsReporter extends AbstractReporter {
       await this.publishResults(this.results.slice(this.firstIndex));
     }
 
+    // Clear results because we don't need to send them again then we use Cypress reporter
+    this.results.length = 0;
+
     if (!this.run.complete) {
       return;
     }


### PR DESCRIPTION
fix: fix an issue with sending test results duplicates
--
Fixed an issue with sending test results duplicates when we use the `qase-cypress` reporter. Now the reporter will send the test results only once.