### PR TITLE
fix: issue with attaching the screenshot

### DIFF
--- a/qase-wdio/changelog.md
+++ b/qase-wdio/changelog.md
@@ -1,3 +1,14 @@
+# qase-wdio@1.0.0-beta.4
+
+## What's new
+
+Fix an issue with attaching the screenshot to the test case. Now, the reporter will correctly handle the screenshots and
+will attach them to the test case in the Qase TMS.
+
+```log
+The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received an instance of Object
+```
+
 # qase-wdio@1.0.0-beta.3
 
 ## What's new

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -329,11 +329,11 @@ export default class WDIOQaseReporter extends WDIOReporter {
   override onAfterCommand(command: AfterCommandArgs) {
     const { disableWebdriverStepsReporting, disableWebdriverScreenshotsReporting } = this._options;
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const commandResult: string | undefined = command.result || undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+    const commandResult: string | undefined = command.result.value || undefined;
     const isScreenshot = isScreenshotCommand(command);
     if (!disableWebdriverScreenshotsReporting && isScreenshot && commandResult) {
-      this.attachFile('Screenshot', Buffer.from(commandResult, 'base64'), 'image/png');
+      this.attachFile('Screenshot.png', Buffer.from(commandResult, 'base64'), 'image/png');
     }
 
     if (disableWebdriverStepsReporting || this._isMultiremote || !this.storage.getCurrentStep()) {
@@ -549,7 +549,6 @@ export default class WDIOQaseReporter extends WDIOReporter {
       content: content,
     };
 
-    console.log('attachFile:', attach);
     this.storage.getLastItem()?.attachments.push(attach);
   }
 


### PR DESCRIPTION
Fix an issue with attaching the screenshot to the test case. Now, the reporter will correctly handle the screenshots and will attach them to the test case in the Qase TMS.

[#672]