### PR TITLE
fix: resolve parallel reporter execution issue by using separate sync files

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.2.10
+
+## What's new
+
+Resolved an issue with parallel execution of multiple reporters using a shared sync file. Each reporter now uses its own
+dedicated file for state synchronization.
+
 # qase-javascript-commons@2.2.7
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/state/state.ts
+++ b/qase-javascript-commons/src/state/state.ts
@@ -9,7 +9,7 @@ export interface StateModel {
 }
 
 export class StateManager {
-  static statePath = path.resolve(__dirname, 'reporterState.json');
+  static statePath = path.resolve(process.cwd(), 'reporterState.json');
 
   static getState(): StateModel {
     let state: StateModel = {


### PR DESCRIPTION
This pull request includes updates to the `qase-javascript-commons` package, focusing on resolving an issue with parallel execution of multiple reporters and updating the package version. The most important changes include modifying the state synchronization file path and updating the version in `package.json`.

### Improvements to state synchronization:

* [`qase-javascript-commons/src/state/state.ts`](diffhunk://#diff-1dead262c2b8dc521c83b4b0421bb8717594e75ef5a1e57aec61081c865fc2d9L12-R12): Changed the `statePath` in `StateManager` to use `process.cwd()` instead of `__dirname` to ensure each reporter uses its own dedicated file for state synchronization.

### Version update:

* [`qase-javascript-commons/package.json`](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL3-R3): Updated the package version from `2.2.9` to `2.2.10`.

### Documentation update:

* [`qase-javascript-commons/changelog.md`](diffhunk://#diff-52f0da163733bdd7a580e506366bdc1f0dc9d4b727e3d061da2385ed7d86d770R1-R7): Added a new entry for version `2.2.10` detailing the resolution of the issue with parallel execution of multiple reporters.

#743 