### PR TITLE
fix: correct handling of parent test suites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17596,7 +17596,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.2.14",
+      "version": "2.2.15",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -17850,7 +17850,7 @@
       }
     },
     "qaseio": {
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.2",

--- a/qase-mocha/changelog.md
+++ b/qase-mocha/changelog.md
@@ -2,7 +2,7 @@
 
 ## What's new
 
-Major release of the Cypress reporter package
+Major release of the Mocha reporter package
 
 # qase-mocha@1.0.0-beta.5
 

--- a/qase-wdio/changelog.md
+++ b/qase-wdio/changelog.md
@@ -1,3 +1,15 @@
+# qase-wdio@1.0.1
+
+## What's new
+
+Resolved an issue with handling parent test suites, ensuring proper structure and reporting.
+
+# qase-wdio@1.0.0
+
+## What's new
+
+Major release of the WDIO reporter package.
+
 # qase-wdio@1.0.0-beta.4
 
 ## What's new

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-wdio/src/storage.ts
+++ b/qase-wdio/src/storage.ts
@@ -9,9 +9,14 @@ export class Storage {
 
   clear() {
     this.currentFile = undefined;
-    this.suites = [];
     this.items = [];
     this.ignore = false;
+
+    if (this.suites.length > 0) {
+      this.suites.pop();
+    } else {
+      this.suites = [];
+    }
   }
 
   push(item: TestResultType | TestStepType) {


### PR DESCRIPTION
This pull request includes several updates and improvements across multiple packages, mainly focusing on the `qase-wdio` and `qase-mocha` packages. The most significant changes include version updates, changelog additions, and a bug fix in the `Storage` class.

### Updates and Improvements:

**Changelog Updates:**
* [`qase-mocha/changelog.md`](diffhunk://#diff-b408629d8cfd1cdc4f952b2339cdf7d72a9bbb1b5939db2edbdda37ea2158fc8L5-R5): Updated the changelog to reflect the major release of the Mocha reporter package.
* [`qase-wdio/changelog.md`](diffhunk://#diff-8343aa0a0d3a3e6cbac3f8e9ecc22786105c91f1ee77e254e264576ed8467a99R1-R12): Added entries for versions 1.0.0 and 1.0.1, including a fix for handling parent test suites.

**Version Updates:**
* [`qase-wdio/package.json`](diffhunk://#diff-65edb3d91c6eb943e1c8807c2d36ab59b49cb9ded80d63621b146512d4914048L3-R3): Updated the version from 1.0.0 to 1.0.1 to reflect the new changes and bug fixes.

**Bug Fixes:**
* [`qase-wdio/src/storage.ts`](diffhunk://#diff-590beaa9071db5c3466eb5264ed296972731be03ba8d1ed07b5ef70259b8d6ebL12-R19): Modified the `clear` method in the `Storage` class to ensure proper handling of the `suites` array.

#759 