### PR TITLE
chore: bump axios-retry to 4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4540,12 +4540,15 @@
       }
     },
     "node_modules/axios-retry": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
-      "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
         "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
       }
     },
     "node_modules/babel-jest": {
@@ -17488,7 +17491,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.2",
-        "axios-retry": "^3.5.0"
+        "axios-retry": "^4.5.0"
       },
       "devDependencies": {
         "@jest/globals": "^27.5.1",
@@ -18605,7 +18608,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.2",
-        "axios-retry": "^3.5.0"
+        "axios-retry": "^4.5.0"
       },
       "devDependencies": {
         "@jest/globals": "^27.5.1",
@@ -20002,7 +20005,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.2",
-        "axios-retry": "^3.5.0"
+        "axios-retry": "^4.5.0"
       },
       "devDependencies": {
         "@jest/globals": "^27.5.1",

--- a/qase-api-client/package.json
+++ b/qase-api-client/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "axios": "^1.8.2",
-    "axios-retry": "^3.5.0"
+    "axios-retry": "^4.5.0"
   },
   "devDependencies": {
     "@jest/globals": "^27.5.1",

--- a/qase-api-v2-client/package.json
+++ b/qase-api-v2-client/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "axios": "^1.8.2",
-    "axios-retry": "^3.5.0"
+    "axios-retry": "^4.5.0"
   },
   "devDependencies": {
     "@jest/globals": "^27.5.1",

--- a/qaseio/package.json
+++ b/qaseio/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "axios": "^1.8.2",
-    "axios-retry": "^3.5.0"
+    "axios-retry": "^4.5.0"
   },
   "devDependencies": {
     "@jest/globals": "^27.5.1",

--- a/qaseio/src/qaseio.ts
+++ b/qaseio/src/qaseio.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import * as axiosRetry from 'axios-retry';
+import axiosRetry from 'axios-retry';
 
 import {
   ProjectsApi,


### PR DESCRIPTION
axios-retry 3.* depends on a vulnerable version of @babel/runtime
4.* no longer depends on @babel/runtime

See https://github.com/advisories/GHSA-968p-4wvh-cqc8