### PR TITLE
feat: improve start/end time handling for tests and steps

### DIFF
--- a/qase-testcafe/changelog.md
+++ b/qase-testcafe/changelog.md
@@ -1,3 +1,9 @@
+# qase-testcafe@2.0.6
+
+## What's new
+
+Enhanced handling of start and end times for tests and steps, ensuring greater accuracy in reporting.
+
 # qase-testcafe@2.0.4
 
 ## What's new

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-qase",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Qase TMS TestCafe Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -131,6 +131,7 @@ export class TestcafeQaseReporter {
 
   private steps: TestStepType[] = [];
   private attachments: Attachment[] = [];
+  private testBeginTime: number = Date.now();
 
   /**
    * @param {TestcafeQaseOptionsType} options
@@ -170,6 +171,7 @@ export class TestcafeQaseReporter {
   public reportTestStart = () => {
     this.steps = [];
     this.attachments = [];
+    this.testBeginTime = Date.now();
   };
 
   /**
@@ -208,8 +210,8 @@ export class TestcafeQaseReporter {
       author: null,
       execution: {
         status: TestcafeQaseReporter.getStatus(testRunInfo),
-        start_time: null,
-        end_time: null,
+        start_time: this.testBeginTime / 1000,
+        end_time: (this.testBeginTime + testRunInfo.durationMs) / 1000,
         duration: testRunInfo.durationMs,
         stacktrace: errorLog,
         thread: null,


### PR DESCRIPTION
This pull request includes enhancements to the `qase-testcafe` package, specifically focusing on improving the accuracy of test and step timing. The changes involve updating the version, modifying the reporter to handle start and end times more accurately, and documenting these changes.

Enhancements to timing accuracy:

* [`qase-testcafe/src/reporter.ts`](diffhunk://#diff-dea2c7dc39d9cbc2eae7e8674e6ffdaf7fc3de73db68c3427d0ac16cb044fa7bR134): Introduced `testBeginTime` to store the test start time and updated the `reportTestStart` method to reset this time at the beginning of each test. The `execution` object now uses `testBeginTime` to set accurate `start_time` and `end_time` values. [[1]](diffhunk://#diff-dea2c7dc39d9cbc2eae7e8674e6ffdaf7fc3de73db68c3427d0ac16cb044fa7bR134) [[2]](diffhunk://#diff-dea2c7dc39d9cbc2eae7e8674e6ffdaf7fc3de73db68c3427d0ac16cb044fa7bR174) [[3]](diffhunk://#diff-dea2c7dc39d9cbc2eae7e8674e6ffdaf7fc3de73db68c3427d0ac16cb044fa7bL211-R214)

Version update:

* [`qase-testcafe/package.json`](diffhunk://#diff-d80c5ec1ea497b45d677429533024a46a672e4947fcfa4740ffe56ba91ce279fL3-R3): Updated the version from `2.0.5` to `2.0.6`.

Documentation update:

* [`qase-testcafe/changelog.md`](diffhunk://#diff-1380183e42a7879b9ef50be3c9ced994d6546a71d2d4902e3150996348772f5dR1-R6): Added a new entry for version `2.0.6` detailing the enhanced handling of start and end times for tests and steps.