### PR TITLE
feature: support specifying the test case ID in the `annotation

### DIFF
--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,19 @@
+# playwright-qase-reporter@2.0.14
+
+## What's new
+
+Support specifying the test case ID in the `annotation`.
+
+```ts
+test('test',
+  {
+    annotation: { type: 'QaseID', description: '1' },
+  },
+  async ({ page }) => {
+    await page.goto('https://example.com');
+  });
+```
+
 # playwright-qase-reporter@2.0.13
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -408,7 +408,10 @@ export class PlaywrightQaseReporter implements Reporter {
       }
     }
 
-    if (testCaseMetadata.ids.length > 0) {
+    const ids = this.extractQaseIdsFromAnnotation(test.annotations);
+    if (ids.length > 0) {
+      testResult.testops_id = ids;
+    } else if (testCaseMetadata.ids.length > 0) {
       testResult.testops_id = testCaseMetadata.ids;
     } else {
       const ids = PlaywrightQaseReporter.qaseIds.get(test.title) ?? null;
@@ -494,5 +497,26 @@ export class PlaywrightQaseReporter implements Reporter {
       return title.replace(matches[0], '').trimEnd();
     }
     return title;
+  }
+
+  /**
+   * @param annotation
+   * @returns {number[]}
+   * @private
+   */
+  private extractQaseIdsFromAnnotation(annotation: { type: string, description?: string }[]): number[] {
+    const ids: number[] = [];
+    for (const item of annotation) {
+      if (item.type.toLowerCase() === 'qaseid' && item.description) {
+        if (item.description.includes(',')) {
+          ids.push(...item.description.split(',').map((id) => parseInt(id)));
+          continue;
+        }
+
+        ids.push(parseInt(item.description));
+      }
+    }
+
+    return ids;
   }
 }

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -60,12 +60,6 @@ export class PlaywrightQaseReporter implements Reporter {
   private static qaseIds: Map<string, number[]> = new Map<string, number[]>();
 
   /**
-   * @type {Map<string, number[]>}
-   * @private
-   */
-  private qaseTestWithOldAnnotation: Map<string, number[]> = new Map<string, number[]>();
-
-  /**
    * @param {TestCase} test
    * @returns {string[]}
    * @private
@@ -414,12 +408,7 @@ export class PlaywrightQaseReporter implements Reporter {
     } else if (testCaseMetadata.ids.length > 0) {
       testResult.testops_id = testCaseMetadata.ids;
     } else {
-      const ids = PlaywrightQaseReporter.qaseIds.get(test.title) ?? null;
-      testResult.testops_id = ids;
-      if (ids) {
-        const path = `${test.location.file}:${test.location.line}:${test.location.column}`;
-        this.qaseTestWithOldAnnotation.set(path, ids);
-      }
+      testResult.testops_id = PlaywrightQaseReporter.qaseIds.get(test.title) ?? null;
     }
 
     testResult.signature = this.getSignature(suites, testCaseMetadata.parameters, testResult.testops_id ?? []);


### PR DESCRIPTION
feature: support specifying the test case ID in the `annotation`
--
```ts
test('test',
  {
    annotation: { type: 'QaseID', description: '1' },
  },
  async ({ page }) => {
    await page.goto('https://example.com');
  });
```

---

refactor: remove unused code