### PR TITLE
fix: an issue where the reporter got error if screenshot folder was not exist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17673,7 +17673,7 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "license": "Apache-2.0",
       "dependencies": {
         "qase-javascript-commons": "~2.2.3",

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,9 @@
+# cypress-qase-reporter@2.2.7
+
+## What's new
+
+Fixed an issue where the reporter got error if screenshot folder was not exist.
+
 # cypress-qase-reporter@2.2.6
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/fileSearcher.ts
+++ b/qase-cypress/src/fileSearcher.ts
@@ -51,6 +51,10 @@ export class FileSearcher {
     const result: string[] = [];
 
     function searchDirectory(currentPath: string): void {
+      if (!fs.existsSync(currentPath)) {
+        return;
+      }
+
       const items = fs.readdirSync(currentPath, { withFileTypes: true });
 
       for (const item of items) {


### PR DESCRIPTION
This pull request includes several updates to the `cypress-qase-reporter` package, addressing a bug fix and a version bump. The most important changes are as follows:

Bug Fix:
* [`qase-cypress/src/fileSearcher.ts`](diffhunk://#diff-d3ad025eefb90638d963b844ca1a29c72461288a5d20e658aca6b904e239b49cR54-R57): Added a check to ensure the directory exists before attempting to read its contents, preventing errors when the screenshot folder does not exist.

Version Update:
* [`qase-cypress/package.json`](diffhunk://#diff-f50f25410e8641426bca1d154b56935d9f8ae5fcbce8c26b153cefcdbc5b7509L3-R3): Updated the package version from `2.2.6` to `2.2.7`.
* [`qase-cypress/changelog.md`](diffhunk://#diff-2a371c9549af06539aa3565c286f4a826afe99ffec7641cecf8cbfe5253b198bR1-R6): Added a new entry for version `2.2.7` detailing the bug fix.