### PR TITLE
fix: issue with attaching screenshots for failed tests in subdirectories

### DIFF
--- a/examples/cypressCucumber/package.json
+++ b/examples/cypressCucumber/package.json
@@ -8,7 +8,7 @@
     "cypress": "^13.16.0",
     "cypress-cucumber-preprocessor": "^4.3.1",
     "cypress-multi-reporters": "^1.6.3",
-    "cypress-qase-reporter": "2.2.5"
+    "cypress-qase-reporter": "^2.2.5"
   },
   "cypress-cucumber-preprocessor": {
     "step_definitions": "cypress/step_definitions/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,11 +57,12 @@
       }
     },
     "examples/cypressCucumber": {
+      "name": "cypress-cucumber",
       "devDependencies": {
         "cypress": "^13.16.0",
         "cypress-cucumber-preprocessor": "^4.3.1",
         "cypress-multi-reporters": "^1.6.3",
-        "cypress-qase-reporter": "2.2.5"
+        "cypress-qase-reporter": "^2.2.5"
       }
     },
     "examples/cypressCucumber/node_modules/@cypress/request": {
@@ -164,6 +165,35 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "examples/cypressCucumber/node_modules/cypress-qase-reporter": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/cypress-qase-reporter/-/cypress-qase-reporter-2.2.5.tgz",
+      "integrity": "sha512-kiWjlduMb2Uo12DjxZjJvPpHPQV8toYzP54ynk3vr/WqPBTY7ppZpIvAdVEtUBLgpnZFtU6peiGM85x8zsod4A==",
+      "dev": true,
+      "dependencies": {
+        "qase-javascript-commons": "~2.2.3",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "cypress": ">=8.0.0"
+      }
+    },
+    "examples/cypressCucumber/node_modules/cypress-qase-reporter/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "examples/cypressCucumber/node_modules/execa": {
@@ -17643,7 +17673,7 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "Apache-2.0",
       "dependencies": {
         "qase-javascript-commons": "~2.2.3",
@@ -17666,7 +17696,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.2.7",
+      "version": "2.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,9 @@
+# cypress-qase-reporter@2.2.6
+
+## What's new
+
+Fixed an issue where screenshots for failed tests were not attached if the tests were located in subdirectories.
+
 # cypress-qase-reporter@2.2.5
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/fileSearcher.ts
+++ b/qase-cypress/src/fileSearcher.ts
@@ -6,13 +6,19 @@ export class FileSearcher {
    * Finds all files in the given directory and its subdirectories
    * that were created after the specified time.
    *
-   * @param folderPath Relative path to the folder.
+   * @param screenshotFolderPath Path to the folder with screenshots.
+   * @param specFileName Name of the spec file.
    * @param time Time threshold as a Date object.
    * @returns Array of absolute paths to the matching files.
    */
-  public static findFilesBeforeTime(folderPath: string, time: Date): string[] {
-    const absolutePath = path.resolve(process.cwd(), folderPath);
+  public static findFilesBeforeTime(screenshotFolderPath: string, specFileName: string, time: Date): string[] {
+    const absolutePath = path.resolve(process.cwd(), screenshotFolderPath);
     const result: string[] = [];
+
+    const paths = this.findFolderByName(absolutePath, specFileName);
+    if (paths.length === 0) {
+      return result;
+    }
 
     const searchFiles = (dir: string) => {
       if (!fs.existsSync(dir)) {
@@ -34,7 +40,33 @@ export class FileSearcher {
       }
     };
 
-    searchFiles(absolutePath);
+    for (const path of paths) {
+      searchFiles(path);
+    }
+
+    return result;
+  }
+
+  private static findFolderByName(startPath: string, folderName: string): string[] {
+    const result: string[] = [];
+
+    function searchDirectory(currentPath: string): void {
+      const items = fs.readdirSync(currentPath, { withFileTypes: true });
+
+      for (const item of items) {
+        const itemPath = path.join(currentPath, item.name);
+
+        if (item.isDirectory()) {
+          if (item.name === folderName) {
+            result.push(itemPath);
+          } else {
+            searchDirectory(itemPath);
+          }
+        }
+      }
+    }
+
+    searchDirectory(startPath);
     return result;
   }
 }

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -158,7 +158,7 @@ export class CypressQaseReporter extends reporters.Base {
 
     const testFileName = this.getTestFileName(test);
     const files = this.screenshotsFolder ?
-      FileSearcher.findFilesBeforeTime(path.join(this.screenshotsFolder, testFileName), new Date(this.testBeginTime))
+      FileSearcher.findFilesBeforeTime(this.screenshotsFolder, testFileName, new Date(this.testBeginTime))
       : [];
 
     const attachments = files.map((file) => ({


### PR DESCRIPTION
- Added recursive folder search by a specified name.
- Screenshots for failed tests are now correctly attached, even if the tests are located in subdirectories.

This pull request includes several changes to the `qase-cypress` package, focusing on fixing an issue with screenshot attachments for failed tests and updating the package version. The most important changes are the addition of a new method to search for folders by name and modifying the file search logic to correctly handle subdirectories.

Fixes and improvements:

* [`qase-cypress/changelog.md`](diffhunk://#diff-2a371c9549af06539aa3565c286f4a826afe99ffec7641cecf8cbfe5253b198bR1-R6): Added a new entry for version `2.2.6` detailing the fix for attaching screenshots of failed tests located in subdirectories.
* [`qase-cypress/package.json`](diffhunk://#diff-f50f25410e8641426bca1d154b56935d9f8ae5fcbce8c26b153cefcdbc5b7509L3-R3): Updated the package version from `2.2.5` to `2.2.6`.

Code changes:

* [`qase-cypress/src/fileSearcher.ts`](diffhunk://#diff-d3ad025eefb90638d963b844ca1a29c72461288a5d20e658aca6b904e239b49cL9-R22): Modified the `findFilesBeforeTime` method to include `screenshotFolderPath` and `specFileName` parameters, and added logic to handle subdirectories. Introduced a new `findFolderByName` method to locate folders by name within a directory. [[1]](diffhunk://#diff-d3ad025eefb90638d963b844ca1a29c72461288a5d20e658aca6b904e239b49cL9-R22) [[2]](diffhunk://#diff-d3ad025eefb90638d963b844ca1a29c72461288a5d20e658aca6b904e239b49cL37-R69)
* [`qase-cypress/src/reporter.ts`](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1L161-R161): Updated the call to `findFilesBeforeTime` to use the new parameters for correctly searching screenshot folders.