### PR TITLE
feat: remove QaseID from test names in output

### DIFF
--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,17 @@
+# cypress-qase-reporter@2.2.1
+
+## What's new
+
+When specifying test names, QaseIDs are now excluded from the final test name.
+
+```js
+// The test name will be 'Example', not 'Example (Qase ID: 1)'
+qase(1,it('Example', () => {
+    expect(true).to.equal(true);
+  })
+);
+```
+
 # cypress-qase-reporter@2.2.0
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -47,7 +47,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.2.0",
+    "qase-javascript-commons": "~2.2.3",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -250,7 +250,7 @@ export class CypressQaseReporter extends reporters.Base {
         thread: null,
       },
       testops_id: ids.length > 0 ? ids : null,
-      title: metadata?.title ?? test.title,
+      title: metadata?.title ?? this.removeQaseIdsFromTitle(test.title),
     };
 
     void this.reporter.addTestResult(result);
@@ -300,6 +300,19 @@ export class CypressQaseReporter extends reporters.Base {
     }
 
     return undefined;
+  }
+
+  /**
+   * @param {string} title
+   * @returns {string}
+   * @private
+   */
+  private removeQaseIdsFromTitle(title: string): string {
+    const matches = title.match(/\(Qase ID: ([0-9,]+)\)$/i);
+    if (matches) {
+      return title.replace(matches[0], '').trimEnd();
+    }
+    return title;
   }
 
   private getSteps(steps: (StepStart | StepEnd)[], attachments: Record<string, Attachment[]>): TestStepType[] {


### PR DESCRIPTION
When specifying test names, QaseIDs are now excluded from the final test name. For example, `Example (Qase ID: 1)` will appear as `Example` in the test output.