### PR TITLE
feat: add support for specifying expected result and data for steps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17549,11 +17549,11 @@
     },
     "qase-cucumberjs": {
       "name": "cucumberjs-qase-reporter",
-      "version": "2.0.4",
+      "version": "2.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/messages": "^22.0.0",
-        "qase-javascript-commons": "^2.2.0"
+        "qase-javascript-commons": "^2.2.14"
       },
       "devDependencies": {
         "@jest/globals": "^29.5.0",
@@ -17571,10 +17571,10 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "2.2.8",
+      "version": "2.2.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.2.3",
+        "qase-javascript-commons": "~2.2.14",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -17594,7 +17594,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.2.11",
+      "version": "2.2.14",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -17657,12 +17657,12 @@
     },
     "qase-jest": {
       "name": "jest-qase-reporter",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "qase-javascript-commons": "~2.2.1",
+        "qase-javascript-commons": "~2.2.14",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -17684,12 +17684,12 @@
     },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "deasync-promise": "^1.0.1",
         "mocha": "^10.2.0",
-        "qase-javascript-commons": "~2.2.0",
+        "qase-javascript-commons": "~2.2.14",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -17743,11 +17743,11 @@
     },
     "qase-playwright": {
       "name": "playwright-qase-reporter",
-      "version": "2.0.16",
+      "version": "2.0.17",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
-        "qase-javascript-commons": "~2.2.0",
+        "qase-javascript-commons": "~2.2.14",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -17765,10 +17765,10 @@
     },
     "qase-testcafe": {
       "name": "testcafe-reporter-qase",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.2.4",
+        "qase-javascript-commons": "~2.2.14",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -17786,14 +17786,14 @@
     },
     "qase-wdio": {
       "name": "wdio-qase-reporter",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@wdio/reporter": "^8.39.0",
         "@wdio/types": "^8.39.0",
         "csv-stringify": "^6.0.4",
-        "qase-javascript-commons": "~2.2.0",
+        "qase-javascript-commons": "~2.2.14",
         "strip-ansi": "^7.1.0",
         "uuid": "^9.0.1"
       },

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/messages": "^22.0.0",
-    "qase-javascript-commons": "^2.2.0"
+    "qase-javascript-commons": "^2.2.14"
   },
   "peerDependencies": {
     "@cucumber/cucumber": ">=7.0.0"

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -51,7 +51,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.2.3",
+    "qase-javascript-commons": "~2.2.14",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -362,6 +362,7 @@ export class CypressQaseReporter extends reporters.Base {
       step.data = {
         action: message.name,
         expected_result: null,
+        data: null,
       };
 
       if (lastIndex === messages.indexOf(message) && testStatus !== 'passed') {
@@ -388,6 +389,7 @@ export class CypressQaseReporter extends reporters.Base {
         newStep.data = {
           action: step.name,
           expected_result: null,
+          data: null,
         };
 
         if (attachments[step.id]) {

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/models/step-data.ts
+++ b/qase-javascript-commons/src/models/step-data.ts
@@ -1,6 +1,7 @@
 export interface StepTextData {
   action: string;
   expected_result: string | null;
+  data: string | null;
 }
 
 export interface StepGherkinData {

--- a/qase-javascript-commons/src/models/test-step.ts
+++ b/qase-javascript-commons/src/models/test-step.ts
@@ -29,6 +29,7 @@ export class TestStepType {
       this.data = {
         action: '',
         expected_result: null,
+        data: null,
       };
     } else {
       this.data = {

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -625,6 +625,14 @@ export class TestOpsReporter extends AbstractReporter {
             resultStep.data.action = step.data.action;
           }
         }
+
+        if ('expected_result' in step.data && resultStep.data != undefined && step.data.expected_result != null) {
+          resultStep.data.expected_result = step.data.expected_result;
+        }
+
+        if ('data' in step.data && resultStep.data != undefined && step.data.data != null) {
+          resultStep.data.input_data = step.data.data;
+        }
       }
 
       if (step.step_type === StepType.GHERKIN) {

--- a/qase-javascript-commons/src/steps/step.ts
+++ b/qase-javascript-commons/src/steps/step.ts
@@ -70,6 +70,7 @@ export class QaseStep {
     step.data = {
       action: this.name,
       expected_result: null,
+      data: null,
     };
 
     try {

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-qase-reporter",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Qase TMS Jest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
-    "qase-javascript-commons": "~2.2.1",
+    "qase-javascript-commons": "~2.2.14",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/qase-jest/src/step.ts
+++ b/qase-jest/src/step.ts
@@ -71,6 +71,7 @@ export class QaseStep {
     step.data = {
       action: this.name,
       expected_result: null,
+      data: null,
     };
 
     try {

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -43,7 +43,7 @@
   "dependencies": {
     "mocha": "^10.2.0",
     "deasync-promise": "^1.0.1",
-    "qase-javascript-commons": "~2.2.0",
+    "qase-javascript-commons": "~2.2.14",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -370,6 +370,7 @@ export class MochaQaseReporter extends reporters.Base {
       data: {
         action: title,
         expected_result: null,
+        data: null,
       },
       execution: {
         start_time: Date.now(),

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,9 @@
+# playwright-qase-reporter@2.0.17
+
+## What's new
+
+Introduced the ability to specify expected results and data for each step, improving step validation and customization.
+
 # playwright-qase-reporter@2.0.16
 
 ## What's new

--- a/qase-playwright/docs/usage.md
+++ b/qase-playwright/docs/usage.md
@@ -121,6 +121,24 @@ test('A Test case with steps, updated from code', async () => {
   });
 });
 ```
+
+You also can use the `qase.step()` method to set the expected result and data of the step, which will be used in the Qase report.
+
+```javascript
+test('A Test case with steps, updated from code', async () => {
+  await test.step(qase.step('Initialize the environment'), async () => {
+    // Set up test environment
+  });
+  await test.step(qase.step('Test Core Functionality of the app', 'expected result'), async () => {
+    // Exercise core functionality
+  });
+
+  await test.step(qase.step('Verify Expected Behavior of the app', 'expected result', 'data'), async () => {
+    // Assert expected behavior
+  });
+});
+```
+
 <br>
 
 ### Fields

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.2",
-    "qase-javascript-commons": "~2.2.0",
+    "qase-javascript-commons": "~2.2.14",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -245,6 +245,23 @@ qase.comment = function(value: string) {
   return this;
 };
 
+/**
+ * Set a expected result and data for the test step
+ * @param action
+ * @param expectedResult
+ * @param data
+ * @example
+ * test('test', async ({ page }) => {
+ *    await test.step(qase.step('action', 'expected result', 'data'), async () => {
+ *      await page.goto('https://example.com');
+ *    });
+ * });
+ */
+qase.step = function(action: string, expectedResult: string | undefined, data: string | undefined): string {
+  return `${action} QaseExpRes:${expectedResult ? `: ${expectedResult}` : ''} QaseData:${data ? `: ${data}` : ''}`;
+};
+
+
 const addMetadata = (metadata: MetadataMessage): void => {
   test.info().attach('qase-metadata.json', {
     contentType: ReporterContentType,
@@ -273,3 +290,4 @@ const addAttachment = (name: string, contentType: string, filePath?: string, bod
   }).catch(() => {/**/
   });
 };
+

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-qase",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Qase TMS TestCafe Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -40,7 +40,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.2.4",
+    "qase-javascript-commons": "~2.2.14",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -32,7 +32,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.2.0",
+    "qase-javascript-commons": "~2.2.14",
     "uuid": "^9.0.1",
     "@types/node": "^20.1.0",
     "@wdio/reporter": "^8.39.0",

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -512,6 +512,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
       data: {
         action: title,
         expected_result: null,
+        data: null,
       },
       parent_id: this.storage.getLastItem()?.id ?? null,
       execution: {

--- a/qase-wdio/src/step.ts
+++ b/qase-wdio/src/step.ts
@@ -70,6 +70,7 @@ export class QaseStep {
     step.data = {
       action: this.name,
       expected_result: null,
+      data: null,
     };
 
     try {


### PR DESCRIPTION
This pull request includes multiple changes across various packages to introduce new functionality and update dependencies. The most significant changes involve adding a new `data` field to step data structures and updating the `qase-javascript-commons` dependency version across all packages.

### New functionality:
* Added the ability to specify `data` for each step in `qase-cypress`, `qase-javascript-commons`, `qase-jest`, `qase-mocha`, `qase-playwright`, and `qase-wdio`. This includes updates to the respective `Step` classes and interfaces. [[1]](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1R365) [[2]](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1R392) [[3]](diffhunk://#diff-a9d14bef553a558532fda3402f52cb9e68e7641503ef19a485323aa421870536R4) [[4]](diffhunk://#diff-c4f3a8fc4465f2881c0b4e2424b710edb22c77ef79a55474855414afed16c99dR32) [[5]](diffhunk://#diff-70b59085c6c5c6301ca886ea137d1c9ab941ba4d9200ff03168f5eb82a16df02R74) [[6]](diffhunk://#diff-9e21691f29dedbdadb38491a2e4666a5c2a6f3e2d0cf15a8297d1f444d2f372bR373) [[7]](diffhunk://#diff-20ccef597b893e65bd4c0ddea63f9466f91048a89ad0fd4590fc00583deda4eeR248-R264) [[8]](diffhunk://#diff-3f15218cd3a03d6ac76683c4437c053029f848df708978f79ff7c29c8818df1eR260-R269) [[9]](diffhunk://#diff-3f15218cd3a03d6ac76683c4437c053029f848df708978f79ff7c29c8818df1eR536-R561) [[10]](diffhunk://#diff-8af0c733bd4efa0d2374d8a0dd94fe31cbdf77b24825bb0343000b28bf5257e6R73)

### Dependency updates:
* Updated `qase-javascript-commons` dependency to version `2.2.14` across all packages including `qase-cucumberjs`, `qase-cypress`, `qase-jest`, `qase-mocha`, `qase-playwright`, `qase-testcafe`, and `qase-wdio`. [[1]](diffhunk://#diff-1eb2b5a6fc55e1cd1bac74043ca9f57955736d82f4481c5af5ec361f3b8ea5c2L43-R43) [[2]](diffhunk://#diff-f50f25410e8641426bca1d154b56935d9f8ae5fcbce8c26b153cefcdbc5b7509L54-R54) [[3]](diffhunk://#diff-9e45811c423ffd36f90c4ce994624813bfea06a97ee2f4a47aca65c4a796a0e3L48-R48) [[4]](diffhunk://#diff-3a4508151c8284f6c6d9a8d247decba669681ae501df17ddee11eea8c43cc200L46-R46) [[5]](diffhunk://#diff-ff5b095bcae2fc44c7fdf71ab36e999f0bd057eef0ec05c9df5b73971c5a3defL47-R47) [[6]](diffhunk://#diff-d80c5ec1ea497b45d677429533024a46a672e4947fcfa4740ffe56ba91ce279fL43-R43) [[7]](diffhunk://#diff-65edb3d91c6eb943e1c8807c2d36ab59b49cb9ded80d63621b146512d4914048L35-R35)

### Version increments:
* Incremented version numbers for all packages to reflect the new changes. [[1]](diffhunk://#diff-1eb2b5a6fc55e1cd1bac74043ca9f57955736d82f4481c5af5ec361f3b8ea5c2L3-R3) [[2]](diffhunk://#diff-f50f25410e8641426bca1d154b56935d9f8ae5fcbce8c26b153cefcdbc5b7509L3-R3) [[3]](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL3-R3) [[4]](diffhunk://#diff-9e45811c423ffd36f90c4ce994624813bfea06a97ee2f4a47aca65c4a796a0e3L3-R3) [[5]](diffhunk://#diff-3a4508151c8284f6c6d9a8d247decba669681ae501df17ddee11eea8c43cc200L3-R3) [[6]](diffhunk://#diff-ff5b095bcae2fc44c7fdf71ab36e999f0bd057eef0ec05c9df5b73971c5a3defL3-R3) [[7]](diffhunk://#diff-d80c5ec1ea497b45d677429533024a46a672e4947fcfa4740ffe56ba91ce279fL3-R3) [[8]](diffhunk://#diff-65edb3d91c6eb943e1c8807c2d36ab59b49cb9ded80d63621b146512d4914048L3-R3)

### Documentation updates:
* Updated `qase-playwright` documentation to include examples of using the new `qase.step()` method to set expected results and data for steps.

### Changelog updates:
* Added a changelog entry for `qase-playwright` to document the new functionality introduced in version `2.0.17`.