### PR TITLE
fix: issues with sending results and completing a test run in the Cypress reporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,6 @@
         "qase-mocha",
         "./examples/*"
       ],
-      "dependencies": {
-        "mocha": "^10.6.0"
-      },
       "devDependencies": {
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
@@ -32,6 +29,7 @@
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-import": "^2.27.5",
         "jest": "^29.5.0",
+        "mocha": "^10.6.0",
         "prettier": "^2.8.8",
         "ts-jest": "^29.1.0",
         "typescript": "^5.4.5"
@@ -57,6 +55,47 @@
         "eslint-plugin-cypress": "^2.13.3"
       }
     },
+    "examples/cypress/node_modules/cypress-qase-reporter": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/cypress-qase-reporter/-/cypress-qase-reporter-2.0.3.tgz",
+      "integrity": "sha512-+k596UDrZ0Z0oq6xtWkqjDp0Kg3lS4PhY49uij8y6zBECF2PyI20CQd8uJb+wL9BNxVojK7bczoJ1oCbVZwKAg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "qase-javascript-commons": "^2.0.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "cypress": ">=8.0.0"
+      }
+    },
+    "examples/cypress/node_modules/qase-javascript-commons": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.0.13.tgz",
+      "integrity": "sha512-ER+q5kTrevo8jKzoHPDeFUOzdDt7ZLqL1ek6Py6oGlR5VnJRZegSt/BfJvXhbFcn2PLa5si/vaNSr/rnGhbF8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "chalk": "^4.1.2",
+        "child-process-ext": "^3.0.2",
+        "env-schema": "^5.2.0",
+        "form-data": "^4.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.33",
+        "qaseio": "~2.2.0",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "examples/jest": {
       "name": "examples-jest",
       "devDependencies": {
@@ -71,7 +110,7 @@
       "name": "examples-mocha",
       "devDependencies": {
         "mocha": "^10.2.0",
-        "mocha-qase-reporter": "^1.0.0"
+        "mocha-qase-reporter": "^1.0.0-beta.1"
       }
     },
     "examples/newman": {
@@ -2102,7 +2141,6 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -3527,7 +3565,6 @@
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -15065,12 +15102,35 @@
         "@cucumber/cucumber": ">=7.0.0"
       }
     },
-    "qase-cypress": {
-      "name": "cypress-qase-reporter",
-      "version": "2.0.2",
+    "qase-cucumberjs/node_modules/qase-javascript-commons": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.0.13.tgz",
+      "integrity": "sha512-ER+q5kTrevo8jKzoHPDeFUOzdDt7ZLqL1ek6Py6oGlR5VnJRZegSt/BfJvXhbFcn2PLa5si/vaNSr/rnGhbF8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.0.0",
+        "ajv": "^8.12.0",
+        "chalk": "^4.1.2",
+        "child-process-ext": "^3.0.2",
+        "env-schema": "^5.2.0",
+        "form-data": "^4.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.33",
+        "qaseio": "~2.2.0",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "qase-cypress": {
+      "name": "cypress-qase-reporter",
+      "version": "2.1.0-beta.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "qase-javascript-commons": "~2.1.0-beta.1",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -15090,7 +15150,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.0.11",
+      "version": "2.1.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -15102,7 +15162,7 @@
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "mime-types": "^2.1.33",
-        "qaseio": "^2.1.3",
+        "qaseio": "~2.2.0",
         "strip-ansi": "^6.0.1",
         "uuid": "^9.0.0"
       },
@@ -15167,9 +15227,32 @@
         "jest": ">=28.0.0"
       }
     },
+    "qase-jest/node_modules/qase-javascript-commons": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.0.13.tgz",
+      "integrity": "sha512-ER+q5kTrevo8jKzoHPDeFUOzdDt7ZLqL1ek6Py6oGlR5VnJRZegSt/BfJvXhbFcn2PLa5si/vaNSr/rnGhbF8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "chalk": "^4.1.2",
+        "child-process-ext": "^3.0.2",
+        "env-schema": "^5.2.0",
+        "form-data": "^4.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.33",
+        "qaseio": "~2.2.0",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
-      "version": "1.0.0",
+      "version": "1.0.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "deasync-promise": "^1.0.1",
@@ -15189,9 +15272,6 @@
       },
       "engines": {
         "node": ">=14"
-      },
-      "peerDependencies": {
-        "cypress": ">=8.0.0"
       }
     },
     "qase-mocha/node_modules/@types/node": {
@@ -15202,6 +15282,29 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "qase-mocha/node_modules/qase-javascript-commons": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.0.13.tgz",
+      "integrity": "sha512-ER+q5kTrevo8jKzoHPDeFUOzdDt7ZLqL1ek6Py6oGlR5VnJRZegSt/BfJvXhbFcn2PLa5si/vaNSr/rnGhbF8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "chalk": "^4.1.2",
+        "child-process-ext": "^3.0.2",
+        "env-schema": "^5.2.0",
+        "form-data": "^4.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.33",
+        "qaseio": "~2.2.0",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "qase-newman": {
@@ -15228,6 +15331,29 @@
         "newman": ">=5.3.0"
       }
     },
