### PR TITLE
feature: support `ignore` metadata

### DIFF
--- a/qase-testcafe/changelog.md
+++ b/qase-testcafe/changelog.md
@@ -1,3 +1,20 @@
+# qase-testcafe@2.0.3
+
+## What's new
+
+Support `ignore` metadata for test cases. If the test case has the `ignore` tag, the reporter will not send the result to the Qase
+TMS.
+
+```ts
+const q = qase.ignore().create();
+test.meta({ ...q })(
+  'test',
+  async (t) => {
+    await t;
+  },
+);
+```
+
 # qase-testcafe@2.0.2
 
 ## What's new
@@ -8,7 +25,8 @@ Improved error collection. The error stack trace contains more useful debugging 
 
 ## What's new
 
-Support group parameters for test cases. You can specify the group parameters in the test case using the following format:
+Support group parameters for test cases. You can specify the group parameters in the test case using the following
+format:
 
 ```ts
 const q = qase.groupParameters({ 'param01': 'value01', 'param02': 'value02' }).create();

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-qase",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Qase TMS TestCafe Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-testcafe/src/qase.ts
+++ b/qase-testcafe/src/qase.ts
@@ -5,6 +5,7 @@ export class qase {
   private static _qaseFields = '';
   private static _qaseParameters = '';
   private static _qaseGroupParameters = '';
+  private static _qaseIgnore = '';
 
   /**
    * Set a Qase ID for the test case
@@ -71,13 +72,27 @@ export class qase {
    * Don't forget to call `create` method after setting all the necessary parameters
    * @param {Record<string, string>} values
    * @example
-   * const q = qase.group_parameters({ 'severity': 'high', 'priority': 'medium' }).create();
+   * const q = qase.groupParameters({ 'severity': 'high', 'priority': 'medium' }).create();
    * test.meta(q)('Test case title', async t => { ... });
    * or
    * test.meta({userField: 123, ...q})('Test case title', async t => { ... });
    */
-  public static group_parameters = (values: Record<string, string>) => {
+  public static groupParameters = (values: Record<string, string>) => {
     this._qaseGroupParameters = this.toNormalizeRecord(values);
+    return this;
+  };
+
+  /**
+   * Set a ignore flag for the test case
+   * Don't forget to call `create` method after setting all the necessary parameters
+   * @example
+   * const q = qase.ignore().create();
+   * test.meta(q)('Test case title', async t => { ... });
+   * or
+   * test.meta({userField: 123, ...q})('Test case title', async t => { ... });
+   */
+  public static ignore = () => {
+    this._qaseIgnore = 'true';
     return this;
   };
 
@@ -97,6 +112,7 @@ export class qase {
       QaseFields: this._qaseFields,
       QaseParameters: this._qaseParameters,
       QaseGroupParameters: this._qaseGroupParameters,
+      QaseIgnore: this._qaseIgnore,
     };
 
     this._qaseID = '';
@@ -104,6 +120,7 @@ export class qase {
     this._qaseFields = '';
     this._qaseParameters = '';
     this._qaseGroupParameters = '';
+    this._qaseIgnore = '';
 
     return meta;
   };

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -54,6 +54,7 @@ enum metadataEnum {
   parameters = 'QaseParameters',
   groupParameters = 'QaseGroupParameters',
   oldID = 'CID',
+  ignore = 'QaseIgnore',
 }
 
 interface MetadataType {
@@ -62,6 +63,7 @@ interface MetadataType {
   [metadataEnum.fields]: Record<string, string>;
   [metadataEnum.parameters]: Record<string, string>;
   [metadataEnum.groupParameters]: Record<string, string>;
+  [metadataEnum.ignore]: boolean;
 }
 
 export interface TestRunInfoType {
@@ -162,6 +164,12 @@ export class TestcafeQaseReporter {
     meta: Record<string, string>,
     formatError: (error: any, prefix: string) => string,
   ) => {
+    const metadata = this.getMeta(meta);
+
+    if (metadata[metadataEnum.ignore]) {
+      return;
+    }
+
     const errorLog = testRunInfo.errs
       .map((error, index) => formatError(error, `${index + 1} `).replace(
         // eslint-disable-next-line no-control-regex
@@ -170,7 +178,6 @@ export class TestcafeQaseReporter {
       ))
       .join('\n');
 
-    const metadata = this.getMeta(meta);
     await this.reporter.addTestResult({
       author: null,
       execution: {
@@ -222,6 +229,7 @@ export class TestcafeQaseReporter {
       QaseFields: {},
       QaseParameters: {},
       QaseGroupParameters: {},
+      QaseIgnore: false,
     };
 
     if (meta[metadataEnum.oldID] !== undefined && meta[metadataEnum.oldID] !== '') {
@@ -244,6 +252,14 @@ export class TestcafeQaseReporter {
 
     if (meta[metadataEnum.parameters] !== undefined && meta[metadataEnum.parameters] !== '') {
       metadata.QaseParameters = JSON.parse(meta[metadataEnum.parameters]) as Record<string, string>;
+    }
+
+    if (meta[metadataEnum.groupParameters] !== undefined && meta[metadataEnum.groupParameters] !== '') {
+      metadata.QaseGroupParameters = JSON.parse(meta[metadataEnum.groupParameters]) as Record<string, string>;
+    }
+
+    if (meta[metadataEnum.ignore] !== undefined && meta[metadataEnum.ignore] !== '') {
+      metadata.QaseIgnore = meta[metadataEnum.ignore] === 'true';
     }
 
     return metadata;


### PR DESCRIPTION
If the test case has the `ignore` tag, the reporter will not send the result to the Qase TMS.

```ts
const q = qase.ignore().create();
test.meta({ ...q })(
  'test',
  async (t) => {
    await t;
  },
);
```