### PR TITLE
fix: ensure custom suite from `qase.suite` is correctly applied

### DIFF
--- a/qase-wdio/changelog.md
+++ b/qase-wdio/changelog.md
@@ -1,3 +1,9 @@
+# qase-wdio@1.0.2
+
+## What's new
+
+Resolved an issue where a custom suite set via `qase.suite` was not included in the test results.
+
 # qase-wdio@1.0.1
 
 ## What's new

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -275,19 +275,22 @@ export default class WDIOQaseReporter extends WDIOReporter {
       return;
     }
 
-    const relations: Relation = {};
-    if (this.storage.suites.length > 0) {
-      relations.suite = {
-        data: this.storage.suites.map((suite) => {
-          return {
-            title: suite,
-            public_id: null,
-          };
-        }),
-      };
+    if (testResult.relations === null) {
+      const relations: Relation = {};
+      if (this.storage.suites.length > 0) {
+        relations.suite = {
+          data: this.storage.suites.map((suite) => {
+            return {
+              title: suite,
+              public_id: null,
+            };
+          }),
+        };
+      }
+
+      testResult.relations = relations;
     }
 
-    testResult.relations = relations;
     testResult.execution.duration = testResult.execution.start_time ? Math.round(end_time - testResult.execution.start_time) : 0;
     testResult.execution.status = status;
     testResult.execution.stacktrace = err === null ?


### PR DESCRIPTION
This pull request includes updates to the `qase-wdio` package, specifically addressing a bug fix, version bump, and code improvements. The most important changes are summarized below:

### Bug Fix:
* Resolved an issue where a custom suite set via `qase.suite` was not included in the test results. (`qase-wdio/changelog.md`, `qase-wdio/src/reporter.ts`) [[1]](diffhunk://#diff-8343aa0a0d3a3e6cbac3f8e9ecc22786105c91f1ee77e254e264576ed8467a99R1-R6) [[2]](diffhunk://#diff-b59909cf64d6c06c8fe5356db40408673e67035e467a10b36634973f15eadcdaR278) [[3]](diffhunk://#diff-b59909cf64d6c06c8fe5356db40408673e67035e467a10b36634973f15eadcdaR292-R293)

### Version Update:
* Updated the package version from `1.0.1` to `1.0.2` in `package.json`. (`qase-wdio/package.json`)