### PR TITLE
feat: improve start/end time handling for tests and steps

### DIFF
--- a/qase-mocha/changelog.md
+++ b/qase-mocha/changelog.md
@@ -1,3 +1,9 @@
+# qase-mocha@1.0.2
+
+## What's new
+
+Enhanced handling of start and end times for tests and steps, ensuring greater accuracy in reporting.
+
 # qase-mocha@1.0.0
 
 ## What's new

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -59,6 +59,7 @@ export class MochaQaseReporter extends reporters.Base {
   private readonly metadata: Metadata = new Metadata();
 
   private currentTest: currentTest = new currentTest();
+  private testBeginTime: number = Date.now();
   private currentType: 'test' | 'step' = 'test';
 
   public constructor(
@@ -151,9 +152,13 @@ export class MochaQaseReporter extends reporters.Base {
 
   private onStartTest() {
     this.currentType = 'test';
+    this.testBeginTime = Date.now();
   }
 
   private onEndTest(test: Mocha.Test) {
+    const end_time = Date.now();
+    const duration = test.duration ?? end_time - this.testBeginTime;
+
     process.stdout.write = this.originalStdoutWrite;
     process.stderr.write = this.originalStderrWrite;
 
@@ -219,9 +224,9 @@ export class MochaQaseReporter extends reporters.Base {
         status: test.state
           ? MochaQaseReporter.statusMap[test.state]
           : TestStatusEnum.invalid,
-        start_time: null,
-        end_time: null,
-        duration: test.duration ?? 0,
+        start_time: this.testBeginTime / 1000,
+        end_time: end_time / 1000,
+        duration: duration,
         stacktrace: test.err?.stack ?? null,
         thread: null,
       },


### PR DESCRIPTION
This pull request includes enhancements to the `qase-mocha` package, specifically improving the handling of test and step start and end times for more accurate reporting. The most important changes include updating the version number, adding new properties for timing, and modifying the test handling methods to record and report accurate timings.

Enhancements to test and step timing:

* [`qase-mocha/src/reporter.ts`](diffhunk://#diff-9e21691f29dedbdadb38491a2e4666a5c2a6f3e2d0cf15a8297d1f444d2f372bR62): Added `testBeginTime` property to record the start time of tests and updated `onStartTest` and `onEndTest` methods to calculate and store accurate start, end, and duration times for tests. [[1]](diffhunk://#diff-9e21691f29dedbdadb38491a2e4666a5c2a6f3e2d0cf15a8297d1f444d2f372bR62) [[2]](diffhunk://#diff-9e21691f29dedbdadb38491a2e4666a5c2a6f3e2d0cf15a8297d1f444d2f372bR155-R161) [[3]](diffhunk://#diff-9e21691f29dedbdadb38491a2e4666a5c2a6f3e2d0cf15a8297d1f444d2f372bL222-R229)

Version update:

* [`qase-mocha/package.json`](diffhunk://#diff-3a4508151c8284f6c6d9a8d247decba669681ae501df17ddee11eea8c43cc200L3-R3): Updated version number from `1.0.1` to `1.0.2`.

Changelog update:

* [`qase-mocha/changelog.md`](diffhunk://#diff-b408629d8cfd1cdc4f952b2339cdf7d72a9bbb1b5939db2edbdda37ea2158fc8R1-R6): Added entry for version `1.0.2` detailing the enhanced handling of start and end times for tests and steps.