### PR TITLE
Release/qase cypress 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,22 @@
         "eslint-plugin-cypress": "^2.13.3"
       }
     },
+    "examples/cypress/node_modules/cypress-qase-reporter": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cypress-qase-reporter/-/cypress-qase-reporter-2.1.1.tgz",
+      "integrity": "sha512-0eiAEp9dLpkCdfrI860StR6bNtmyD8FTVua79XBnUGEimdLZgBCPV0Mj/8fvelyN8R8bKvpgu9Uzr7yuO+u02A==",
+      "dev": true,
+      "dependencies": {
+        "qase-javascript-commons": "~2.2.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "cypress": ">=8.0.0"
+      }
+    },
     "examples/jest": {
       "name": "examples-jest",
       "devDependencies": {

--- a/qase-cypress/README.md
+++ b/qase-cypress/README.md
@@ -106,6 +106,7 @@ parameterize your tests.
 - `qase.parameters` - set the parameters of the test case
 - `qase.groupParameters` - set the group parameters of the test case
 - `qase.ignore` - ignore the test case in Qase. The test will be executed, but the results will not be sent to Qase.
+- `qase.step` - create a step in the test case
 
 For example:
 
@@ -206,8 +207,8 @@ module.exports = cypress.defineConfig({
   video: false,
   e2e: {
     setupNodeEvents(on, config) {
-       require('cypress-qase-reporter/plugin')(on, config)
-       require('cypress-qase-reporter/metadata')(on)
+      require('cypress-qase-reporter/plugin')(on, config)
+      require('cypress-qase-reporter/metadata')(on)
     },
   },
 });

--- a/qase-cypress/README.md
+++ b/qase-cypress/README.md
@@ -4,19 +4,10 @@ Publish results simple and easy.
 
 ## Installation
 
-To install the latest release version (2.1.x), run:
+To install the latest release version (2.2.x), run:
 
 ```sh
 npm install -D cypress-qase-reporter
-```
-
-<!-- if there's no current beta, comment the next block
--->
-
-To install the latest beta version (2.2.x), run:
-
-```sh
-npm install -D cypress-qase-reporter@beta
 ```
 
 ## Updating from v1 to v2.1

--- a/qase-cypress/README.md
+++ b/qase-cypress/README.md
@@ -4,7 +4,7 @@ Publish results simple and easy.
 
 ## Installation
 
-To install the latest release version (2.0.x), run:
+To install the latest release version (2.1.x), run:
 
 ```sh
 npm install -D cypress-qase-reporter
@@ -13,7 +13,7 @@ npm install -D cypress-qase-reporter
 <!-- if there's no current beta, comment the next block
 -->
 
-To install the latest beta version (2.1.x), run:
+To install the latest beta version (2.2.x), run:
 
 ```sh
 npm install -D cypress-qase-reporter@beta
@@ -30,7 +30,7 @@ run the following steps:
    - import { qase } from 'cypress-qase-reporter/dist/mocha'
    + import { qase } from 'cypress-qase-reporter/mocha'
    ```                                        
-   
+
 2. Update reporter configuration in `cypress.config.js` and/or environment variables —
    see the [configuration reference](#configuration) below.
 
@@ -68,6 +68,23 @@ run the following steps:
      ...
    ```
 
+## Updating from v2.1 to v2.2
+
+To update an existing test project using Qase reporter from version 2.1 to version 2.2,
+run the following steps:
+
+1. Add a metadata in the `e2e` section of `cypress.config.js`
+
+   ```diff
+     ...
+     e2e: {
+      setupNodeEvents(on, config) { 
+        require('cypress-qase-reporter/plugin')(on, config)
+   +    require('cypress-qase-reporter/metadata')(on)
+       }
+     }
+     ...
+
 ## Getting started
 
 The Cypress reporter can auto-generate test cases
@@ -80,6 +97,16 @@ from Qase.io before executing tests. It's a more reliable way to bind
 autotests to test cases, that persists when you rename, move, or
 parameterize your tests.
 
+### Metadata
+
+- `qase.title` - set the title of the test case
+- `qase.fields` - set the fields of the test case
+- `qase.suite` - set the suite of the test case
+- `qase.comment` - set the comment of the test case
+- `qase.parameters` - set the parameters of the test case
+- `qase.groupParameters` - set the group parameters of the test case
+- `qase.ignore` - ignore the test case in Qase. The test will be executed, but the results will not be sent to Qase.
+
 For example:
 
 ```typescript
@@ -88,6 +115,7 @@ import { qase } from 'cypress-qase-reporter/mocha';
 describe('My First Test', () => {
   qase(1,
     it('Several ids', () => {
+      qase.title('My title');
       expect(true).to.equal(true);
     })
   );
@@ -145,8 +173,6 @@ Example `cypress.config.js` config:
 ```js
 import cypress from 'cypress';
 
-import plugins from './cypress/plugins/index.js';
-
 module.exports = cypress.defineConfig({
   reporter: 'cypress-multi-reporters',
   reporterOptions: {
@@ -180,7 +206,8 @@ module.exports = cypress.defineConfig({
   video: false,
   e2e: {
     setupNodeEvents(on, config) {
-      return plugins(on, config);
+       require('cypress-qase-reporter/plugin')(on, config)
+       require('cypress-qase-reporter/metadata')(on)
     },
   },
 });

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,19 @@
+# cypress-qase-reporter@2.2.0-beta.2
+
+## What's new
+
+Added the ability to add steps in tests:
+
+- `qase.step` - add a step to the test
+
+```ts
+it('test', () => {
+  qase.step('Step 1', () => {
+    cy.visit('https://example.com');
+  });
+});
+```
+
 # cypress-qase-reporter@2.2.0-beta.1
 
 ## What's new

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,21 @@
+# cypress-qase-reporter@2.2.0-beta.3
+
+## What's new
+
+Added the ability to add attachments to tests or steps:
+
+- `qase.attach` - add an attachment to test or step
+
+```ts
+it('test', () => {
+  qase.attach({ paths: '/path/to/file' });
+  qase.step('Step 1', () => {
+    cy.visit('https://example.com');
+    qase.attach({ name: 'attachment.txt', content: 'Hello, world!', contentType: 'text/plain' });
+  });
+});
+```
+
 # cypress-qase-reporter@2.2.0-beta.2
 
 ## What's new

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,31 @@
+# cypress-qase-reporter@2.2.0-beta.1
+
+## What's new
+
+Added the ability to specify a test metadata in tests:
+
+- `qase.title` - set the test title
+- `qase.fields` - set the test fields
+- `qase.suite` - set the test suite
+- `qase.comment` - set the test comment
+- `qase.parameters` - set the test parameters
+- `qase.groupParameters` - set the test group parameters
+- `qase.ignore` - ignore the test in Qase
+
+```ts
+it('test', () => {
+  qase.title('Title');
+  qase.fields({ field: 'value' });
+  qase.suite('Suite');
+  qase.comment('Comment');
+  qase.parameters({ param: 'value' });
+  qase.groupParameters({ param: 'value' });
+  qase.ignore();
+
+  cy.visit('https://example.com');
+});
+```
+
 # cypress-qase-reporter@2.1.0
 
 ## What's new
@@ -40,8 +68,8 @@ The reporter will wait for all results to be sent to Qase and will not block the
 
 ## What's new
 
-1. Cypress kills the process after the last tests. 
-The reporter will wait for all results to be sent to Qase and will not block the process after sending.
+1. Cypress kills the process after the last tests.
+   The reporter will wait for all results to be sent to Qase and will not block the process after sending.
 
 2. The reporter will collect suites and add them to results.
 
@@ -66,7 +94,7 @@ For more information about the new features and a guide for migration from v1, r
 
 # cypress-qase-reporter@2.0.0-beta.3
 
-Fixed an issue with multiple test runs created when Cypress is running 
+Fixed an issue with multiple test runs created when Cypress is running
 multiple tests in parallel.
 
 # cypress-qase-reporter@2.0.0-beta.2

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,9 @@
+# cypress-qase-reporter@2.2.0
+
+## What's new
+
+Minor release of the Cypress reporter package
+
 # cypress-qase-reporter@2.2.0-beta.3
 
 ## What's new

--- a/qase-cypress/docs/usage.md
+++ b/qase-cypress/docs/usage.md
@@ -1,0 +1,196 @@
+# Qase Integration in Cypress
+
+This guide demonstrates how to integrate Qase with Cypress, providing instructions on how to add Qase IDs, titles,
+fields, suites, comments, and file attachments to your test cases.
+
+---
+
+## Adding QaseID to a Test
+
+To associate a QaseID with a test in Cypress, use the `qase` function. This function accepts a single integer
+representing the test's ID in Qase.
+
+### Example:
+
+```javascript
+import { qase } from 'cypress-qase-reporter/mocha';
+
+qase(1, it('simple test', () => {
+  cy.visit('https://example.com');
+}));
+```
+
+---
+
+## Adding a Title to a Test
+
+You can provide a title for your test using the `qase.title` function. The function accepts a string, which will be
+used as the test's title in Qase. If no title is provided, the test method name will be used by default.
+
+### Example:
+
+```javascript
+import { qase } from 'cypress-qase-reporter/mocha';
+
+it('test', () => {
+  qase.title('Title');
+  cy.visit('https://example.com');
+});
+```
+
+---
+
+## Adding Fields to a Test
+
+The `qase.fields` function allows you to add additional metadata to a test case. You can specify multiple fields to
+enhance test case information in Qase.
+
+### System Fields:
+
+- `description` — Description of the test case.
+- `preconditions` — Preconditions for the test case.
+- `postconditions` — Postconditions for the test case.
+- `severity` — Severity of the test case (e.g., `critical`, `major`).
+- `priority` — Priority of the test case (e.g., `high`, `low`).
+- `layer` — Test layer (e.g., `UI`, `API`).
+
+### Example:
+
+```javascript
+import { qase } from 'cypress-qase-reporter/mocha';
+
+it('test', () => {
+  qase.fields({ description: "Description", preconditions: "Preconditions" });
+  cy.visit('https://example.com');
+});
+```
+
+---
+
+## Adding a Suite to a Test
+
+To assign a suite or sub-suite to a test, use the `qase.suite` function. It can receive a suite name, and optionally a
+sub-suite, both as strings.
+
+### Example:
+
+```javascript
+import { qase } from 'cypress-qase-reporter/mocha';
+
+it('test', () => {
+  qase.suite("Suite 01");
+  cy.visit('https://example.com');
+});
+
+it('test', () => {
+  qase.suite("Suite 01\tSuite 02");
+  cy.visit('https://example.com');
+});
+```
+
+---
+
+## Ignoring a Test in Qase
+
+To exclude a test from being reported to Qase (while still executing the test in Cypress), use the `qase.ignore`
+function. The test will run, but its result will not be sent to Qase.
+
+### Example:
+
+```javascript
+import { qase } from 'cypress-qase-reporter/mocha';
+
+it('test', () => {
+  qase.ignore();
+  cy.visit('https://example.com');
+});
+```
+
+---
+
+## Adding a Comment to a Test
+
+You can attach comments to the test results in Qase using the `qase.comment` function. The comment will be displayed
+alongside the test execution details in Qase.
+
+### Example:
+
+```javascript
+import { qase } from 'cypress-qase-reporter/mocha';
+
+it('test', () => {
+  qase.comment("Some comment");
+  cy.visit('https://example.com');
+});
+```
+
+---
+
+## Attaching Files to a Test
+
+To attach files to a test result, use the `qase.attach` function. This method supports attaching one or multiple files,
+along with optional file names, comments, and file types.
+
+### Example:
+
+```javascript
+import { qase } from 'cypress-qase-reporter/mocha';
+
+it('test', () => {
+  qase.attach({ name: 'attachment.txt', content: 'Hello, world!', contentType: 'text/plain' });
+  qase.attach({ paths: '/path/to/file' });
+  qase.attach({ paths: ['/path/to/file', '/path/to/another/file'] });
+  cy.visit('https://example.com');
+});
+```
+
+## Adding Parameters to a Test
+
+You can add parameters to a test case using the `qase.parameters` function. This function accepts an object with
+parameter names and values.
+
+### Example:
+
+```javascript
+import { qase } from 'cypress-qase-reporter/mocha';
+
+it('test', () => {
+  qase.parameters({ param1: 'value1', param2: 'value2' });
+  cy.visit('https://example.com');
+});
+```
+
+## Adding Group Parameters to a Test
+
+To add group parameters to a test case, use the `qase.groupParameters` function. This function accepts an list with
+group parameter names.
+
+### Example:
+
+```javascript
+import { qase } from 'cypress-qase-reporter/mocha';
+
+it('test', () => {
+  qase.parameters({ param1: 'value1', param2: 'value2' });
+  qase.groupParameters(['param1']);
+  cy.visit('https://example.com');
+});
+```
+
+## Adding Steps to a Test
+
+You can add steps to a test case using the `qase.step` function. This function accepts a string, which will be used as
+the step description in Qase.
+
+### Example:
+
+```javascript
+import { qase } from 'cypress-qase-reporter/mocha';
+
+it('test', () => {
+  qase.step('Some step', () => {
+    // some actions
+  });
+  cy.visit('https://example.com');
+});
+```

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0-beta.2",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.1.1",
+  "version": "2.2.0-beta.1",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -12,6 +12,7 @@
     "./reporter": "./dist/reporter.js",
     "./package.json": "./package.json",
     "./plugin": "./dist/plugin.js",
+    "./metadata": "./dist/metadata.js",
     "./hooks": "./dist/hooks.js"
   },
   "typesVersions": {

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.0-beta.2",
+  "version": "2.2.0-beta.3",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.0-beta.3",
+  "version": "2.2.0",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/metadata.js
+++ b/qase-cypress/src/metadata.js
@@ -1,0 +1,52 @@
+import { MetadataManager } from './metadata/manager';
+
+module.exports = function(on) {
+  on('task', {
+    qaseTitle(value) {
+      MetadataManager.setTitle(value);
+      return null;
+    },
+  });
+
+  on('task', {
+    qaseFields(value) {
+      MetadataManager.setFields(value);
+      return null;
+    },
+  });
+
+  on('task', {
+    qaseIgnore() {
+      MetadataManager.setIgnore();
+      return null;
+    },
+  });
+
+  on('task', {
+    qaseParameters(value) {
+      MetadataManager.setParameters(value);
+      return null;
+    },
+  });
+
+  on('task', {
+    qaseGroupParameters(value) {
+      MetadataManager.setGroupParams(value);
+      return null;
+    },
+  });
+
+  on('task', {
+    qaseSuite(value) {
+      MetadataManager.setSuite(value);
+      return null;
+    },
+  });
+
+  on('task', {
+    qaseComment(value) {
+      MetadataManager.setComment(value);
+      return null;
+    },
+  });
+};

--- a/qase-cypress/src/metadata.js
+++ b/qase-cypress/src/metadata.js
@@ -49,4 +49,18 @@ module.exports = function(on) {
       return null;
     },
   });
+
+  on('task', {
+    qaseStepStart(value) {
+      MetadataManager.addStepStart(value);
+      return null;
+    },
+  });
+
+  on('task', {
+    qaseStepEnd(value) {
+      MetadataManager.addStepEnd(value);
+      return null;
+    },
+  });
 };

--- a/qase-cypress/src/metadata.js
+++ b/qase-cypress/src/metadata.js
@@ -63,4 +63,11 @@ module.exports = function(on) {
       return null;
     },
   });
+
+  on('task', {
+    qaseAttach(value) {
+      MetadataManager.addAttach(value);
+      return null;
+    },
+  });
 };

--- a/qase-cypress/src/metadata/manager.ts
+++ b/qase-cypress/src/metadata/manager.ts
@@ -1,0 +1,101 @@
+import { Metadata } from './models';
+import { readFileSync, existsSync, unlinkSync, writeFileSync } from 'fs';
+
+const metadataPath = 'qaseMetadata';
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export class MetadataManager {
+  public static getMetadata(): Metadata | undefined {
+    if (!this.isExists()) {
+      return undefined;
+    }
+
+    let metadata: Metadata = {
+      title: undefined,
+      fields: {},
+      parameters: {},
+      groupParams: {},
+      ignore: false,
+      suite: undefined,
+      comment: undefined,
+    };
+
+    try {
+      const data = readFileSync(metadataPath, 'utf8');
+      metadata = JSON.parse(data) as Metadata;
+
+      return metadata;
+    } catch (err) {
+      console.error('Error reading metadata file:', err);
+    }
+
+    return undefined;
+  }
+
+  public static setIgnore(): void {
+    const metadata = this.getMetadata() ?? {};
+    metadata.ignore = true;
+    this.setMetadata(metadata);
+  }
+
+  public static setSuite(suite: string): void {
+    const metadata = this.getMetadata() ?? {};
+    metadata.suite = suite;
+    this.setMetadata(metadata);
+  }
+
+  public static setComment(comment: string): void {
+    const metadata = this.getMetadata() ?? {};
+    metadata.comment = comment;
+    this.setMetadata(metadata);
+  }
+
+  public static setTitle(title: string): void {
+    const metadata = this.getMetadata() ?? {};
+    metadata.title = title;
+    this.setMetadata(metadata);
+  }
+
+  public static setFields(fields: Record<string, string>): void {
+    const metadata = this.getMetadata() ?? {};
+    metadata.fields = fields;
+    this.setMetadata(metadata);
+  }
+
+  public static setParameters(parameters: Record<string, string>): void {
+    const metadata = this.getMetadata() ?? {};
+    metadata.parameters = parameters;
+    this.setMetadata(metadata);
+  }
+
+  public static setGroupParams(groupParams: Record<string, string>): void {
+    const metadata = this.getMetadata() ?? {};
+    metadata.groupParams = groupParams;
+    this.setMetadata(metadata);
+  }
+
+  private static setMetadata(metadata: Metadata): void {
+    try {
+      const data = JSON.stringify(metadata);
+      writeFileSync(metadataPath, data);
+    } catch (err) {
+      console.error('Error writing metadata file:', err);
+    }
+  }
+
+  public static clear() {
+    if (!this.isExists()) {
+      return;
+    }
+
+    try {
+      unlinkSync(metadataPath);
+    } catch (err) {
+      console.error('Error clearing state file:', err);
+    }
+  }
+
+  static isExists(): boolean {
+    return existsSync(metadataPath);
+  }
+}

--- a/qase-cypress/src/metadata/models.ts
+++ b/qase-cypress/src/metadata/models.ts
@@ -1,0 +1,9 @@
+export interface Metadata {
+  title?: string | undefined;
+  fields?: Record<string, string>;
+  parameters?: Record<string, string>;
+  groupParams?: Record<string, string>;
+  ignore?: boolean;
+  suite?: string | undefined;
+  comment?: string | undefined;
+}

--- a/qase-cypress/src/metadata/models.ts
+++ b/qase-cypress/src/metadata/models.ts
@@ -6,4 +6,20 @@ export interface Metadata {
   ignore?: boolean;
   suite?: string | undefined;
   comment?: string | undefined;
+  steps?: (StepStart | StepEnd)[];
+  currentStepId?: string | undefined;
+  firstStepName?: string | undefined;
+}
+
+export interface StepStart {
+  id: string;
+  timestamp: number;
+  name: string;
+  parentId: string | undefined;
+}
+
+export interface StepEnd {
+  id: string;
+  timestamp: number;
+  status: string;
 }

--- a/qase-cypress/src/metadata/models.ts
+++ b/qase-cypress/src/metadata/models.ts
@@ -1,3 +1,5 @@
+import { Attachment } from 'qase-javascript-commons';
+
 export interface Metadata {
   title?: string | undefined;
   fields?: Record<string, string>;
@@ -9,6 +11,8 @@ export interface Metadata {
   steps?: (StepStart | StepEnd)[];
   currentStepId?: string | undefined;
   firstStepName?: string | undefined;
+  attachments?: Attachment[];
+  stepAttachments?: Record<string, Attachment[]>;
 }
 
 export interface StepStart {
@@ -22,4 +26,12 @@ export interface StepEnd {
   id: string;
   timestamp: number;
   status: string;
+}
+
+
+export interface Attach {
+  name?: string;
+  paths?: string | string[];
+  content?: Buffer | string;
+  contentType?: string;
 }

--- a/qase-cypress/src/mocha.ts
+++ b/qase-cypress/src/mocha.ts
@@ -127,3 +127,25 @@ qase.comment = (
     //
   });
 };
+
+/**
+ * Add a step to  the test case
+ * @param {string} name
+ * @param {() => T | PromiseLike<T>} body
+ * @example
+ * it('test', () => {
+ *    qase.step("Some step", () => {
+ *      // some actions
+ *    });
+ *    cy.visit('https://example.com');
+ * });
+ */
+qase.step = <T = void>(name: string, body: () => T | PromiseLike<T>) => {
+  return cy.task('qaseStepStart', name).then(() => {
+    return Cypress.Promise.resolve(body());
+  }).then(() => {
+    cy.task('qaseStepEnd', 'passed').then(() => {
+      //
+    });
+  });
+};

--- a/qase-cypress/src/mocha.ts
+++ b/qase-cypress/src/mocha.ts
@@ -23,7 +23,7 @@ export const qase = (
 qase.title = (
   value: string,
 ) => {
-  cy.task('qaseTitle', value).then(() => {
+  return cy.task('qaseTitle', value).then(() => {
     //
   });
 };
@@ -41,7 +41,7 @@ qase.title = (
 qase.fields = (
   values: Record<string, string>,
 ) => {
-  cy.task('qaseFields', values).then(() => {
+  return cy.task('qaseFields', values).then(() => {
     //
   });
 };
@@ -55,7 +55,7 @@ qase.fields = (
  * });
  */
 qase.ignore = () => {
-  cy.task('qaseIgnore').then(() => {
+  return cy.task('qaseIgnore').then(() => {
     //
   });
 };
@@ -72,7 +72,7 @@ qase.ignore = () => {
 qase.parameters = (
   values: Record<string, string>,
 ) => {
-  cy.task('qaseParameters', values).then(() => {
+  return cy.task('qaseParameters', values).then(() => {
     //
   });
 };
@@ -89,7 +89,7 @@ qase.parameters = (
 qase.groupParameters = (
   values: Record<string, string>,
 ) => {
-  cy.task('qaseGroupParameters', values).then(() => {
+  return cy.task('qaseGroupParameters', values).then(() => {
     //
   });
 };
@@ -106,7 +106,7 @@ qase.groupParameters = (
 qase.suite = (
   value: string,
 ) => {
-  cy.task('qaseSuite', value).then(() => {
+  return cy.task('qaseSuite', value).then(() => {
     //
   });
 };
@@ -123,7 +123,7 @@ qase.suite = (
 qase.comment = (
   value: string,
 ) => {
-  cy.task('qaseComment', value).then(() => {
+  return cy.task('qaseComment', value).then(() => {
     //
   });
 };
@@ -147,5 +147,27 @@ qase.step = <T = void>(name: string, body: () => T | PromiseLike<T>) => {
     cy.task('qaseStepEnd', 'passed').then(() => {
       //
     });
+  });
+};
+
+/**
+ * Attach a file to the test case or the step
+ * @param attach
+ * @example
+ * it('test', () => {
+ *   qase.attach({ name: 'attachment.txt', content: 'Hello, world!', contentType: 'text/plain' });
+ *   qase.attach({ paths: '/path/to/file'});
+ *   qase.attach({ paths: ['/path/to/file', '/path/to/another/file']});
+ *   cy.visit('https://example.com');
+ *  });
+ */
+qase.attach = (attach: {
+  name?: string,
+  paths?: string | string[],
+  content?: Buffer | string,
+  contentType?: string,
+}) => {
+  return cy.task('qaseAttach', attach).then(() => {
+    //
   });
 };

--- a/qase-cypress/src/mocha.ts
+++ b/qase-cypress/src/mocha.ts
@@ -10,3 +10,120 @@ export const qase = (
 
   return test;
 };
+
+/**
+ * Set a title for the test case
+ * @param {string} value
+ * @example
+ * it('test', () => {
+ *    qase.title("Title");
+ *    cy.visit('https://example.com');
+ * });
+ */
+qase.title = (
+  value: string,
+) => {
+  cy.task('qaseTitle', value).then(() => {
+    //
+  });
+};
+
+
+/**
+ * Set fields for the test case
+ * @param {Record<string, string>} values
+ * @example
+ * it('test', () => {
+ *    qase.fields({description: "Description"});
+ *    cy.visit('https://example.com');
+ * });
+ */
+qase.fields = (
+  values: Record<string, string>,
+) => {
+  cy.task('qaseFields', values).then(() => {
+    //
+  });
+};
+
+/**
+ * Ignore the test case result in Qase
+ * @example
+ * it('test', () => {
+ *    qase.ignore();
+ *    cy.visit('https://example.com');
+ * });
+ */
+qase.ignore = () => {
+  cy.task('qaseIgnore').then(() => {
+    //
+  });
+};
+
+/**
+ * Set parameters for the test case
+ * @param {Record<string, string>} values
+ * @example
+ * it('test', () => {
+ *    qase.parameters({param01: "value01"});
+ *    cy.visit('https://example.com');
+ * });
+ */
+qase.parameters = (
+  values: Record<string, string>,
+) => {
+  cy.task('qaseParameters', values).then(() => {
+    //
+  });
+};
+
+/**
+ * Set group parameters for the test case
+ * @param {Record<string, string>} values
+ * @example
+ * it('test', () => {
+ *    qase.groupParameters({param01: "value01"});
+ *    cy.visit('https://example.com');
+ * });
+ */
+qase.groupParameters = (
+  values: Record<string, string>,
+) => {
+  cy.task('qaseGroupParameters', values).then(() => {
+    //
+  });
+};
+
+/**
+ * Set a suite for the test case
+ * @param {string} value
+ * @example
+ * it('test', () => {
+ *    qase.suite("Suite 01");
+ *    cy.visit('https://example.com');
+ * });
+ */
+qase.suite = (
+  value: string,
+) => {
+  cy.task('qaseSuite', value).then(() => {
+    //
+  });
+};
+
+/**
+ * Set a comment for the test case
+ * @param {string} value
+ * @example
+ * it('test', () => {
+ *    qase.comment("Some comment");
+ *    cy.visit('https://example.com');
+ * });
+ */
+qase.comment = (
+  value: string,
+) => {
+  cy.task('qaseComment', value).then(() => {
+    //
+  });
+};

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -183,6 +183,8 @@ export class CypressQaseReporter extends reporters.Base {
       ? CypressQaseReporter.findAttachments(ids, this.screenshotsFolder)
       : undefined;
 
+    attachments?.push(...(metadata?.attachments ?? []));
+
     let relations = {};
     if (test.parent !== undefined) {
       const data = [];
@@ -235,7 +237,7 @@ export class CypressQaseReporter extends reporters.Base {
       relations: relations,
       run_id: null,
       signature: this.getSignature(test, ids),
-      steps: metadata?.steps ? this.getSteps(metadata.steps) : [],
+      steps: metadata?.steps ? this.getSteps(metadata.steps, metadata.stepAttachments ?? {}) : [],
       id: uuidv4(),
       execution: {
         status: test.state
@@ -300,7 +302,7 @@ export class CypressQaseReporter extends reporters.Base {
     return undefined;
   }
 
-  private getSteps(steps: (StepStart | StepEnd)[]): TestStepType[] {
+  private getSteps(steps: (StepStart | StepEnd)[], attachments: Record<string, Attachment[]>): TestStepType[] {
     const result: TestStepType[] = [];
     const stepMap = new Map<string, TestStepType>();
 
@@ -315,6 +317,10 @@ export class CypressQaseReporter extends reporters.Base {
           action: step.name,
           expected_result: null,
         };
+
+        if (attachments[step.id]) {
+          newStep.attachments = attachments[step.id] ?? [];
+        }
 
         const parentId = step.parentId;
         if (parentId) {


### PR DESCRIPTION
Added the ability to specify a test metadata in tests:

- `qase.title` - set the test title
- `qase.fields` - set the test fields
- `qase.suite` - set the test suite
- `qase.comment` - set the test comment
- `qase.parameters` - set the test parameters
- `qase.groupParameters` - set the test group parameters
- `qase.ignore` - ignore the test in Qase

```ts
it('test', () => {
  qase.title('Title');
  qase.fields({ field: 'value' });
  qase.suite('Suite');
  qase.comment('Comment');
  qase.parameters({ param: 'value' });
  qase.groupParameters({ param: 'value' });
  qase.ignore();

  cy.visit('https://example.com');
});
```

---

Added the ability to add steps in tests:

- `qase.step` - add a step to the test

```ts
it('test', () => {
  qase.step('Step 1', () => {
    cy.visit('https://example.com');
  });
});
```

---

Added the ability to add attachments to tests or steps:

- `qase.attach` - add an attachment to test or step

```ts
it('test', () => {
  qase.attach({ paths: '/path/to/file' });
  qase.step('Step 1', () => {
    cy.visit('https://example.com');
    qase.attach({ name: 'attachment.txt', content: 'Hello, world!', contentType: 'text/plain' });
  });
});
```