+    "qase-newman/node_modules/qase-javascript-commons": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.0.13.tgz",
+      "integrity": "sha512-ER+q5kTrevo8jKzoHPDeFUOzdDt7ZLqL1ek6Py6oGlR5VnJRZegSt/BfJvXhbFcn2PLa5si/vaNSr/rnGhbF8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "chalk": "^4.1.2",
+        "child-process-ext": "^3.0.2",
+        "env-schema": "^5.2.0",
+        "form-data": "^4.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.33",
+        "qaseio": "~2.2.0",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "qase-playwright": {
       "name": "playwright-qase-reporter",
       "version": "2.0.6",
@@ -15248,6 +15374,29 @@
       },
       "peerDependencies": {
         "@playwright/test": ">=1.16.3"
+      }
+    },
+    "qase-playwright/node_modules/qase-javascript-commons": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.0.13.tgz",
+      "integrity": "sha512-ER+q5kTrevo8jKzoHPDeFUOzdDt7ZLqL1ek6Py6oGlR5VnJRZegSt/BfJvXhbFcn2PLa5si/vaNSr/rnGhbF8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "chalk": "^4.1.2",
+        "child-process-ext": "^3.0.2",
+        "env-schema": "^5.2.0",
+        "form-data": "^4.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.33",
+        "qaseio": "~2.2.0",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "qase-testcafe": {
@@ -15271,8 +15420,31 @@
         "testcafe": ">=2.0.0"
       }
     },
