### PR TITLE
feature: improve steps handling

### DIFF
--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,9 @@
+# playwright-qase-reporter@2.0.15
+
+## What's new
+
+Exclude `Worker Cleanup` step if it doesn't have children steps.
+
 # playwright-qase-reporter@2.0.14
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -35,6 +35,8 @@ interface TestCaseMetadata {
   comment: string;
 }
 
+const defaultSteps: string[] = ['Before Hooks', 'After Hooks', 'Worker Cleanup'];
+
 export type PlaywrightQaseOptionsType = ConfigType;
 
 /**
@@ -249,7 +251,7 @@ export class PlaywrightQaseReporter implements Reporter {
         continue;
       }
 
-      if ((testStep.title === 'Before Hooks' || testStep.title === 'After Hooks') && testStep.steps.length === 0) {
+      if (defaultSteps.includes(testStep.title) && testStep.steps.length === 0) {
         continue;
       }
 


### PR DESCRIPTION
Exclude `Worker Cleanup` step if it doesn't have children steps.