### PR TITLE
chore: remove unused dependency child-process-ext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -167,35 +167,6 @@
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
-    "examples/cypressCucumber/node_modules/cypress-qase-reporter": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/cypress-qase-reporter/-/cypress-qase-reporter-2.2.5.tgz",
-      "integrity": "sha512-kiWjlduMb2Uo12DjxZjJvPpHPQV8toYzP54ynk3vr/WqPBTY7ppZpIvAdVEtUBLgpnZFtU6peiGM85x8zsod4A==",
-      "dev": true,
-      "dependencies": {
-        "qase-javascript-commons": "~2.2.3",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "cypress": ">=8.0.0"
-      }
-    },
-    "examples/cypressCucumber/node_modules/cypress-qase-reporter/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "examples/cypressCucumber/node_modules/execa": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -297,7 +268,7 @@
         "@jest/globals": "^29.5.0",
         "babel-jest": "^29.5.0",
         "jest": "^29.5.0",
-        "jest-qase-reporter": "^2.0.0"
+        "jest-qase-reporter": "^2.0.3"
       }
     },
     "examples/mocha": {
@@ -318,7 +289,7 @@
       "name": "examples-playwright",
       "devDependencies": {
         "@playwright/test": "^1.34.3",
-        "playwright-qase-reporter": "^2.0.0"
+        "playwright-qase-reporter": "^2.0.16"
       }
     },
     "examples/testcafe": {
@@ -4099,15 +4070,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/2-thenable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/2-thenable/-/2-thenable-1.0.0.tgz",
-      "integrity": "sha512-HqiDzaLDFCXkcCO/SwoyhRwqYtINFHF7t9BDRq4x90TOKNAJpiqUt9X5lQ08bwxYzc067HUywDjGySpebHcUpw==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.47"
-      }
-    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -5619,21 +5581,6 @@
       "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/child-process-ext": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/child-process-ext/-/child-process-ext-3.0.2.tgz",
-      "integrity": "sha512-oBePsLbQpTJFxzwyCvs9yWWF0OEM6vGGepHwt1stqmX7QQqOuDc8j2ywdvAs9Tvi44TT7d9ackqhR4Q10l1u8w==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "es5-ext": "^0.10.62",
-        "log": "^6.3.1",
-        "split2": "^3.2.2",
-        "stream-promise": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/chokidar": {
@@ -11693,20 +11640,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
-    "node_modules/log": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
-      "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "duration": "^0.2.2",
-        "es5-ext": "^0.10.53",
-        "event-emitter": "^0.3.5",
-        "sprintf-kit": "^2.0.1",
-        "type": "^2.5.0",
-        "uni-global": "^1.0.0"
-      }
-    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -12552,9 +12485,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -14226,6 +14159,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -14927,30 +14861,11 @@
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated"
     },
-    "node_modules/split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
-    },
-    "node_modules/sprintf-kit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.2.tgz",
-      "integrity": "sha512-lnapdj6W4LflHZGKvl9eVkz5YF0xaTrqpRWVA4cNVOTedwqifIP8ooGImldzT/4IAN5KXFQAyXTdLidYVQdyag==",
-      "dependencies": {
-        "es5-ext": "^0.10.64"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
     },
     "node_modules/sshpk": {
       "version": "1.18.0",
@@ -15167,24 +15082,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ=="
     },
-    "node_modules/stream-promise": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/stream-promise/-/stream-promise-3.2.0.tgz",
-      "integrity": "sha512-P+7muTGs2C8yRcgJw/PPt61q7O517tDHiwYEzMWo1GSBCcZedUMT/clz7vUNsSxFphIlJ6QUL4GexQKlfJoVtA==",
-      "dependencies": {
-        "2-thenable": "^1.0.0",
-        "es5-ext": "^0.10.49",
-        "is-stream": "^1.1.0"
-      }
-    },
-    "node_modules/stream-promise/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stream-splicer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
@@ -15235,6 +15132,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -16814,14 +16712,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
-    "node_modules/uni-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
-      "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
-      "dependencies": {
-        "type": "^2.5.0"
-      }
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -17516,9 +17406,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -17651,7 +17541,7 @@
     },
     "qase-cucumberjs": {
       "name": "cucumberjs-qase-reporter",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/messages": "^22.0.0",
@@ -17673,7 +17563,7 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "2.2.7",
+      "version": "2.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "qase-javascript-commons": "~2.2.3",
@@ -17701,7 +17591,6 @@
       "dependencies": {
         "ajv": "^8.12.0",
         "chalk": "^4.1.2",
-        "child-process-ext": "^3.0.2",
         "env-schema": "^5.2.0",
         "form-data": "^4.0.0",
         "lodash.get": "^4.4.2",
@@ -17759,7 +17648,7 @@
     },
     "qase-jest": {
       "name": "jest-qase-reporter",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.get": "^4.4.2",
@@ -17786,7 +17675,7 @@
     },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "deasync-promise": "^1.0.1",

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -26,7 +26,6 @@
   "dependencies": {
     "ajv": "^8.12.0",
     "chalk": "^4.1.2",
-    "child-process-ext": "^3.0.2",
     "env-schema": "^5.2.0",
     "form-data": "^4.0.0",
     "lodash.get": "^4.4.2",


### PR DESCRIPTION
This pull request includes updates to the `qase-javascript-commons` package, including a version bump and the removal of an unused dependency.

Version update:

* [`qase-javascript-commons/package.json`](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL3-R3): Updated the package version from `2.2.8` to `2.2.9`.

Dependency management:

* [`qase-javascript-commons/package.json`](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL29): Removed the `child-process-ext` dependency as it is no longer needed.