### PR TITLE
Dependabot/npm and yarn/axios 1.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4581,11 +4581,12 @@
       "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g=="
     },
     "node_modules/axios": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
-      "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -17859,7 +17860,7 @@
       "version": "2.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^0.28.0",
+        "axios": "^1.8.2",
         "axios-retry": "^3.5.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/jest": "^29.5.2",
         "@typescript-eslint/eslint-plugin": "^5.59.6",
         "@typescript-eslint/parser": "^5.59.6",
+        "babel-jest": "^29.7.0",
         "eslint": "^8.40.0",
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-import": "^2.27.5",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-import": "^2.27.5",
     "jest": "^29.5.0",
+    "babel-jest": "^29.7.0",
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.0",
     "typescript": "^5.4.5",

--- a/qaseio/babel.config.js
+++ b/qaseio/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env']
+};

--- a/qaseio/jest.config.js
+++ b/qaseio/jest.config.js
@@ -4,7 +4,11 @@ module.exports = {
   roots: ['<rootDir>/test'],
   transform: {
     '^.+\\.ts$': 'ts-jest',
+    '^.+\\.js$': 'babel-jest'
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(axios)/)'
+  ],
   testMatch: ['**/*.test.ts'],
   moduleFileExtensions: ['js', 'ts'],
   collectCoverage: true,

--- a/qaseio/package.json
+++ b/qaseio/package.json
@@ -24,7 +24,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "axios": "^0.28.0",
+    "axios": "^1.8.2",
     "axios-retry": "^3.5.0"
   },
   "devDependencies": {

--- a/qaseio/src/qaseio.ts
+++ b/qaseio/src/qaseio.ts
@@ -18,13 +18,13 @@ import {
   Configuration, EnvironmentsApi,
 } from './generated';
 
-export type QaseApiOptionsType = {
+export interface QaseApiOptionsType {
   token: string;
   host?: string | undefined;
   headers?: Record<string, string | undefined> | undefined;
   retries?: number | undefined;
   retryDelay?: number | undefined;
-};
+}
 
 export interface QaseApiInterface {
   projects: ProjectsApi;


### PR DESCRIPTION
This pull request introduces several updates and improvements to the project, including dependency updates, configuration changes, and type modifications. Below are the most important changes:

### Dependency Updates:
* Updated the `axios` dependency to version `^1.8.2` in `qaseio/package.json`.
* Added `babel-jest` to the `devDependencies` in `package.json`.

### Configuration Changes:
* Added Babel configuration in `qaseio/babel.config.js` with the preset `@babel/preset-env`.
* Updated `jest.config.js` to include `babel-jest` for transforming JavaScript files and added `transformIgnorePatterns` to exclude `node_modules` except for `axios`.

### Type Modifications:
* Changed the `QaseApiOptionsType` from a `type` to an `interface` in `qaseio/src/qaseio.ts`.

#756 