### PR TITLE
feat: support attachments in the test results

### DIFF
--- a/examples/cucumberjs/package.json
+++ b/examples/cucumberjs/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^7.3.2",
-    "cucumberjs-qase-reporter": "^2.0.0-beta.3"
+    "cucumberjs-qase-reporter": "^2.0.3"
   }
 }

--- a/examples/cucumberjs/qase.config.json
+++ b/examples/cucumberjs/qase.config.json
@@ -5,9 +5,8 @@
     "api": {
       "token": "api_key"
     },
-
     "project": "project_code",
-
+    "uploadAttachments": true,
     "run": {
       "complete": true
     }

--- a/examples/cucumberjs/step_definitions/simple_steps.js
+++ b/examples/cucumberjs/step_definitions/simple_steps.js
@@ -2,6 +2,7 @@ const { Given, When, Then } = require('@cucumber/cucumber');
 
 Given('I have a step', function() {
   console.log('I have a step');
+  this.attach('I\'m an attachment', 'text/plain');
 });
 
 Given('I have another step', function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
       "name": "examples-cucumberjs",
       "devDependencies": {
         "@cucumber/cucumber": "^7.3.2",
-        "cucumberjs-qase-reporter": "^2.0.0-beta.3"
+        "cucumberjs-qase-reporter": "^2.0.3"
       }
     },
     "examples/cypress": {
@@ -15189,7 +15189,7 @@
     },
     "qase-cucumberjs": {
       "name": "cucumberjs-qase-reporter",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/messages": "^22.0.0",
@@ -15199,7 +15199,8 @@
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
         "jest": "^29.5.0",
-        "ts-jest": "^29.1.0"
+        "ts-jest": "^29.1.0",
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -15210,7 +15211,7 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "qase-javascript-commons": "~2.2.3",

--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,21 @@
+# qase-cucumberjs@2.0.3
+
+## What's new
+
+Support attachments in the test results.
+
+```js
+const { Given, Then } = require('cucumber');
+
+Given('I have a step with attachment', async function () {
+  await this.attach('Hello, world!', 'text/plain');
+});
+
+Then('I have a step with attachment', async function () {
+  await this.attach('Hello, world!', 'text/plain');
+});
+```
+
 # qase-cucumberjs@2.0.2
 
 ## What's new

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",
@@ -49,6 +49,7 @@
     "@jest/globals": "^29.5.0",
     "@types/jest": "^29.5.2",
     "jest": "^29.5.0",
-    "ts-jest": "^29.1.0"
+    "ts-jest": "^29.1.0",
+    "uuid": "^9.0.0"
   }
 }


### PR DESCRIPTION
```js
const { Given, Then } = require('cucumber');

Given('I have a step with attachment', async function () {
  await this.attach('Hello, world!', 'text/plain');
});

Then('I have a step with attachment', async function () {
  await this.attach('Hello, world!', 'text/plain');
});
```