### PR TITLE
fix: uploading results with the same name

### DIFF
--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,10 @@
+# playwright-qase-reporter@2.0.9
+
+## What's new
+
+Fixed the problem when tests have the same name and different QaseIDs.
+They were uploaded into the Qase with an incorrect QaseID.
+
 # playwright-qase-reporter@2.0.7
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -51,9 +51,11 @@ export const qase = (
     console.log(`qase: qase ID ${id} should be a number`);
   }
 
-  PlaywrightQaseReporter.addIds(ids, name);
+  const newName = `${name} (Qase ID: ${caseIds.join(',')})`;
 
-  return `${name} (Qase ID: ${caseIds.join(',')})`;
+  PlaywrightQaseReporter.addIds(ids, newName);
+
+  return newName;
 };
 
 /**

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -401,7 +401,7 @@ export class PlaywrightQaseReporter implements Reporter {
     if (testCaseMetadata.ids.length > 0) {
       testResult.testops_id = testCaseMetadata.ids;
     } else {
-      const ids = PlaywrightQaseReporter.qaseIds.get(testTitle) ?? null;
+      const ids = PlaywrightQaseReporter.qaseIds.get(test.title) ?? null;
       testResult.testops_id = ids;
       if (ids) {
         const path = `${test.location.file}:${test.location.line}:${test.location.column}`;


### PR DESCRIPTION
Fixed the problem when tests have the same name and different QaseIDs. They were uploaded into the Qase with an incorrect QaseID.