### PR TITLE
fix: an issue with the `@cypress/grep` plugin

### DIFF
--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,8 +1,20 @@
+# cypress-qase-reporter@2.2.3
+
+## What's new
+
+Fixed an issue with the `@cypress/grep` plugin. When the `grepOmitFiltered` option is set to `true`, the reporter
+encounters an error.
+
+```log
+Cannot set properties of undefined (setting 'title')
+```
+
 # cypress-qase-reporter@2.2.2
 
 ## What's new
 
-Fixed an issue with metadata. When specifying the path to the Cypress config located outside the root directory, metadata was not added to the test case.
+Fixed an issue with metadata. When specifying the path to the Cypress config located outside the root directory,
+metadata was not added to the test case.
 
 # cypress-qase-reporter@2.2.1
 
@@ -12,7 +24,7 @@ When specifying test names, QaseIDs are now excluded from the final test name.
 
 ```js
 // The test name will be 'Example', not 'Example (Qase ID: 1)'
-qase(1,it('Example', () => {
+qase(1, it('Example', () => {
     expect(true).to.equal(true);
   })
 );

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/mocha.ts
+++ b/qase-cypress/src/mocha.ts
@@ -4,6 +4,10 @@ export const qase = (
   caseId: number | string | number[] | string[],
   test: Test,
 ) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!test?.title) {
+    return test;
+  }
   const caseIds = Array.isArray(caseId) ? caseId : [caseId];
 
   test.title = `${test.title} (Qase ID: ${caseIds.join(',')})`;


### PR DESCRIPTION
When the `grepOmitFiltered` option is set to `true`, the reporter encounters an error.

```log
Cannot set properties of undefined (setting 'title')
```