### PR TITLE
chore: update axios dependency to fix security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17621,7 +17621,7 @@
         "@types/mime-types": "^2.1.4",
         "@types/node": "^20.12.5",
         "@types/uuid": "^9.0.1",
-        "axios": "^0.21.4",
+        "axios": "^1.8.2",
         "jest": "^29.5.0",
         "ts-jest": "^29.1.0"
       },
@@ -17636,14 +17636,6 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "qase-javascript-commons/node_modules/axios": {
-      "version": "0.21.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "qase-javascript-commons/node_modules/qaseio/node_modules/axios": {

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.2.15
+
+## What's new
+
+Updated axios dependency to address identified security vulnerabilities.
+
 # qase-javascript-commons@2.2.13
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.2.14",
+  "version": "2.2.15",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -46,7 +46,7 @@
     "@types/mime-types": "^2.1.4",
     "@types/node": "^20.12.5",
     "@types/uuid": "^9.0.1",
-    "axios": "^0.21.4",
+    "axios": "^1.8.2",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0"
   }

--- a/qaseio/changelog.md
+++ b/qaseio/changelog.md
@@ -1,3 +1,9 @@
+# qaseio@2.4.2
+
+## What's new
+
+Updated axios dependency to address identified security vulnerabilities.
+
 # qaseio@2.4.0
 
 ## What's new

--- a/qaseio/package.json
+++ b/qaseio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qaseio",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Qase TMS Javascript API Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This pull request includes updates to address security vulnerabilities by updating the `axios` dependency in two packages: `qase-javascript-commons` and `qaseio`. The version numbers for both packages have also been incremented accordingly.

Dependency updates:

* [`qase-javascript-commons/package.json`](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL49-R49): Updated `axios` dependency to version `^1.8.2` to address identified security vulnerabilities.
* [`qaseio/package.json`](diffhunk://#diff-f68cebf949e240a3c55ba44c6caf0430f09fae964cd1a1272087844c9d00da45L3-R3): Updated `axios` dependency to version `^1.8.2` to address identified security vulnerabilities.

Version increments:

* [`qase-javascript-commons/package.json`](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL3-R3): Incremented version number from `2.2.14` to `2.2.15`.
* [`qaseio/package.json`](diffhunk://#diff-f68cebf949e240a3c55ba44c6caf0430f09fae964cd1a1272087844c9d00da45L3-R3): Incremented version number from `2.4.1` to `2.4.2`.

Changelog updates:

* [`qase-javascript-commons/changelog.md`](diffhunk://#diff-52f0da163733bdd7a580e506366bdc1f0dc9d4b727e3d061da2385ed7d86d770R1-R6): Added entry for version `2.2.15` with details on the `axios` update.
* [`qaseio/changelog.md`](diffhunk://#diff-f50ddec8a96cd317ca79728e3615a8e507b79106917af61aadcda974be1c83ebR1-R6): Added entry for version `2.4.2` with details on the `axios` update.

#756 