### PR TITLE
docs: update code examples in Cypress migration guide

### DIFF
--- a/qase-cypress/README.md
+++ b/qase-cypress/README.md
@@ -2,57 +2,70 @@
 
 Publish results simple and easy.
 
-To install the latest version, run:
+## Installation
+
+To install the latest release version (2.0.x), run:
 
 ```sh
 npm install -D cypress-qase-reporter
 ```
 
+<!-- if there's no current beta, comment the next block
+-->
+
+To install the latest beta version (2.1.x), run:
+
+```sh
+npm install -D cypress-qase-reporter@beta
+```
+
 ## Updating from v1 to v2.1
 
-You can update a test project from using version 1 to version 2.1 in several steps:
+To update an existing test project using Qase reporter from version 1 to version 2.1,
+run the following steps:
 
-1. Change import paths:
+1. Change import paths in your test files:
 
    ```diff
    - import { qase } from 'cypress-qase-reporter/dist/mocha'
    + import { qase } from 'cypress-qase-reporter/mocha'
-   ```
+   ```                                        
+   
 2. Update reporter configuration in `cypress.config.js` and/or environment variables —
    see the [configuration reference](#configuration) below.
 
-3. Set the hooks in the `e2e` section in `cypress.config.js`:
+3. Add a hook in the `e2e` section of `cypress.config.js`:
 
    ```diff
-   ...
-   e2e: {
-        setupNodeEvents(on, config) { 
-          + require('cypress-qase-reporter/plugin')(on, config);
-        }
-   }
-   ...
+     ...
+     e2e: {
+   +   setupNodeEvents(on, config) { 
+   +     require('cypress-qase-reporter/plugin')(on, config)
+       }
+     }
+     ...
    ```
 
-   If you are override before:run or after:run hooks, use this:
+   If you already override `before:run` or `after:run` hooks in your `cypress.config.js`, use this instead:
 
    ```diff  
    const { beforeRunHook, afterRunHook } = require('cypress-qase-reporter/hooks');
     
    ...
-   e2e: {
+     e2e: {
        setupNodeEvents(on, config) {
-           + on('before:run', async () => {
-               + console.log('override before:run');
-               + await beforeRunHook(config);
-           + });
-
-           + on('after:run', async () => {
-               + console.log('override after:run');
-               + await afterRunHook(config);
-           + });
+   +     on('before:run', async () => {
+   +       console.log('override before:run');
+   +       await beforeRunHook(config);
+   +     });
+     
+   +     on('after:run', async () => {
+   +       console.log('override after:run');
+   +       await afterRunHook(config);
+   +     });
        },
-   },
-   ...
+     },
+     ...
    ```
 
 ## Getting started


### PR DESCRIPTION
Fixed the diff code blocks in the migration guide. See preview: https://github.com/qase-tms/qase-javascript/blob/docs/cypress-migration/qase-cypress/README.md