### PR TITLE
feat: update API client contract with search endpoint field

### DIFF
--- a/qaseio/changelog.md
+++ b/qaseio/changelog.md
@@ -1,3 +1,10 @@
+# qaseio@2.4.3
+
+## What's new
+
+- New field in the search endpoint of the public API contract.
+- Extended API client functionality to accommodate the updated contract.
+
 # qaseio@2.4.2
 
 ## What's new

--- a/qaseio/package.json
+++ b/qaseio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qaseio",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Qase TMS Javascript API Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qaseio/src/qaseio.ts
+++ b/qaseio/src/qaseio.ts
@@ -15,7 +15,9 @@ import {
   DefectsApi,
   CustomFieldsApi,
   AuthorsApi,
-  Configuration, EnvironmentsApi,
+  Configuration,
+  EnvironmentsApi,
+  SearchApi,
 } from './generated';
 
 export interface QaseApiOptionsType {
@@ -41,6 +43,7 @@ export interface QaseApiInterface {
   customFields: CustomFieldsApi;
   authors: AuthorsApi;
   environment: EnvironmentsApi;
+  search: SearchApi;
 }
 
 /**
@@ -62,6 +65,7 @@ export class QaseApi implements QaseApiInterface {
   public customFields: CustomFieldsApi;
   public authors: AuthorsApi;
   public environment: EnvironmentsApi;
+  public search: SearchApi;
 
   /**
    * @param {QaseApiOptionsType} options
@@ -125,5 +129,6 @@ export class QaseApi implements QaseApiInterface {
     this.customFields = new CustomFieldsApi(configuration, host, transport);
     this.authors = new AuthorsApi(configuration, host, transport);
     this.environment = new EnvironmentsApi(configuration, host, transport);
+    this.search = new SearchApi(configuration, host, transport);
   }
 }


### PR DESCRIPTION
This pull request includes updates to the `qaseio` package to introduce a new search functionality in the API client. The most important changes include adding a new field to the search endpoint and updating the API client to support this new functionality.

### New search functionality:

* [`qaseio/changelog.md`](diffhunk://#diff-f50ddec8a96cd317ca79728e3615a8e507b79106917af61aadcda974be1c83ebR1-R7): Added a new field in the search endpoint of the public API contract and extended API client functionality to accommodate the updated contract.
* [`qaseio/package.json`](diffhunk://#diff-f68cebf949e240a3c55ba44c6caf0430f09fae964cd1a1272087844c9d00da45L3-R3): Updated the version from `2.4.2` to `2.4.3` to reflect the new changes.

### API client updates:

* `qaseio/src/qaseio.ts`: 
  * Added `SearchApi` to the imports.
  * Included `search` in the `QaseApiInterface`.
  * Implemented `search` in the `QaseApi` class. [[1]](diffhunk://#diff-13be6625b04dd9e73c9a54545b34dc5245ae7ebc097b0a8af075ea5e1806b96aR68) [[2]](diffhunk://#diff-13be6625b04dd9e73c9a54545b34dc5245ae7ebc097b0a8af075ea5e1806b96aR132)