### PR TITLE
fix: handle package version retrieval errors in npm list

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.2.18
+
+## What's new
+
+Resolved an issue where retrieving installed package versions failed if some dependencies were missing.
+
 # qase-javascript-commons@2.2.17
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/utils/hostData.ts
+++ b/qase-javascript-commons/src/utils/hostData.ts
@@ -120,9 +120,15 @@ function getPackageVersion(packageName: string): string | null {
       return packageJson.version;
     }
 
+
     // Try using npm list as fallback with recursive search
-    const output = execCommand(`npm list --depth=10 --json`);
-    if (!output) return null;
+    let output = null;
+    try {
+      output = execCommand(`npm list --depth=10 --json`);
+      if (!output) return null;
+    } catch (error) {
+      return null;
+    }
 
     try {
       const npmList = JSON.parse(output) as NpmListResult;


### PR DESCRIPTION
This pull request includes several updates to the `qase-javascript-commons` package to resolve an issue and improve error handling. The most important changes are listed below:

### Version Update and Changelog:

* Updated the package version to `2.2.18` in `package.json`.
* Added a new entry in the changelog for version `2.2.18`, detailing the resolved issue with retrieving installed package versions when some dependencies were missing.

### Error Handling Improvement:

* Enhanced the `getPackageVersion` function in `hostData.ts` to handle errors more gracefully by adding a try-catch block around the `execCommand` call. This ensures that if the command fails, the function returns `null` instead of throwing an error.

#774 