### PR TITLE
feature: added the ability to specify a test metadata in tests

### DIFF
--- a/qase-jest/README.md
+++ b/qase-jest/README.md
@@ -59,7 +59,6 @@ module.exports = {
 Now, run the Jest tests as usual.
 Test results will be reported to a new test run in Qase.
 
-
 ```console
 $ npx jest
 Determining test suites to run...
@@ -79,32 +78,49 @@ and suites from your test data.
 But if necessary, you can independently register the ID of already
 existing test cases from TMS before the executing tests. For example:
 
+### Metadata
+
+- `qase.title` - set the title of the test case
+- `qase.fields` - set the fields of the test case
+- `qase.suite` - set the suite of the test case
+- `qase.comment` - set the comment of the test case
+- `qase.parameters` - set the parameters of the test case
+- `qase.groupParameters` - set the group parameters of the test case
+- `qase.ignore` - ignore the test case in Qase. The test will be executed, but the results will not be sent to Qase.
+- `qase.step` - create a step in the test case
+- `qase.attach` - attach a file to the test case
+
 ```typescript
-const { qase } = require("jest-qase-reporter/jest");
+const { qase } = require('jest-qase-reporter/jest');
 
 describe('My First Test', () => {
-    test(qase([1,2], 'Several ids'), () => {
-        expect(true).toBe(true);
-    })
+  test(qase([1, 2], 'Several ids'), () => {
+    expect(true).toBe(true);
+  });
 
-    test(qase(3, 'Correct test'), () => {
-        expect(true).toBe(true);
-    })
+  test(qase(3, 'Correct test'), () => {
+    qase.title('Title');
+    expect(true).toBe(true);
+  });
 
-    test.skip(qase("4", 'Skipped test'), () => {
-        expect(true).toBe(true);
-    })
+  test.skip(qase('4', 'Skipped test'), () => {
+    expect(true).toBe(true);
+  });
 
-    test(qase(["5", "6"], 'Failed test'), () => {
-        expect(true).toBe(false);
-    })
+  test(qase(['5', '6'], 'Failed test'), () => {
+    expect(true).toBe(false);
+  });
 });
 ```
+
 To run tests and create a test run, execute the command (for example from folder examples):
+
 ```bash
 QASE_MODE=testops npx jest
 ```
+
 or
+
 ```bash
 npm test
 ```
@@ -125,7 +141,7 @@ Reporter options (* - required):
 
 - `mode` - `testops`/`off` Enables reporter, default - `off`
 - `debug` - Enables debug logging, default - `false`
-- `environment` - To execute with the sending of the envinroment information 
+- `environment` - To execute with the sending of the envinroment information
 - *`testops.api.token` - Token for API access, you can find more information
   [here](https://developers.qase.io/#authentication)
 - *`testops.project` - Qase project code, for example, in https://app.qase.io/project/DEMO the code is `DEMO`
@@ -167,7 +183,7 @@ Supported ENV variables:
 
 - `QASE_MODE` - Same as `mode`
 - `QASE_DEBUG` - Same as `debug`
-- `QASE_ENVIRONMENT` - Same as `environment` 
+- `QASE_ENVIRONMENT` - Same as `environment`
 - `QASE_TESTOPS_API_TOKEN` - Same as `testops.api.token`
 - `QASE_TESTOPS_PROJECT` - Same as `testops.project`
 - `QASE_TESTOPS_RUN_ID` - Pass Run ID from ENV and override reporter option `testops.run.id`
@@ -176,7 +192,8 @@ Supported ENV variables:
 
 ## Requirements
 
-We maintain the reporter on LTS versions of Node. You can find the current versions by following the [link](https://nodejs.org/en/about/releases/)
+We maintain the reporter on LTS versions of Node. You can find the current versions by following
+the [link](https://nodejs.org/en/about/releases/)
 
 `jest >= 28.0.0`
 

--- a/qase-jest/changelog.md
+++ b/qase-jest/changelog.md
@@ -1,9 +1,46 @@
+# jest-qase-reporter@2.0.3
+
+## What's new
+
+Added the ability to specify a test metadata in tests:
+
+- `qase.title` - set the test title
+- `qase.fields` - set the test fields
+- `qase.suite` - set the test suite
+- `qase.comment` - set the test comment
+- `qase.parameters` - set the test parameters
+- `qase.groupParameters` - set the test group parameters
+- `qase.ignore` - ignore the test in Qase
+- `qase.attach` - attach a file to the test
+- `qase.steps` - add the test steps
+
+```ts
+const { qase } = require('jest-qase-reporter/jest');
+
+test('test', () => {
+  qase.title('Title');
+  qase.fields({ custom_field: 'value' });
+  qase.suite('Suite');
+  qase.comment('Comment');
+  qase.parameters({ param01: 'value' });
+  qase.groupParameters({ param02: 'value' });
+  qase.ignore();
+  qase.attach({ name: 'attachment.txt', content: 'Hello, world!', type: 'text/plain' });
+
+  qase.step('Step 1', () => {
+    expect(true).toBe(true);
+  });
+
+  expect(true).toBe(true);
+});
+```
+
 # jest-qase-reporter@2.0.1
 
 ## What's new
 
 Fixed a bug when a test was marked as skipped.
-This reporter has uploaded this test as blocked. 
+This reporter has uploaded this test as blocked.
 Right now the reporter will upload this test as skipped.
 
 # jest-qase-reporter@2.0.0

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-qase-reporter",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Qase TMS Jest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
-    "qase-javascript-commons": "~2.2.0",
+    "qase-javascript-commons": "~2.2.1",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/qase-jest/src/global.ts
+++ b/qase-jest/src/global.ts
@@ -1,0 +1,69 @@
+import { JestQaseReporter } from './reporter';
+import { Attachment, TestStepType } from 'qase-javascript-commons';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace NodeJS {
+    interface Global {
+      Qase: Qase;
+    }
+  }
+}
+
+export class Qase {
+  private reporter: JestQaseReporter;
+
+  constructor(reporter: JestQaseReporter) {
+    this.reporter = reporter;
+  }
+
+  title(title: string): void {
+    this.reporter.addTitle(title);
+  }
+
+  ignore(): void {
+    this.reporter.addIgnore();
+  }
+
+  comment(value: string): void {
+    this.reporter.addComment(value);
+  }
+
+  suite(value: string): void {
+    this.reporter.addSuite(value);
+  }
+
+  fields(values: Record<string, string>): void {
+    const stringRecord: Record<string, string> = {};
+    for (const [key, value] of Object.entries(values)) {
+      stringRecord[String(key)] = String(value);
+    }
+    this.reporter.addFields(stringRecord);
+  }
+
+  parameters(values: Record<string, string>): void {
+    const stringRecord: Record<string, string> = {};
+    for (const [key, value] of Object.entries(values)) {
+      stringRecord[String(key)] = String(value);
+    }
+    this.reporter.addParameters(stringRecord);
+  }
+
+  groupParams(values: Record<string, string>): void {
+    const stringRecord: Record<string, string> = {};
+    for (const [key, value] of Object.entries(values)) {
+      stringRecord[String(key)] = String(value);
+    }
+    this.reporter.addGroupParams(stringRecord);
+  }
+
+  step(step: TestStepType): void {
+    this.reporter.addStep(step);
+  }
+
+  attachment(attachment: Attachment): void {
+    this.reporter.addAttachment(attachment);
+  }
+}
+
+export {};

--- a/qase-jest/src/jest.ts
+++ b/qase-jest/src/jest.ts
@@ -1,3 +1,8 @@
+import { QaseStep, StepFunction } from './step';
+import path from 'path';
+import { getMimeTypes } from 'qase-javascript-commons';
+import { v4 as uuidv4 } from 'uuid';
+
 export const qase = (
   caseId: number | string | number[] | string[],
   name: string,
@@ -6,3 +11,160 @@ export const qase = (
 
   return `${name} (Qase ID: ${caseIds.join(',')})`;
 };
+
+/**
+ * Set a title for the test case
+ * @param {string} value
+ * @example
+ * test('test', () => {
+ *    qase.title("Title");
+ *     expect(true).toBe(true);
+ * });
+ */
+qase.title = (value: string): void => {
+  global.Qase.title(value);
+};
+
+/**
+ * Ignore the test case
+ * @example
+ * test('test', () => {
+ *    qase.ignore();
+ *     expect(true).toBe(true);
+ * });
+ */
+qase.ignore = (): void => {
+  global.Qase.ignore();
+};
+
+/**
+ * Add a comment to the test case
+ * @param {string} value
+ * @example
+ * test('test', () => {
+ *    qase.comment("Comment");
+ *     expect(true).toBe(true);
+ * });
+ */
+qase.comment = (value: string): void => {
+  global.Qase.comment(value);
+};
+
+/**
+ * Set a suite for the test case
+ * @param {string} value
+ * @example
+ * test('test', () => {
+ *    qase.suite("Suite");
+ *     expect(true).toBe(true);
+ * });
+ */
+qase.suite = (value: string): void => {
+  global.Qase.suite(value);
+};
+
+/**
+ * Set fields for the test case
+ * @param {Record<string, string>} values
+ * @example
+ * test('test', () => {
+ *    qase.fields({field: "value"});
+ *     expect(true).toBe(true);
+ * });
+ */
+qase.fields = (values: Record<string, string>): void => {
+  global.Qase.fields(values);
+};
+
+/**
+ * Set parameters for the test case
+ * @param {Record<string, string>} values
+ * @example
+ * test('test', () => {
+ *    qase.parameters({param: "value"});
+ *     expect(true).toBe(true);
+ * });
+ */
+qase.parameters = (values: Record<string, string>): void => {
+  global.Qase.parameters(values);
+};
+
+/**
+ * Set group params for the test case
+ * @param {Record<string, string>} values
+ * @example
+ * test('test', () => {
+ *    qase.groupParameters({param: "value"});
+ *     expect(true).toBe(true);
+ * });
+ */
+qase.groupParameters = (values: Record<string, string>): void => {
+  global.Qase.groupParams(values);
+};
+
+/**
+ * Add a step to the test case
+ * @param name
+ * @param body
+ * @example
+ * test('test', () => {
+ *    qase.step("Step", () => {
+ *      expect(true).toBe(true);
+ *    });
+ *     expect(true).toBe(true);
+ * });
+ */
+qase.step = async (name: string, body: StepFunction) => {
+  const runningStep = new QaseStep(name);
+  // eslint-disable-next-line @typescript-eslint/require-await
+  await runningStep.run(body, async (step) => global.Qase.step(step));
+};
+
+
+/**
+ * Add an attachment to the test case
+ * @param attach
+ * @example
+ * test('test', () => {
+ *   qase.attach({ name: 'attachment.txt', content: 'Hello, world!', type: 'text/plain' });
+ *   qase.attach({ paths: ['/path/to/file', '/path/to/another/file']});
+ *     expect(true).toBe(true);
+ * });
+ */
+qase.attach = (attach: {
+  name?: string;
+  type?: string;
+  content?: string;
+  paths?: string[];
+}) => {
+  if (attach.paths) {
+    for (const file of attach.paths) {
+      const attachmentName = path.basename(file);
+      const contentType: string = getMimeTypes(file);
+
+      global.Qase.attachment({
+        file_path: file,
+        size: 0,
+        id: uuidv4(),
+        file_name: attachmentName,
+        mime_type: contentType,
+        content: '',
+      });
+    }
+    return;
+  }
+
+  if (attach.content) {
+    global.Qase.attachment({
+      file_path: null,
+      size: attach.content.length,
+      id: uuidv4(),
+      file_name: attach.name ?? 'attachment',
+      mime_type: attach.type ?? 'application/octet-stream',
+      content: attach.content,
+    });
+  }
+};
+
+
+

--- a/qase-jest/src/models.ts
+++ b/qase-jest/src/models.ts
@@ -1,0 +1,13 @@
+import { Attachment, TestStepType } from 'qase-javascript-commons';
+
+export interface Metadata {
+  title: string | undefined;
+  ignore: boolean;
+  comment: string | undefined;
+  suite: string | undefined;
+  fields: Record<string, string>;
+  parameters: Record<string, string>;
+  groupParams: Record<string, string>;
+  steps: TestStepType[];
+  attachments: Attachment[];
+}

--- a/qase-jest/src/step.ts
+++ b/qase-jest/src/step.ts
@@ -1,0 +1,106 @@
+import { Attachment, StepStatusEnum, TestStepType } from 'qase-javascript-commons';
+import { v4 as uuidv4 } from 'uuid';
+import path from 'path';
+
+export type StepFunction<T = any> = (
+  this: QaseStep,
+  step: QaseStep,
+) => T | Promise<T>;
+
+// TODO: Move to common, because it's duplicated in qase-wdio/src/step.ts
+export class QaseStep {
+  name = '';
+  attachments: Attachment[] = [];
+  steps: TestStepType[] = [];
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  attach(attach: {
+    name?: string;
+    type?: string;
+    content?: string;
+    paths?: string[] | string;
+  }): void {
+    if (attach.paths) {
+      const files = Array.isArray(attach.paths) ? attach.paths : [attach.paths];
+
+      for (const file of files) {
+        const attachmentName = path.basename(file);
+        const contentType = 'application/octet-stream';
+        this.attachments.push({
+          id: uuidv4(),
+          file_name: attachmentName,
+          mime_type: contentType,
+          content: '',
+          file_path: file,
+          size: 0,
+        });
+      }
+
+      return;
+    }
+
+    if (attach.content) {
+      const attachmentName = attach.name ?? 'attachment';
+      const contentType = attach.type ?? 'application/octet-stream';
+
+      this.attachments.push({
+        id: uuidv4(),
+        file_name: attachmentName,
+        mime_type: contentType,
+        content: attach.content,
+        file_path: null,
+        size: attach.content.length,
+      });
+    }
+  }
+
+  async step(name: string, body: StepFunction): Promise<void> {
+    const childStep = new QaseStep(name);
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await childStep.run(body, async (step: TestStepType) => {
+      this.steps.push(step);
+    });
+  }
+
+  async run(body: StepFunction, messageEmitter: (step: TestStepType) => Promise<void>): Promise<void> {
+    const startDate = new Date().getTime();
+    const step = new TestStepType();
+    step.data = {
+      action: this.name,
+      expected_result: null,
+    };
+
+    try {
+      await body.call(this, this);
+
+      step.execution = {
+        start_time: startDate,
+        end_time: new Date().getTime(),
+        status: StepStatusEnum.passed,
+        duration: null,
+      };
+
+      step.attachments = this.attachments;
+      step.steps = this.steps;
+
+      await messageEmitter(step);
+    } catch (e: any) {
+      step.execution = {
+        start_time: startDate,
+        end_time: new Date().getTime(),
+        status: StepStatusEnum.failed,
+        duration: null,
+      };
+
+      step.attachments = this.attachments;
+      step.steps = this.steps;
+
+      await messageEmitter(step);
+
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
- `qase.title` - set the test title
- `qase.fields` - set the test fields
- `qase.suite` - set the test suite
- `qase.comment` - set the test comment
- `qase.parameters` - set the test parameters
- `qase.groupParameters` - set the test group parameters
- `qase.ignore` - ignore the test in Qase
- `qase.attach` - attach a file to the test
- `qase.steps` - add the test steps

```ts
const { qase } = require('jest-qase-reporter/jest');

test('test', () => {
  qase.title('Title');
  qase.fields({ custom_field: 'value' });
  qase.suite('Suite');
  qase.comment('Comment');
  qase.parameters({ param01: 'value' });
  qase.groupParameters({ param02: 'value' });
  qase.ignore();
  qase.attach({ name: 'attachment.txt', content: 'Hello, world!', type: 'text/plain' });

  qase.step('Step 1', () => {
    expect(true).toBe(true);
  });

  expect(true).toBe(true);
});
```