### PR TITLE
fix: a state file was not deleted

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.1.1
+
+## What's new
+
+Fixed an issue where the state file was not deleted. This resulted in results being uploaded into the same test run.
+
 # qase-javascript-commons@2.1.0
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/models/error.ts
+++ b/qase-javascript-commons/src/models/error.ts
@@ -1,0 +1,25 @@
+export class CompoundError {
+  message: string | undefined;
+  stacktrace: string | undefined;
+
+  constructor() {
+    this.message = 'CompoundError: One or more errors occurred. ---\n';
+  }
+
+  addMessage(message: string): void {
+    this.message += `${message}\n--- End of error message ---\n`;
+  }
+
+  addStacktrace(stacktrace: string): void {
+    if (!this.stacktrace) {
+      this.stacktrace = `${indentAll(stacktrace)}\n--- End of stack trace ---\n`;
+      return
+    }
+
+    this.stacktrace += `${indentAll(stacktrace)}\n--- End of stack trace ---\n`;
+  }
+}
+
+function indentAll(lines: string) {
+  return lines.split('\n').map(x => '    ' + x).join('\n');
+}

--- a/qase-javascript-commons/src/models/index.ts
+++ b/qase-javascript-commons/src/models/index.ts
@@ -4,3 +4,4 @@ export { type TestStepType, StepType } from './test-step';
 export { StepStatusEnum } from './step-execution';
 export { Attachment } from './attachment';
 export { Report } from './report';
+export { CompoundError } from './error';

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -445,6 +445,7 @@ export class QaseReporter implements ReporterInterface {
         await this.publishFallback();
       }
     }
+    StateManager.clearState();
   }
 
   /**

--- a/qase-javascript-commons/src/state/state.ts
+++ b/qase-javascript-commons/src/state/state.ts
@@ -36,6 +36,7 @@ export class StateManager {
   static setMode(mode: ModeEnum): void {
     const state = this.getState();
     state.Mode = mode;
+    state.IsModeChanged = true;
     this.setState(state);
   }
 


### PR DESCRIPTION
Fixed an issue where the state file was not deleted. This resulted in results being uploaded into the same test run.