### PR TITLE
feature: ability to add attachments to tests or steps

### DIFF
--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,21 @@
+# cypress-qase-reporter@2.2.0-beta.3
+
+## What's new
+
+Added the ability to add attachments to tests or steps:
+
+- `qase.attach` - add an attachment to test or step
+
+```ts
+it('test', () => {
+  qase.attach({ paths: '/path/to/file' });
+  qase.step('Step 1', () => {
+    cy.visit('https://example.com');
+    qase.attach({ name: 'attachment.txt', content: 'Hello, world!', contentType: 'text/plain' });
+  });
+});
+```
+
 # cypress-qase-reporter@2.2.0-beta.2
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.0-beta.2",
+  "version": "2.2.0-beta.3",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/metadata.js
+++ b/qase-cypress/src/metadata.js
@@ -63,4 +63,11 @@ module.exports = function(on) {
       return null;
     },
   });
+
+  on('task', {
+    qaseAttach(value) {
+      MetadataManager.addAttach(value);
+      return null;
+    },
+  });
 };

--- a/qase-cypress/src/metadata/models.ts
+++ b/qase-cypress/src/metadata/models.ts
@@ -1,3 +1,5 @@
+import { Attachment } from 'qase-javascript-commons';
+
 export interface Metadata {
   title?: string | undefined;
   fields?: Record<string, string>;
@@ -9,6 +11,8 @@ export interface Metadata {
   steps?: (StepStart | StepEnd)[];
   currentStepId?: string | undefined;
   firstStepName?: string | undefined;
+  attachments?: Attachment[];
+  stepAttachments?: Record<string, Attachment[]>;
 }
 
 export interface StepStart {
@@ -22,4 +26,12 @@ export interface StepEnd {
   id: string;
   timestamp: number;
   status: string;
+}
+
+
+export interface Attach {
+  name?: string;
+  paths?: string | string[];
+  content?: Buffer | string;
+  contentType?: string;
 }

--- a/qase-cypress/src/mocha.ts
+++ b/qase-cypress/src/mocha.ts
@@ -23,7 +23,7 @@ export const qase = (
 qase.title = (
   value: string,
 ) => {
-  cy.task('qaseTitle', value).then(() => {
+  return cy.task('qaseTitle', value).then(() => {
     //
   });
 };
@@ -41,7 +41,7 @@ qase.title = (
 qase.fields = (
   values: Record<string, string>,
 ) => {
-  cy.task('qaseFields', values).then(() => {
+  return cy.task('qaseFields', values).then(() => {
     //
   });
 };
@@ -55,7 +55,7 @@ qase.fields = (
  * });
  */
 qase.ignore = () => {
-  cy.task('qaseIgnore').then(() => {
+  return cy.task('qaseIgnore').then(() => {
     //
   });
 };
@@ -72,7 +72,7 @@ qase.ignore = () => {
 qase.parameters = (
   values: Record<string, string>,
 ) => {
-  cy.task('qaseParameters', values).then(() => {
+  return cy.task('qaseParameters', values).then(() => {
     //
   });
 };
@@ -89,7 +89,7 @@ qase.parameters = (
 qase.groupParameters = (
   values: Record<string, string>,
 ) => {
-  cy.task('qaseGroupParameters', values).then(() => {
+  return cy.task('qaseGroupParameters', values).then(() => {
     //
   });
 };
@@ -106,7 +106,7 @@ qase.groupParameters = (
 qase.suite = (
   value: string,
 ) => {
-  cy.task('qaseSuite', value).then(() => {
+  return cy.task('qaseSuite', value).then(() => {
     //
   });
 };
@@ -123,7 +123,7 @@ qase.suite = (
 qase.comment = (
   value: string,
 ) => {
-  cy.task('qaseComment', value).then(() => {
+  return cy.task('qaseComment', value).then(() => {
     //
   });
 };
@@ -147,5 +147,27 @@ qase.step = <T = void>(name: string, body: () => T | PromiseLike<T>) => {
     cy.task('qaseStepEnd', 'passed').then(() => {
       //
     });
+  });
+};
+
+/**
+ * Attach a file to the test case or the step
+ * @param attach
+ * @example
+ * it('test', () => {
+ *   qase.attach({ name: 'attachment.txt', content: 'Hello, world!', contentType: 'text/plain' });
+ *   qase.attach({ paths: '/path/to/file'});
+ *   qase.attach({ paths: ['/path/to/file', '/path/to/another/file']});
+ *   cy.visit('https://example.com');
+ *  });
+ */
+qase.attach = (attach: {
+  name?: string,
+  paths?: string | string[],
+  content?: Buffer | string,
+  contentType?: string,
+}) => {
+  return cy.task('qaseAttach', attach).then(() => {
+    //
   });
 };

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -183,6 +183,8 @@ export class CypressQaseReporter extends reporters.Base {
       ? CypressQaseReporter.findAttachments(ids, this.screenshotsFolder)
       : undefined;
 
+    attachments?.push(...(metadata?.attachments ?? []));
+
     let relations = {};
     if (test.parent !== undefined) {
       const data = [];
@@ -235,7 +237,7 @@ export class CypressQaseReporter extends reporters.Base {
       relations: relations,
       run_id: null,
       signature: this.getSignature(test, ids),
-      steps: metadata?.steps ? this.getSteps(metadata.steps) : [],
+      steps: metadata?.steps ? this.getSteps(metadata.steps, metadata.stepAttachments ?? {}) : [],
       id: uuidv4(),
       execution: {
         status: test.state
@@ -300,7 +302,7 @@ export class CypressQaseReporter extends reporters.Base {
     return undefined;
   }
 
-  private getSteps(steps: (StepStart | StepEnd)[]): TestStepType[] {
+  private getSteps(steps: (StepStart | StepEnd)[], attachments: Record<string, Attachment[]>): TestStepType[] {
     const result: TestStepType[] = [];
     const stepMap = new Map<string, TestStepType>();
 
@@ -315,6 +317,10 @@ export class CypressQaseReporter extends reporters.Base {
           action: step.name,
           expected_result: null,
         };
+
+        if (attachments[step.id]) {
+          newStep.attachments = attachments[step.id] ?? [];
+        }
 
         const parentId = step.parentId;
         if (parentId) {


### PR DESCRIPTION
- `qase.attach` - add an attachment to test or step

```ts
it('test', () => {
  qase.attach({ paths: '/path/to/file' });
  qase.step('Step 1', () => {
    cy.visit('https://example.com');
    qase.attach({ name: 'attachment.txt', content: 'Hello, world!', contentType: 'text/plain' });
  });
});
```