### PR TITLE
feature: exclude empty default steps

### DIFF
--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,9 @@
+# playwright-qase-reporter@2.0.12
+
+## What's new
+
+Exclude `Before Hook` and `After Hook` if they don't have children steps. 
+
 # playwright-qase-reporter@2.0.11
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -256,6 +256,10 @@ export class PlaywrightQaseReporter implements Reporter {
         continue;
       }
 
+      if ((testStep.title === 'Before Hooks' || testStep.title === 'After Hooks') && testStep.steps.length === 0) {
+        continue;
+      }
+
       const attachments = this.stepAttachments.get(testStep);
 
       const id = uuidv4();


### PR DESCRIPTION
Exclude `Before Hook` and `After Hook` from a result if they don't have children steps.