### PR TITLE
feat: add QaseID support and console log attachments for tests

### DIFF
--- a/examples/mocha/package.json
+++ b/examples/mocha/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "mocha": "^10.2.0",
-    "mocha-qase-reporter": "^1.0.0-beta.1"
+    "mocha-qase-reporter": "^1.0.0-beta.5"
   }
 }

--- a/examples/mocha/test/attachTests.spec.js
+++ b/examples/mocha/test/attachTests.spec.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 
 
-describe('tests with attachments', function() {
+describe('Attachment tests', function() {
   it('successful test with string attachment', function() {
     this.attach({name:"attachment.log", content:"data", contentType:"text/plain"});
     assert.strictEqual(1, 1);

--- a/examples/mocha/test/parametrizedTests.spec.js
+++ b/examples/mocha/test/parametrizedTests.spec.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+
+describe('Parametrized test', function() {
+  const params = [1, 2, 3, 4, 5];
+  params.forEach((param) => {
+    it(`test with parameters success ${param}`, function() {
+      this.parameters({ number: param });
+      assert.strictEqual(param, param);
+    });
+    it(`test with parameters failed ${param}`, function() {
+      this.parameters({ number: param });
+      assert.strictEqual(param, param + 1);
+    });
+  });
+});

--- a/examples/mocha/test/simpleTests.spec.js
+++ b/examples/mocha/test/simpleTests.spec.js
@@ -1,99 +1,72 @@
 const assert = require('assert');
+const { qase } = require('mocha-qase-reporter/mocha');
 
 
-describe('test without qase metadata', function() {
-  it('successful test', function() {
+describe('Simple tests', function() {
+  it('test without qase metadata success', function() {
     assert.strictEqual(1, 1);
   });
 
-  it('failing test', function() {
+  it('test without qase metadata failed', function() {
     assert.strictEqual(1, 2);
   });
-});
 
-describe('test with qase id', function() {
-  it('successful test', function() {
-    this.qaseId(1);
+  it.skip(qase(1, 'test with qase id success'), function() {
     assert.strictEqual(1, 1);
   });
 
-  it('failing test', function() {
-    this.qaseId(2);
+  it(qase(2, 'test with qase id failed'), function() {
     assert.strictEqual(1, 2);
   });
-});
 
-describe('test with title', function() {
-  it('successful test', function() {
+  it('test with title success', function() {
     this.title('Successful test with title');
     assert.strictEqual(1, 1);
   });
 
-  it('failing test', function() {
+  it('test with title failed', function() {
     this.title('Failing test with title');
     assert.strictEqual(1, 2);
   });
-});
 
-describe('test with suite', function() {
-  it('successful test', function() {
+  it('test with suite success', function() {
     this.suite('Suite 1');
     assert.strictEqual(1, 1);
   });
 
-  it('failing test', function() {
+  it('test with suite failed', function() {
     this.suite('Suite 1');
     assert.strictEqual(1, 2);
   });
-});
 
-describe('test with comment', function() {
-  it('successful test', function() {
+  it('test with comment success', function() {
     this.comment('comment');
     assert.strictEqual(1, 1);
   });
 
-  it('failing test', function() {
+  it('test with comment failed', function() {
     this.comment('comment');
     assert.strictEqual(1, 2);
   });
-});
 
-describe('test with parameters', function() {
-  const params = [1, 2, 3, 4, 5];
-  params.forEach((param) => {
-    it(`successful test with parameter ${param}`, function() {
-      this.parameters({ number: param });
-      assert.strictEqual(param, param);
-    });
-    it(`failing test with parameter ${param}`, function() {
-      this.parameters({ number: param });
-      assert.strictEqual(param, param + 1);
-    });
-  });
-});
-
-
-describe('test with fields', function() {
-  it('successful test', function() {
+  it('test with fields success', function() {
     this.fields({ custom_field: 'value' });
     assert.strictEqual(1, 1);
   });
 
-  it('failing test', function() {
+  it('test with fields failed', function() {
     this.fields({ custom_field: 'value' });
     assert.strictEqual(1, 2);
   });
-});
 
-describe('ignored test', function() {
-  it('successful test', function() {
+  it('ignored test success', function() {
     this.ignore();
     assert.strictEqual(1, 1);
   });
 
-  it('failing test', function() {
+  it('ignored test failed', function() {
     this.ignore();
     assert.strictEqual(1, 2);
   });
 });
+

--- a/examples/mocha/test/stepTests.spec.js
+++ b/examples/mocha/test/stepTests.spec.js
@@ -1,13 +1,10 @@
 const assert = require('assert');
 
 
-describe('tests with steps', function() {
+describe('Step tests', function() {
   it('successful test with steps', function() {
-    this.step('step 1', function() {
-      this.attach({name:"attachment.log", content:"data", contentType:"text/plain"});
-    });
+    this.step('step 1', function() {});
     this.step('step 2', function() {});
-    this.attach({name:"attachment111.log", content:"data", contentType:"text/plain"});
     assert.strictEqual(1, 1);
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
       "name": "examples-mocha",
       "devDependencies": {
         "mocha": "^10.2.0",
-        "mocha-qase-reporter": "^1.0.0-beta.1"
+        "mocha-qase-reporter": "^1.0.0-beta.5"
       }
     },
     "examples/newman": {
@@ -84,7 +84,7 @@
       "name": "examples-playwright",
       "devDependencies": {
         "@playwright/test": "^1.34.3",
-        "playwright-qase-reporter": "^2.0.16"
+        "playwright-qase-reporter": "^2.0.0"
       }
     },
     "examples/testcafe": {
@@ -15218,7 +15218,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -15308,7 +15308,7 @@
     },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
         "deasync-promise": "^1.0.1",
@@ -15342,7 +15342,7 @@
     },
     "qase-newman": {
       "name": "newman-reporter-qase",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "qase-javascript-commons": "~2.2.0",

--- a/qase-mocha/README.md
+++ b/qase-mocha/README.md
@@ -23,15 +23,15 @@ parameterize your tests.
 For example:
 
 ```typescript
+import { qase } from 'mocha-qase-reporter/mocha';
+
 describe('My First Test', () => {
-  it('Several ids', () => {
-    this.qaseId(1);
+  it(qase(1,'Several ids'), () => {;
     expect(true).to.equal(true);
   });
 
   // a test can check multiple test cases
-  it('Correct test', () => {
-    this.qaseId([2, 3]);
+  it(qase([2,3],'Correct test'), () => {
     expect(true).to.equal(true);
   });
 

--- a/qase-mocha/changelog.md
+++ b/qase-mocha/changelog.md
@@ -1,3 +1,11 @@
+# qase-mocha@1.0.0-beta.5
+
+## What's new
+
+- Added a `qase` function to allow specifying QaseID for tests.
+- Marked the old syntax for QaseID as deprecated.
+- Implemented functionality to capture console logs and include them as attachments in tests.
+
 # qase-mocha@1.0.0-beta.4
 
 ## What's new

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -9,7 +9,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./reporter": "./dist/reporter.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./mocha": "./dist/mocha.js"
   },
   "typesVersions": {
     "*": {

--- a/qase-mocha/src/interceptor.ts
+++ b/qase-mocha/src/interceptor.ts
@@ -1,0 +1,21 @@
+import { Writable } from 'stream';
+
+export interface TestOutput {
+  stdout: string;
+  stderr: string;
+}
+
+export class StreamInterceptor extends Writable {
+  private readonly onWrite: (data: string) => void;
+
+  constructor(onWriteCallback: (data: string) => void) {
+    super();
+    this.onWrite = onWriteCallback;
+  }
+
+  override _write(chunk: any, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-call
+    this.onWrite(chunk.toString());
+    callback();
+  }
+}

--- a/qase-mocha/src/mocha.ts
+++ b/qase-mocha/src/mocha.ts
@@ -1,0 +1,36 @@
+/**
+ * Set IDs for the test case
+ *
+ * @param caseId
+ * @param name
+ * @example
+ * it(qase(1, 'test'), function() => {
+ *  // test code
+ * });
+ * @returns {string}
+ */
+export const qase = (
+  caseId: number | string | number[] | string[],
+  name: string,
+): string => {
+  const caseIds = Array.isArray(caseId) ? caseId : [caseId];
+  const ids: number[] = [];
+
+  for (const id of caseIds) {
+    if (typeof id === 'number') {
+      ids.push(id);
+      continue;
+    }
+
+    const parsedId = parseInt(id);
+
+    if (!isNaN(parsedId)) {
+      ids.push(parsedId);
+      continue;
+    }
+
+    console.log(`qase: qase ID ${id} should be a number`);
+  }
+
+  return `${name} (Qase ID: ${caseIds.join(',')})`;
+};

--- a/qase-mocha/src/types.ts
+++ b/qase-mocha/src/types.ts
@@ -18,6 +18,10 @@ export interface Hook extends Mocha.Hook {
 }
 
 export interface Methods {
+  /**
+   * Set IDs for the test case
+   * Use `qase()` instead. This method is deprecated and kept for reverse compatibility.
+   */
   qaseId(id: number | number[]): void;
 
   title(title: string): void;


### PR DESCRIPTION
This pull request includes several updates and improvements to the `qase-mocha` package, including new features, refactoring, and test updates. The most important changes include the addition of a new `qase` function, capturing console logs as test attachments, and renaming test files for better clarity.

### New Features:
* Added a `qase` function to allow specifying QaseID for tests.
* Implemented functionality to capture console logs and include them as attachments in tests. [[1]](diffhunk://#diff-9e21691f29dedbdadb38491a2e4666a5c2a6f3e2d0cf15a8297d1f444d2f372bR126-R181) [[2]](diffhunk://#diff-9e21691f29dedbdadb38491a2e4666a5c2a6f3e2d0cf15a8297d1f444d2f372bL173-R232)

### Refactoring:
* Renamed `examples/mocha/test/stepsTests.spec.js` to `stepTests.spec.js` for better clarity.
* Updated `mocha-qase-reporter` dependency to `^1.0.0-beta.5` in `examples/mocha/package.json`.

### Test Updates:
* Simplified and renamed test descriptions in `attachTests.spec.js`, `parametrizedTests.spec.js`, and `simpleTests.spec.js` for better readability. [[1]](diffhunk://#diff-27fa83c2c542b813487a15da2389cd8a6bf6a39ed158b619860faf7ba55605f9L4-R4) [[2]](diffhunk://#diff-fc03f63d098f1aa2fbfd57a4615ffa31bc9c1dc4db89304bf7603ea1192ff7f5R1-R15) [[3]](diffhunk://#diff-2ababac9ddbfa68091dd9ac993a2cb76362e6b91cd1afc137bf1fa3733e102d6R2-R72)

### Documentation:
* Updated `changelog.md` to include changes for version `1.0.0-beta.5`.

### Miscellaneous:
* Added `./mocha` export to `qase-mocha/package.json`.