### PR TITLE
feature: add a signature to the test results

### DIFF
--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -234,7 +234,7 @@ export class Storage {
       params: {},
       relations: relations,
       run_id: null,
-      signature: '',
+      signature: this.getSignature(pickle, metadata.ids),
       steps: this.convertSteps(pickle.steps, tc),
       testops_id: metadata.ids.length > 0 ? metadata.ids : null,
       id: tcs.id,
@@ -352,5 +352,22 @@ export class Storage {
     }
 
     return metadata;
+  }
+
+  /**
+   * @param {Pickle} pickle
+   * @param {number[]} ids
+   * @private
+   */
+  private getSignature(pickle: Pickle, ids: number[]): string {
+    let signature = pickle.uri.split('/').join('::')
+      + '::'
+      + pickle.name.toLowerCase().replace(/\s/g, '_');
+
+    if (ids.length > 0) {
+      signature += '::' + ids.join('::');
+    }
+
+    return signature;
   }
 }

--- a/qase-newman/src/reporter.ts
+++ b/qase-newman/src/reporter.ts
@@ -160,7 +160,7 @@ export class NewmanQaseReporter {
           params: {},
           relations: relation,
           run_id: null,
-          signature: '',
+          signature: this.getSignature(suites, item.name, ids),
           steps: [],
           testops_id: ids.length > 0 ? ids : null,
           id: item.id,
@@ -228,5 +228,27 @@ export class NewmanQaseReporter {
         process.exit = _exit;
       };
     }
+  }
+
+  /**
+   * @param {string[]} suites
+   * @param {string} title
+   * @param {number[]} ids
+   * @private
+   */
+  private getSignature(suites: string[], title: string, ids: number[]) {
+    let signature = '';
+
+    for (const suite of suites) {
+      signature += suite.toLowerCase().replace(/\s/g, '_') + '::';
+    }
+
+    signature += title.toLowerCase().replace(/\s/g, '_');
+
+    if (ids.length > 0) {
+      signature += '::' + ids.join('::');
+    }
+
+    return signature;
   }
 }

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -367,7 +367,7 @@ export class PlaywrightQaseReporter implements Reporter {
         },
       },
       run_id: null,
-      signature: suites.join(':'),
+      signature: '',
       steps: this.transformSteps(result.steps, null),
       testops_id: null,
       title: testCaseMetadata.title === '' ? test.title : testCaseMetadata.title,
@@ -393,6 +393,8 @@ export class PlaywrightQaseReporter implements Reporter {
         this.qaseTestWithOldAnnotation.set(path, ids);
       }
     }
+
+    testResult.signature = this.getSignature(suites, testCaseMetadata.parameters, testResult.testops_id ?? []);
 
     await this.reporter.addTestResult(testResult);
   }
@@ -434,5 +436,33 @@ export class PlaywrightQaseReporter implements Reporter {
       mime_type: logMimeType,
       content: content,
     } as Attachment;
+  }
+
+  /**
+   * @param {string[]} suites
+   * @param {Record<string, string>} parameters
+   * @param {number[]} ids
+   * @private
+   */
+  private getSignature(suites: string[], parameters: Record<string, string>, ids: number[]): string {
+    let signature = suites.map(suite =>
+      suite.toLowerCase()
+        .replace('/', '::')
+        .replace(/\s/g, '_'),
+    ).join('::');
+
+    if (ids.length > 0) {
+      signature += '::' + ids.join('::');
+    }
+
+    if (Object.keys(parameters).length !== 0) {
+      signature += '::';
+    }
+
+    signature += Object.entries(parameters)
+      .map(([key, value]) => `{${key}:${value}}`)
+      .join('::');
+
+    return signature;
   }
 }

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -170,7 +170,7 @@ export class TestcafeQaseReporter {
    * @returns {Promise<void>}
    */
   public startTestRun = (): void => {
-      this.reporter.startTestRun();
+    this.reporter.startTestRun();
   };
 
   /**
@@ -210,7 +210,7 @@ export class TestcafeQaseReporter {
         },
       },
       run_id: null,
-      signature: `${testRunInfo.fixture.name}::${title}`,
+      signature: this.getSignature(testRunInfo.fixture, title, metadata[metadataEnum.id], metadata[metadataEnum.parameters]),
       steps: [],
       id: uuidv4(),
       testops_id: metadata[metadataEnum.id].length > 0 ? metadata[metadataEnum.id] : null,
@@ -259,5 +259,42 @@ export class TestcafeQaseReporter {
     }
 
     return metadata;
+  }
+
+  /**
+   * @param {FixtureType} fixture
+   * @param {string} title
+   * @param {number[]} ids
+   * @param {Record<string, string>} parameters
+   * @private
+   */
+  private getSignature(fixture: FixtureType, title: string, ids: number[], parameters: Record<string, string>) {
+    const executionPath = process.cwd() + '/';
+    const path = fixture.path?.replace(executionPath, '') ?? '';
+    let signature = '';
+
+    if (path != '') {
+      signature += path.split('/').join('::') + '::';
+    }
+
+    signature += fixture.name.toLowerCase()
+        .replace(/\s/g, '_')
+      + '::'
+      + title.toLowerCase()
+        .replace(/\s/g, '_');
+
+    if (ids.length > 0) {
+      signature += `::${ids.join('::')}`;
+    }
+
+    if (Object.keys(parameters).length > 0) {
+      signature += '::';
+    }
+
+    signature += Object.entries(parameters)
+      .map(([key, value]) => `{${key}:${value}}`)
+      .join('::');
+
+    return signature;
   }
 }


### PR DESCRIPTION
feature: add a signature to the test results
--
Implement a method which constructs the signature to each test result. 
It takes the file path, the suites, the qase ids and the parameters.