### PR TITLE
feature: the ability to add steps in tests

### DIFF
--- a/qase-cypress/README.md
+++ b/qase-cypress/README.md
@@ -106,6 +106,7 @@ parameterize your tests.
 - `qase.parameters` - set the parameters of the test case
 - `qase.groupParameters` - set the group parameters of the test case
 - `qase.ignore` - ignore the test case in Qase. The test will be executed, but the results will not be sent to Qase.
+- `qase.step` - create a step in the test case
 
 For example:
 
@@ -206,8 +207,8 @@ module.exports = cypress.defineConfig({
   video: false,
   e2e: {
     setupNodeEvents(on, config) {
-       require('cypress-qase-reporter/plugin')(on, config)
-       require('cypress-qase-reporter/metadata')(on)
+      require('cypress-qase-reporter/plugin')(on, config)
+      require('cypress-qase-reporter/metadata')(on)
     },
   },
 });

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,19 @@
+# cypress-qase-reporter@2.2.0-beta.2
+
+## What's new
+
+Added the ability to add steps in tests:
+
+- `qase.step` - add a step to the test
+
+```ts
+it('test', () => {
+  qase.step('Step 1', () => {
+    cy.visit('https://example.com');
+  });
+});
+```
+
 # cypress-qase-reporter@2.2.0-beta.1
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0-beta.2",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/metadata.js
+++ b/qase-cypress/src/metadata.js
@@ -49,4 +49,18 @@ module.exports = function(on) {
       return null;
     },
   });
+
+  on('task', {
+    qaseStepStart(value) {
+      MetadataManager.addStepStart(value);
+      return null;
+    },
+  });
+
+  on('task', {
+    qaseStepEnd(value) {
+      MetadataManager.addStepEnd(value);
+      return null;
+    },
+  });
 };

--- a/qase-cypress/src/metadata/models.ts
+++ b/qase-cypress/src/metadata/models.ts
@@ -6,4 +6,20 @@ export interface Metadata {
   ignore?: boolean;
   suite?: string | undefined;
   comment?: string | undefined;
+  steps?: (StepStart | StepEnd)[];
+  currentStepId?: string | undefined;
+  firstStepName?: string | undefined;
+}
+
+export interface StepStart {
+  id: string;
+  timestamp: number;
+  name: string;
+  parentId: string | undefined;
+}
+
+export interface StepEnd {
+  id: string;
+  timestamp: number;
+  status: string;
 }

--- a/qase-cypress/src/mocha.ts
+++ b/qase-cypress/src/mocha.ts
@@ -127,3 +127,25 @@ qase.comment = (
     //
   });
 };
+
+/**
+ * Add a step to  the test case
+ * @param {string} name
+ * @param {() => T | PromiseLike<T>} body
+ * @example
+ * it('test', () => {
+ *    qase.step("Some step", () => {
+ *      // some actions
+ *    });
+ *    cy.visit('https://example.com');
+ * });
+ */
+qase.step = <T = void>(name: string, body: () => T | PromiseLike<T>) => {
+  return cy.task('qaseStepStart', name).then(() => {
+    return Cypress.Promise.resolve(body());
+  }).then(() => {
+    cy.task('qaseStepEnd', 'passed').then(() => {
+      //
+    });
+  });
+};


### PR DESCRIPTION
- `qase.step` - add a step to the test

```ts
it('test', () => {
  qase.step('Step 1', () => {
    cy.visit('https://example.com');
  });
});
```