### PR TITLE
feat: added removeQaseIdsFromTitle method to remove IDs from test names

### DIFF
--- a/qase-jest/changelog.md
+++ b/qase-jest/changelog.md
@@ -1,3 +1,9 @@
+# jest-qase-reporter@2.0.4
+
+## What's new
+
+Improved test name processing: Qase IDs are now automatically removed when uploading results
+
 # jest-qase-reporter@2.0.3
 
 ## What's new

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-qase-reporter",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Qase TMS Jest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-jest/src/reporter.ts
+++ b/qase-jest/src/reporter.ts
@@ -331,7 +331,7 @@ export class JestQaseReporter implements Reporter {
       steps: [],
       testops_id: ids.length > 0 ? ids : null,
       id: uuidv4(),
-      title: value.title,
+      title: this.removeQaseIdsFromTitle(value.title),
     };
   }
 
@@ -351,5 +351,18 @@ export class JestQaseReporter implements Reporter {
       steps: [],
       attachments: [],
     };
+  }
+
+  /**
+   * @param {string} title
+   * @returns {string}
+   * @private
+   */
+  private removeQaseIdsFromTitle(title: string): string {
+    const matches = title.match(/\(Qase ID: ([0-9,]+)\)$/i);
+    if (matches) {
+      return title.replace(matches[0], '').trimEnd();
+    }
+    return title;
   }
 }


### PR DESCRIPTION
This pull request introduces several changes to the `jest-qase-reporter` package, focusing on improving the processing of test names by automatically removing Qase IDs when uploading results. The key changes include updating the version, modifying the test title processing, and adding a new private method.

Improvements to test name processing:

* [`qase-jest/src/reporter.ts`](diffhunk://#diff-2cc13d88ad00969f429268e945fb6e3868da9b625af6cef0fc7f939d921617a9L334-R334): Modified the `title` field to use the new `removeQaseIdsFromTitle` method to strip Qase IDs from test titles.
* [`qase-jest/src/reporter.ts`](diffhunk://#diff-2cc13d88ad00969f429268e945fb6e3868da9b625af6cef0fc7f939d921617a9R355-R367): Added a new private method `removeQaseIdsFromTitle` to handle the removal of Qase IDs from test titles.

Version update:

* [`qase-jest/package.json`](diffhunk://#diff-9e45811c423ffd36f90c4ce994624813bfea06a97ee2f4a47aca65c4a796a0e3L3-R3): Updated the version number from `2.0.3` to `2.0.4`.

Documentation update:

* [`qase-jest/changelog.md`](diffhunk://#diff-066d6f2a8ff05baca2eae55757c4d85e6f7c9b69d65da29cec68eee2e0b2deabR1-R6): Added a new entry for version `2.0.4` detailing the improvement in test name processing.