### PR TITLE
feature: improve log errors and show a link of test result

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,15 @@
+# qase-javascript-commons@2.0.11
+
+## What's new
+
+- Improved logging for better debugging and error reporting.
+
+- Show the link to the test run in the console output when the test is failed.
+
+```text
+[INFO] qase: See why this test failed: https://app.qase.io/run/DEMO/dashboard/123?status=%5B2%5D&search=5%20-%206%20=%20-2
+```
+
 # qase-javascript-commons@2.0.10
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -232,6 +232,8 @@ export class QaseReporter implements ReporterInterface {
    */
   public async addTestResult(result: TestResultType) {
     if (!this.disabled) {
+      await this.startTestRunOperation;
+
       this.logTestItem(result);
 
       if (this.useFallback) {
@@ -410,6 +412,7 @@ export class QaseReporter implements ReporterInterface {
           apiClient,
           environment,
           rootSuite,
+          api.host,
         );
       }
 

--- a/qase-javascript-commons/src/utils/qase-error.ts
+++ b/qase-javascript-commons/src/utils/qase-error.ts
@@ -1,6 +1,6 @@
-export type ErrorOptionsType = {
+export interface ErrorOptionsType {
   cause?: unknown;
-};
+}
 
 export interface QaseErrorInterface extends Error {
   cause?: unknown;

--- a/qaseio/changelog.md
+++ b/qaseio/changelog.md
@@ -1,3 +1,9 @@
+# qaseio@2.1.4
+
+## What's new
+
+Fix an issue with base url for enterprise customers.   
+
 # qaseio@2.1.3
 
 ## What's new

--- a/qaseio/package.json
+++ b/qaseio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qaseio",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Qase TMS Javascript API Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qaseio/src/qaseio.ts
+++ b/qaseio/src/qaseio.ts
@@ -101,7 +101,7 @@ export class QaseApi implements QaseApiInterface {
       if (host == 'qase.io') {
         configuration.basePath = `https://api.${host}`;
       } else {
-        configuration.basePath = host;
+        configuration.basePath = `https://${host}`;
       }
     }
 


### PR DESCRIPTION
feature: improve errors
--
Improve the display of error messages that occur when using the API calls. Messages will contain less unnecessary information and will be more informative for users.

[#562]

---

fix: base url for enterprise customers
--
Fix an issue with base url for enterprise customers.

---

feature: show a link if a test is failed
--
Show the link to the test result in the Qase then the test is failed.

---

release: qase-javascript-commons 2.0.11
--
Bump the version of the package and update the changelog