### PR TITLE
feat : use the API v2 client by default

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.2.5
+
+## What's new
+
+Use the API v2 client by default. If you want to use the API v1 client, specify the `useV2` option in the config file or
+the environment variable `QASE_TESTOPS_USEV2` as `False`.
+
 # qase-javascript-commons@2.2.3
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -196,7 +196,7 @@ export class TestOpsReporter extends AbstractReporter {
     this.environment = environment;
     this.planId = plan.id;
     this.batchSize = options.batch?.size ?? defaultChunkSize;
-    this.useV2 = options.useV2 ?? false;
+    this.useV2 = options.useV2 ?? true;
     this.defect = options.defect ?? false;
     this.rootSuite = rootSuite;
   }


### PR DESCRIPTION
Use the API v2 client by default. If you want to use the API v1 client, specify the `useV2` option in the config file or the environment variable `QASE_TESTOPS_USEV2` as `False`.