### PR TITLE
release: qase-javascript-commons 2.0.13

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.0.13
+
+## What's new
+
+- If a plan ID is specified then when creating a test run it also specifies the plan ID.
+- If a test run ID is specified then the reporter won't check for the existence of a test run.
+
 # qase-javascript-commons@2.0.12
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -243,12 +243,8 @@ export class TestOpsReporter extends AbstractReporter {
    */
   private async checkOrCreateTestRun(): Promise<void> {
     if (this.run.id !== undefined) {
-
-      this.logger.logDebug('Check test run');
-
-      await this.checkRun(this.run.id);
-
       this.isTestRunReady = true;
+
       return;
     }
 
@@ -576,23 +572,6 @@ export class TestOpsReporter extends AbstractReporter {
 
   private logEmptyStep(testTitle: string): void {
     this.logger.log(chalk`{magenta Test '${testTitle}' has empty action in step. The reporter will mark this step as unnamed step.}`);
-  }
-
-  /**
-   * @param {number} runId
-   * @returns {Promise<void>}
-   * @private
-   */
-  private async checkRun(runId: number): Promise<void> {
-    try {
-      const resp = await this.api.runs.getRun(this.projectCode, runId);
-
-      this.logger.log(
-        `Get run result on checking run "${String(resp.data.result?.id)}"`,
-      );
-    } catch (error) {
-      throw this.processError(error, 'Error on checking run');
-    }
   }
 
   /**

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -118,10 +118,15 @@ export class TestOpsReporter extends AbstractReporter {
    */
   private run: TestOpsRunType;
   /**
-   * @type { number | undefined}
+   * @type { string | undefined}
    * @private
    */
   private readonly environment: string | undefined;
+  /**
+   * @type { number | undefined}
+   * @private
+   */
+  private readonly planId: number | undefined;
   /**
    * @type {TestResultType[]}
    * @private
@@ -178,6 +183,7 @@ export class TestOpsReporter extends AbstractReporter {
       project,
       uploadAttachments,
       run,
+      plan
     } = options;
 
     super(logger);
@@ -187,6 +193,7 @@ export class TestOpsReporter extends AbstractReporter {
     this.isUploadAttachments = uploadAttachments;
     this.run = { complete: true, ...run };
     this.environment = environment;
+    this.planId = plan.id;
     this.batchSize = options.batch?.size ?? defaultChunkSize;
     this.useV2 = options.useV2 ?? false;
     this.defect = options.defect ?? false;
@@ -611,6 +618,10 @@ export class TestOpsReporter extends AbstractReporter {
 
       if (environment !== undefined) {
         runObject.environment_id = environment;
+      }
+
+      if (this.planId){
+        runObject.plan_id = this.planId;
       }
 
       const { data } = await this.api.runs.createRun(


### PR DESCRIPTION
fix: use a plan ID
--
If the plan ID is specified then when creating a test run it also specifies the plan ID.

---

refactor: remove a checking a test run
--
If a test run ID is specified then the reporter won't check for the existence of a test run.

---

docs: update changelog and bump version
--