### PR TITLE
fix: return the ability to add the QaseID to the test name

### DIFF
--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,10 @@
+# playwright-qase-reporter@2.0.7
+
+## What's new
+
+Returned the ability to add the QaseID to the test name. 
+This allows using the standard playwright mechanism to filter the tests being run.
+
 # playwright-qase-reporter@2.0.6
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -53,7 +53,7 @@ export const qase = (
 
   PlaywrightQaseReporter.addIds(ids, name);
 
-  return `${name}`;
+  return `${name} (Qase ID: ${caseIds.join(',')})`;
 };
 
 /**

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -383,7 +383,7 @@ export class PlaywrightQaseReporter implements Reporter {
       signature: '',
       steps: this.transformSteps(result.steps, null),
       testops_id: null,
-      title: testCaseMetadata.title === '' ? test.title : testCaseMetadata.title,
+      title: testCaseMetadata.title === '' ? this.removeQaseIdsFromTitle(test.title) : testCaseMetadata.title,
     };
 
     if (this.reporter.isCaptureLogs()) {
@@ -475,5 +475,13 @@ export class PlaywrightQaseReporter implements Reporter {
       .join('::');
 
     return signature;
+  }
+
+  private removeQaseIdsFromTitle(title: string): string {
+    const matches = title.match(/\(Qase ID: ([0-9,]+)\)$/i);
+    if (matches) {
+      return title.replace(matches[0], '');
+    }
+    return title;
   }
 }


### PR DESCRIPTION
This allows using the standard playwright mechanism to filter the tests being run.