### PR TITLE
fix: add mutex to ensure correct result submission in multi-threaded tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4520,6 +4520,14 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -17586,10 +17594,11 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.2.9",
+      "version": "2.2.11",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
+        "async-mutex": "~0.5.0",
         "chalk": "^4.1.2",
         "env-schema": "^5.2.0",
         "form-data": "^4.0.0",
@@ -17847,7 +17856,7 @@
       }
     },
     "qaseio": {
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.28.0",

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.2.12
+
+## What's new
+
+Added a mutex to ensure correct result submission when running tests in multiple threads, preventing potential
+duplication.
+
 # qase-javascript-commons@2.2.11
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -34,7 +34,8 @@
     "mime-types": "^2.1.33",
     "qaseio": "~2.4.0",
     "strip-ansi": "^6.0.1",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "async-mutex": "~0.5.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",


### PR DESCRIPTION
This pull request introduces a new mutex to ensure correct result submission when running tests in multiple threads, preventing potential duplication. The changes include updates to the package version, dependencies, and modifications to the `TestOpsReporter` class to integrate the mutex.

### Mutex Implementation for Thread Safety:

* [`qase-javascript-commons/src/reporters/testops-reporter.ts`](diffhunk://#diff-9b393f0c08ec0ce57dfc974a338ccb75a4255b298ecb250e667334a757f288feR36): Added `Mutex` import and integrated it into the `TestOpsReporter` class to ensure thread safety during result submission and publishing. [[1]](diffhunk://#diff-9b393f0c08ec0ce57dfc974a338ccb75a4255b298ecb250e667334a757f288feR36) [[2]](diffhunk://#diff-9b393f0c08ec0ce57dfc974a338ccb75a4255b298ecb250e667334a757f288feR168-R169) [[3]](diffhunk://#diff-9b393f0c08ec0ce57dfc974a338ccb75a4255b298ecb250e667334a757f288feR230-R232) [[4]](diffhunk://#diff-9b393f0c08ec0ce57dfc974a338ccb75a4255b298ecb250e667334a757f288feR246-R248) [[5]](diffhunk://#diff-9b393f0c08ec0ce57dfc974a338ccb75a4255b298ecb250e667334a757f288feR340-R345)

### Package Updates:

* [`qase-javascript-commons/package.json`](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL3-R3): Updated the version to `2.2.12` and added `async-mutex` as a dependency. [[1]](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL3-R3) [[2]](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL37-R38)

### Documentation:

* [`qase-javascript-commons/changelog.md`](diffhunk://#diff-52f0da163733bdd7a580e506366bdc1f0dc9d4b727e3d061da2385ed7d86d770R1-R7): Documented the addition of the mutex in the changelog for version `2.2.12`.