### PR TITLE
feature: support `QaseIgnore` tag

### DIFF
--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,17 @@
+# qase-cucumberjs@2.0.2
+
+## What's new
+
+- Support `QaseIgnore` tag. If the test case has the `QaseIgnore` tag, the reporter will not send the result to the Qase
+  TMS.
+
+    ```cucumber
+    @QaseIgnore
+    Scenario: simple test
+    ```
+
+- Improved error handling.
+
 # qase-cucumberjs@2.0.0
 
 ## What's new

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",

--- a/qase-cucumberjs/src/models.ts
+++ b/qase-cucumberjs/src/models.ts
@@ -1,6 +1,6 @@
-
 interface TestMetadata {
-  ids : number[];
-  fields : Record<string, string>;
-  title : string | null;
+  ids: number[];
+  fields: Record<string, string>;
+  title: string | null;
+  isIgnore: boolean;
 }


### PR DESCRIPTION
- Support `QaseIgnore` tag. If the test case has the `QaseIgnore` tag, the reporter will not send the result to the Qase TMS.

    ```cucumber
    @QaseIgnore
    Scenario: simple test
    ```

- Improved error handling.