### PR TITLE
fix: handle package version retrieval errors in npm list

### DIFF
--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.2.18",
+  "version": "2.2.19",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/utils/hostData.ts
+++ b/qase-javascript-commons/src/utils/hostData.ts
@@ -3,6 +3,7 @@ import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { HostData } from '../models/host-data';
+import { execSync } from "child_process";
 
 interface PackageJson {
   version: string;
@@ -124,7 +125,7 @@ function getPackageVersion(packageName: string): string | null {
     // Try using npm list as fallback with recursive search
     let output = null;
     try {
-      output = execCommand(`npm list --depth=10 --json`);
+      output = execSync(`npm list --depth=10 --json`, { stdio: "pipe" }).toString();
       if (!output) return null;
     } catch (error) {
       return null;


### PR DESCRIPTION
- Fixed an issue where `npm list --depth=10 --json` failed due to missing dependencies.
- Improved error handling to prevent crashes when retrieving installed package versions.