### PR TITLE
fix: error when uploading results due to bad request

### DIFF
--- a/qase-newman/changelog.md
+++ b/qase-newman/changelog.md
@@ -1,3 +1,14 @@
+# qase-newman@2.0.4
+
+## What's new
+
+Resolved error when uploading results due to bad request:
+
+```log
+ Error: Error on uploading results: Bad request. Body: 
+ {"message":"The execution.start time must be at least 1732623290. (and 1 more error)","errors":{"execution.start_time":["The execution.start time must be at least 1732623290."],"execution.end_time":["The execution.end time must be at least 1732623290."]}}
+```
+
 # qase-newman@2.0.3
 
 ## What's new
@@ -27,7 +38,7 @@ For more information about the new features and a guide for migration from v1, r
 
 ## What's new
 
-Add support for suites in test results. 
+Add support for suites in test results.
 
 # qase-newman@2.0.0-beta.1
 

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-qase",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Qase TMS Newman Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-newman/src/reporter.ts
+++ b/qase-newman/src/reporter.ts
@@ -199,8 +199,8 @@ export class NewmanQaseReporter {
           author: null,
           execution: {
             status: TestStatusEnum.passed,
-            start_time: 0,
-            end_time: 0,
+            start_time: null,
+            end_time: null,
             duration: 0,
             stacktrace: null,
             thread: null,


### PR DESCRIPTION
```log
 Error: Error on uploading results: Bad request. Body:
 {"message":"The execution.start time must be at least 1732623290. (and 1 more error)","errors":{"execution.start_time":["The execution.start time must be at least 1732623290."],"execution.end_time":["The execution.end time must be at least 1732623290."]}}
```