### PR TITLE
feat: support for multiple IDs in the `QaseID` tag

### DIFF
--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,15 @@
+# qase-cucumberjs@2.0.5
+
+## What's new
+
+Enabled support for multiple IDs in the `QaseID` tag, allowing tests to be linked to multiple cases.
+
+```gherkin
+@QaseID=1,2,3
+Scenario: Scenario with new Qase ID tag
+Given I have a step
+```
+
 # qase-cucumberjs@2.0.4
 
 ## What's new

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -25,7 +25,7 @@ import { v4 as uuidv4 } from 'uuid';
 type TestStepResultStatus = (typeof Status)[keyof typeof Status];
 
 const qaseIdRegExp = /^@[Qq]-?(\d+)$/g;
-const newQaseIdRegExp = /^@[Qq]ase[Ii][Dd]=(\d+)$/g;
+const newQaseIdRegExp = /^@[Qq]ase[Ii][Dd]=(\d+(?:,\s*\d+)*)$/g;
 const qaseTitleRegExp = /^@[Qq]ase[Tt]itle=(.+)$/g;
 const qaseFieldsRegExp = /^@[Qq]ase[Ff]ields=(.+)$/g;
 const qaseIgnoreRegExp = /^@[Qq]ase[Ii][Gg][Nn][Oo][Rr][Ee]$/g;
@@ -336,7 +336,7 @@ export class Storage {
       }
 
       if (newQaseIdRegExp.test(tag.name)) {
-        metadata.ids.push(Number(tag.name.replace(/^@[Qq]ase[Ii][Dd]=/, '')));
+        metadata.ids.push(...(tag.name.replace(/^@[Qq]ase[Ii][Dd]=/, '')).split(',').map(Number));
         continue;
       }
 


### PR DESCRIPTION
This pull request includes updates to the `qase-cucumberjs` package to enable support for multiple IDs in the `QaseID` tag. The most important changes include updating the regular expression to handle multiple IDs, modifying the storage class to process multiple IDs, and updating the package version.

Enhancements to `QaseID` tag support:

* [`qase-cucumberjs/src/storage.ts`](diffhunk://#diff-b70a3b5b898c3a7bd91062af6785c9f3a77927767b96fcbd4b2a93d3fe4ee0a1L28-R28): Updated the `newQaseIdRegExp` regular expression to support multiple IDs.
* [`qase-cucumberjs/src/storage.ts`](diffhunk://#diff-b70a3b5b898c3a7bd91062af6785c9f3a77927767b96fcbd4b2a93d3fe4ee0a1L339-R339): Modified the `Storage` class to split and map multiple IDs into the `metadata.ids` array.

Documentation and versioning:

* [`qase-cucumberjs/changelog.md`](diffhunk://#diff-3b18c0566f17bdd15fea91ee24dc404665d9094ce21d2a35c3e23d7c59c60cf6R1-R12): Added a new entry for version 2.0.5, documenting the support for multiple IDs in the `QaseID` tag.
* [`qase-cucumberjs/package.json`](diffhunk://#diff-1eb2b5a6fc55e1cd1bac74043ca9f57955736d82f4481c5af5ec361f3b8ea5c2L3-R3): Updated the package version from 2.0.4 to 2.0.5.