### PR TITLE
fix: fixed attachment issue for failed tests on Windows

### DIFF
--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,9 @@
+# cypress-qase-reporter@2.2.8
+
+## What's new
+
+Fixed an issue where attachments were not properly linked to failed tests on Windows.
+
 # cypress-qase-reporter@2.2.7
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -265,7 +265,7 @@ export class CypressQaseReporter extends reporters.Base {
     const file = test.parent ? this.getFile(test.parent) : undefined;
 
     if (file) {
-      signature = file.split('/').join('::');
+      signature = file.split(path.sep).join('::');
     }
 
     if (test.parent) {
@@ -293,7 +293,7 @@ export class CypressQaseReporter extends reporters.Base {
       return '';
     }
 
-    const pathParts = file.split('/');
+    const pathParts = file.split(path.sep);
     const fileName = pathParts[pathParts.length - 1];
 
     return fileName ? fileName : '';


### PR DESCRIPTION
This pull request includes several updates to the `cypress-qase-reporter` package, focusing on fixing an issue with attachments on Windows and updating the package version. The most important changes are summarized below:

Bug fix:

* [`qase-cypress/src/reporter.ts`](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1L268-R268): Fixed an issue where attachments were not properly linked to failed tests on Windows by updating the path separator to use `path.sep` instead of a hardcoded forward slash. [[1]](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1L268-R268) [[2]](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1L296-R296)

Version update:

* [`qase-cypress/package.json`](diffhunk://#diff-f50f25410e8641426bca1d154b56935d9f8ae5fcbce8c26b153cefcdbc5b7509L3-R3): Updated the version number from `2.2.7` to `2.2.8`.

Documentation:

* [`qase-cypress/changelog.md`](diffhunk://#diff-2a371c9549af06539aa3565c286f4a826afe99ffec7641cecf8cbfe5253b198bR1-R6): Added a new entry for version `2.2.8` detailing the fix for the attachment issue on Windows.