### PR TITLE
feat: improve start/end time handling for tests and steps

### DIFF
--- a/qase-newman/changelog.md
+++ b/qase-newman/changelog.md
@@ -1,3 +1,9 @@
+# qase-newman@2.0.5
+
+## What's new
+
+Enhanced handling of start and end times for tests and steps, ensuring greater accuracy in reporting.
+
 # qase-newman@2.0.4
 
 ## What's new

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-qase",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Qase TMS Newman Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-newman/src/reporter.ts
+++ b/qase-newman/src/reporter.ts
@@ -248,6 +248,8 @@ export class NewmanQaseReporter {
         if (timer) {
           const now = Date.now();
           pendingResult.execution.duration = now - timer;
+          pendingResult.execution.start_time = timer / 1000;
+          pendingResult.execution.end_time = now / 1000;
         }
 
         pendingResult.params = this.prepareParameters(item, exec.cursor.iteration);


### PR DESCRIPTION
This pull request includes changes to the `qase-newman` package to enhance the accuracy of test and step time reporting. The most important changes include updating the version number, adding new time handling features, and documenting these changes.

Enhancements to time reporting:

* [`qase-newman/src/reporter.ts`](diffhunk://#diff-eeea7d1eec274dee14fc21cb8e54f0ee033d77cfcb85bc85ca8046e2a170c17aR251-R252): Enhanced handling of start and end times for tests and steps by adding `start_time` and `end_time` to the `pendingResult.execution` object.

Version update and documentation:

* [`qase-newman/package.json`](diffhunk://#diff-f0e1c065db426de26d837b4ef3e7efbe6384f83e0796ed669aa67e56fc62d758L3-R3): Updated the version number from `2.0.4` to `2.0.5`.
* [`qase-newman/changelog.md`](diffhunk://#diff-278630244c7c4441a495950dd67a98b28fcd1a10341e2584728d822e2d5b93eaR1-R6): Added a new section for version `2.0.5` to document the enhanced handling of start and end times for tests and steps.