+    "qase-testcafe/node_modules/qase-javascript-commons": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.0.13.tgz",
+      "integrity": "sha512-ER+q5kTrevo8jKzoHPDeFUOzdDt7ZLqL1ek6Py6oGlR5VnJRZegSt/BfJvXhbFcn2PLa5si/vaNSr/rnGhbF8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "chalk": "^4.1.2",
+        "child-process-ext": "^3.0.2",
+        "env-schema": "^5.2.0",
+        "form-data": "^4.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.33",
+        "qaseio": "~2.2.0",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "qaseio": {
-      "version": "2.1.5",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.28.0",

--- a/qase-cypress/README.md
+++ b/qase-cypress/README.md
@@ -8,19 +8,52 @@ To install the latest version, run:
 npm install -D cypress-qase-reporter
 ```
 
-## Updating from v1
+## Updating from v1 to v2.1
 
-You can update a test project from using version 1 to version 2 in several steps:
+You can update a test project from using version 1 to version 2.1 in several steps:
 
-1.  Change import paths:
+1. Change import paths:
 
-    ```diff
-    - import { qase } from 'cypress-qase-reporter/dist/mocha'
-    + import { qase } from 'cypress-qase-reporter/mocha'
-    ```
+   ```diff
+   - import { qase } from 'cypress-qase-reporter/dist/mocha'
+   + import { qase } from 'cypress-qase-reporter/mocha'
+   ```
+2. Update reporter configuration in `cypress.config.js` and/or environment variables —
+   see the [configuration reference](#configuration) below.
 
-2.  Update reporter configuration in `cypress.config.js` and/or environment variables —
-    see the [configuration reference](#configuration) below.
+3. Set the hooks in the `e2e` section in `cypress.config.js`:
+
+   ```diff
+   ...
+   e2e: {
+        setupNodeEvents(on, config) { 
+          + require('cypress-qase-reporter/plugin')(on, config);
+        }
+   }
+   ...
+   ```
+
+   If you are override before:run or after:run hooks, use this:
+
+   ```diff  
+   const { beforeRunHook, afterRunHook } = require('cypress-qase-reporter/hooks');
+    
+   ...
+   e2e: {
+       setupNodeEvents(on, config) {
+           + on('before:run', async () => {
+               + console.log('override before:run');
+               + await beforeRunHook(config);
+           + });
+
+           + on('after:run', async () => {
+               + console.log('override after:run');
+               + await afterRunHook(config);
+           + });
+       },
+   },
+   ...
+   ```
 
 ## Getting started
 
@@ -41,20 +74,20 @@ import { qase } from 'cypress-qase-reporter/mocha';
 
 describe('My First Test', () => {
   qase(1,
-          it('Several ids', () => {
-            expect(true).to.equal(true);
-          })
+    it('Several ids', () => {
+      expect(true).to.equal(true);
+    })
   );
   // a test can check multiple test cases
   qase([2, 3],
-          it('Correct test', () => {
-            expect(true).to.equal(true);
-          })
+    it('Correct test', () => {
+      expect(true).to.equal(true);
+    })
   );
   qase(4,
-          it.skip('Skipped test', () => {
-            expect(true).to.equal(true);
-          })
+    it.skip('Skipped test', () => {
+      expect(true).to.equal(true);
+    })
   );
 });
 ```
@@ -86,11 +119,13 @@ https://app.qase.io/run/QASE_PROJECT_CODE
 ## Configuration
 
 Qase Cypress reporter can be configured in multiple ways:
+
 - by adding configuration block in `cypress.config.js`,
 - using a separate config file `qase.config.json`,
 - using environment variables (they override the values from the configuration files).
 
-For a full list of configuration options, see the [Configuration reference](../qase-javascript-commons/README.md#configuration).
+For a full list of configuration options, see
+the [Configuration reference](../qase-javascript-commons/README.md#configuration).
 
 Example `cypress.config.js` config:
 

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,22 @@
+# cypress-qase-reporter@2.1.0-beta.1
+
+## What's new
+
+- fixed an issue with the reporter completing the test run before all results are sent to Qase
+- fixed an issue with the reporter not sending all results to Qase
+
+Need to add the following to the `cypress.config.js` file:
+
+```diff
+...
+  e2e: {
+    setupNodeEvents(on, config) {
++      require('cypress-qase-reporter/plugin')(on, config);
+    }
+  }
+...
+```
+
 # cypress-qase-reporter@2.0.3
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.0.3",
+  "version": "2.1.0-beta.1",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -10,7 +10,8 @@
     ".": "./dist/index.js",
     "./mocha": "./dist/mocha.js",
     "./reporter": "./dist/reporter.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./plugin": "./dist/plugin.js"
   },
   "typesVersions": {
     "*": {
@@ -44,7 +45,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "^2.0.0",
+    "qase-javascript-commons": "~2.1.0-beta.1",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {
@@ -58,5 +59,8 @@
     "jest": "^29.5.0",
     "mocha": "^10.2.0",
     "ts-jest": "^29.1.0"
-  }
+  },
+  "files": [
+    "plugin.js"
+  ]
 }

--- a/qase-cypress/src/child.js
+++ b/qase-cypress/src/child.js
@@ -1,7 +1,15 @@
+import { QaseReporter } from 'qase-javascript-commons';
+
+
+const options = JSON.parse(process.env?.reporterConfig);
+const results = JSON.parse(process.env?.results);
+
+
 const runChild = async () => {
-  setTimeout(() => {
-    // do nothing
-  }, 10000);
-}
+  const reporter = QaseReporter.getInstance(options);
+  reporter.setTestResults(results);
+
+  await reporter.publish();
+};
 
 runChild();

--- a/qase-cypress/src/hooks.ts
+++ b/qase-cypress/src/hooks.ts
@@ -1,0 +1,48 @@
+/// <reference types="cypress" />
+
+import { composeOptions, ConfigLoader, QaseReporter } from 'qase-javascript-commons';
+import { configSchema } from './configSchema';
+import PluginConfigOptions = Cypress.PluginConfigOptions;
+
+async function beforeRunHook(options: PluginConfigOptions) {
+  const configLoader = new ConfigLoader(configSchema);
+  const config = configLoader.load();
+  const { reporterOptions } = options;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const { ...composedOptions } = composeOptions(reporterOptions['cypressQaseReporterReporterOptions'], config);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  const reporter = QaseReporter.getInstance({
+    ...composedOptions,
+    frameworkPackage: 'cypress',
+    frameworkName: 'cypress',
+    reporterName: 'cypress-qase-reporter',
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  await reporter.startTestRunAsync();
+}
+
+async function afterRunHook(options: PluginConfigOptions) {
+
+  const configLoader = new ConfigLoader(configSchema);
+  const config = configLoader.load();
+  const { reporterOptions } = options;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const { ...composedOptions } = composeOptions(reporterOptions['cypressQaseReporterReporterOptions'], config);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  const reporter = QaseReporter.getInstance({
+    ...composedOptions,
+    frameworkPackage: 'cypress',
+    frameworkName: 'cypress',
+    reporterName: 'cypress-qase-reporter',
+  });
+
+  await reporter.complete();
+}
+
+module.exports = {
+  beforeRunHook,
+  afterRunHook,
+};

--- a/qase-cypress/src/plugin.js
+++ b/qase-cypress/src/plugin.js
@@ -1,0 +1,11 @@
+import { afterRunHook, beforeRunHook } from './hooks';
+
+module.exports = function (on, config) {
+  on('before:run', async () => {
+    await beforeRunHook(config);
+  });
+
+  on('after:run', async () => {
+    await afterRunHook(config);
+  });
+};

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.1.0-beta.1
+
+## What's new
+
+- update a `InternalReporterInterface`. Added a new methods `sendResults` and `complete` to send the results and complete the test run.
+- add `StateManager` class to manage and share the state of the reporter between the different instances of the reporter.
+
 # qase-javascript-commons@2.0.13
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.0.13",
+  "version": "2.1.0-beta.1",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/abstract-reporter.ts
+++ b/qase-javascript-commons/src/reporters/abstract-reporter.ts
@@ -12,6 +12,10 @@ export interface InternalReporterInterface {
   getTestResults(): TestResultType[];
 
   setTestResults(results: TestResultType[]): void;
+
+  sendResults(): Promise<void>;
+
+  complete(): Promise<void>;
 }
 
 /**
@@ -43,6 +47,16 @@ export abstract class AbstractReporter implements InternalReporterInterface {
   abstract startTestRun(): Promise<void>;
 
   /**
+   * @returns {Promise<void>}
+   */
+  abstract complete(): Promise<void>;
+
+  /**
+   * @returns {Promise<void>}
+   */
+  abstract sendResults(): Promise<void>;
+
+  /**
    * @protected
    * @param {LoggerInterface} logger
    */
@@ -54,7 +68,11 @@ export abstract class AbstractReporter implements InternalReporterInterface {
    * @returns {TestResultType[]}
    */
   public getTestResults(): TestResultType[] {
-    return this.results;
+    const results = this.results;
+
+    this.results = [];
+
+    return results;
   }
 
   /**

--- a/qase-javascript-commons/src/state/state.ts
+++ b/qase-javascript-commons/src/state/state.ts
@@ -1,0 +1,68 @@
+import { ModeEnum } from '../options';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+
+export interface StateModel {
+  RunId: number | undefined;
+  Mode: ModeEnum | undefined;
+  IsModeChanged: boolean | undefined;
+}
+
+const statePath = 'reporterState.json';
+
+export class StateManager {
+
+  static getState(): StateModel {
+    let state: StateModel = {
+      RunId: undefined,
+      Mode: undefined,
+      IsModeChanged: undefined,
+    };
+
+    try {
+      const data = readFileSync(statePath, 'utf8');
+      state = JSON.parse(data) as StateModel;
+    } catch (err) {
+      console.error('Error reading state file:', err);
+    }
+    return state;
+  }
+
+  static setRunId(runId: number): void {
+    const state = this.getState();
+    state.RunId = runId;
+    this.setState(state);
+  }
+
+  static setMode(mode: ModeEnum): void {
+    const state = this.getState();
+    state.Mode = mode;
+    this.setState(state);
+  }
+
+  static setIsModeChanged(isModeChanged: boolean): void {
+    const state = this.getState();
+    state.IsModeChanged = isModeChanged;
+    this.setState(state);
+  }
+
+  static setState(state: StateModel): void {
+    try {
+      const data = JSON.stringify(state);
+      writeFileSync(statePath, data);
+    } catch (err) {
+      console.error('Error writing state file:', err);
+    }
+  }
+
+  static clearState(): void {
+    try {
+      unlinkSync(statePath);
+    } catch (err) {
+      console.error('Error clearing state file:', err);
+    }
+  }
+
+  static isStateExists(): boolean {
+    return existsSync(statePath);
+  }
+}

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -14,6 +14,7 @@ import {
 } from 'qase-javascript-commons';
 import deasyncPromise from 'deasync-promise';
 import { extname, join } from 'node:path';
+import { v4 as uuidv4 } from 'uuid';
 
 const Events = Runner.constants;
 
@@ -70,6 +71,7 @@ export class MochaQaseReporter extends reporters.Base {
     });
 
     if (options.parallel) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       options.require = [...(options.require ?? []), resolveParallelModeSetupFile()];
     } else {
       this.applyListeners();
@@ -153,7 +155,7 @@ export class MochaQaseReporter extends reporters.Base {
       run_id: null,
       signature: this.getSignature(test, ids),
       steps: this.currentTest.steps,
-      id: test.id,
+      id: uuidv4(),
       execution: {
         status: test.state
           ? MochaQaseReporter.statusMap[test.state]


### PR DESCRIPTION
fix: issues with sending results and completing a test run
--
- fixed an issue with the reporter completing the test run before all results are sent to Qase
- fixed an issue with the reporter not sending all results to Qase

Fixes #640 #558

---

feature: share a state between the different instances of the reporter
--
- update a `InternalReporterInterface`. Added a new methods `sendResults` and `complete` to send the results and complete the test run.
- add `StateManager` class to manage and share the state of the reporter between the different instances of the reporter.


---
Completely redesigned the reporter's workflow:
 - Hooks that are executed before and after all tests will be used to create and complete test runs.
 - The reporter's state will share between all instances of reporter through a file.
 
Component interaction diagram:
![image](https://github.com/user-attachments/assets/e14bf2df-37cc-4573-bee0-d1bff8592ab4)
