### PR TITLE
feat: add method to retrieve file attachments for failed tests

### DIFF
--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,9 @@
+# cypress-qase-reporter@2.2.4
+
+## What's new
+
+Fixed an issue with screenshots not being uploaded to Qase for failed tests.
+
 # cypress-qase-reporter@2.2.3
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/fileSearcher.ts
+++ b/qase-cypress/src/fileSearcher.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export class FileSearcher {
+  /**
+   * Finds all files in the given directory and its subdirectories
+   * that were created after the specified time.
+   *
+   * @param folderPath Relative path to the folder.
+   * @param time Time threshold as a Date object.
+   * @returns Array of absolute paths to the matching files.
+   */
+  public static findFilesBeforeTime(folderPath: string, time: Date): string[] {
+    const absolutePath = path.resolve(process.cwd(), folderPath);
+    const result: string[] = [];
+
+    const searchFiles = (dir: string) => {
+      if (!fs.existsSync(dir)) {
+        return;
+      }
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const entryPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+          searchFiles(entryPath);
+        } else if (entry.isFile()) {
+          const stats = fs.statSync(entryPath);
+          if (stats.birthtime > time) {
+            result.push(entryPath);
+          }
+        }
+      }
+    };
+
+    searchFiles(absolutePath);
+    return result;
+  }
+}


### PR DESCRIPTION
#719 
This pull request includes several changes to the `cypress-qase-reporter` package, focusing on fixing issues with screenshot uploads, updating the package version, and refactoring the code to improve functionality and maintainability.

### Bug Fixes:
* Fixed an issue with screenshots not being uploaded to Qase for failed tests. (`qase-cypress/changelog.md`, `qase-cypress/src/reporter.ts`) [[1]](diffhunk://#diff-2a371c9549af06539aa3565c286f4a826afe99ffec7641cecf8cbfe5253b198bR1-R6) [[2]](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1L182-R170)

### Version Update:
* Updated the package version from `2.2.3` to `2.2.4` in `package.json`. (`qase-cypress/package.json`)

### Code Refactoring:
* Added a new `FileSearcher` class to handle file searching operations, replacing the old `traverseDir` function. (`qase-cypress/src/fileSearcher.ts`, `qase-cypress/src/reporter.ts`) [[1]](diffhunk://#diff-d3ad025eefb90638d963b844ca1a29c72461288a5d20e658aca6b904e239b49cR1-R40) [[2]](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1L21-R32)
* Removed the `findAttachments` method and replaced its functionality with the new `FileSearcher` class. (`qase-cypress/src/reporter.ts`)
* Added a `getTestFileName` method to extract the file name from a test suite. (`qase-cypress/src/reporter.ts`)

### Event Handling:
* Added an event listener for `EVENT_TEST_BEGIN` to record the start time of each test. (`qase-cypress/src/reporter.ts`) [[1]](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1R124-R126) [[2]](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1R83-R84)