### PR TITLE
fix: send all fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15229,7 +15229,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -15408,6 +15408,7 @@
       }
     },
     "qase-wdio": {
+      "name": "wdio-qase-reporter",
       "version": "1.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15415,7 +15416,7 @@
         "@wdio/reporter": "^8.39.0",
         "@wdio/types": "^8.39.0",
         "csv-stringify": "^6.0.4",
-        "qase-javascript-commons": "~2.1.1",
+        "qase-javascript-commons": "~2.1.2",
         "strip-ansi": "^7.1.0",
         "uuid": "^9.0.1"
       },

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.1.3
+
+## What's new
+
+Reporters will send all data on the results of the autotests. Including the data of the title, the description, etc.
+
+
 # qase-javascript-commons@2.1.1
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -417,14 +417,28 @@ export class TestOpsReporter extends AbstractReporter {
     const id = Array.isArray(result.testops_id) ? null : result.testops_id;
     if (id) {
       resultCreate.case_id = id;
-      return resultCreate;
     }
 
     const rootSuite = this.rootSuite ? `${this.rootSuite}\t` : '';
     resultCreate.case = {
       title: result.title,
       suite_title: result.relations?.suite ? `${rootSuite}${result.relations?.suite?.data.map((suite) => suite.title).join('\t')}` : rootSuite,
+      description: result.fields['description'] ?? null,
+      postconditions: result.fields['postconditions'] ?? null,
+      preconditions: result.fields['preconditions'] ?? null,
     };
+
+    if (result.fields['severity']) {
+      resultCreate.case.severity = result.fields['severity'];
+    }
+
+    if (result.fields['priority']) {
+      resultCreate.case.priority = result.fields['priority'];
+    }
+
+    if (result.fields['layer']) {
+      resultCreate.case.layer = result.fields['layer'];
+    }
 
     this.logger.logDebug(`Transformed result: ${JSON.stringify(resultCreate)}`);
 


### PR DESCRIPTION
Reporters will send all data on the results of the autotest