### PR TITLE
fix: correct handling of parent suites in test results

### DIFF
--- a/qase-newman/changelog.md
+++ b/qase-newman/changelog.md
@@ -1,3 +1,10 @@
+# qase-newman@2.1.1
+
+## What's new
+
+Fixed an issue where parent suite hierarchy was not properly handled in test results. Now results correctly display the
+full structure of suites.
+
 # qase-newman@2.1.0
 
 ## What's new

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-qase",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Qase TMS Newman Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-newman/src/reporter.ts
+++ b/qase-newman/src/reporter.ts
@@ -93,15 +93,15 @@ export class NewmanQaseReporter {
   private static getParentTitles(
     item: PropertyBase<PropertyBaseDefinition>,
   ) {
-    const titles: string[] = [];
-
-    if ('name' in item) {
-      titles.push(String(item.name));
-    }
+    let titles: string[] = [];
 
     const parent = item.parent();
     if (parent) {
-      titles.concat(NewmanQaseReporter.getParentTitles(parent));
+      titles = titles.concat(NewmanQaseReporter.getParentTitles(parent));
+    }
+
+    if ('name' in item) {
+      titles.push(String(item.name));
     }
 
     return titles;


### PR DESCRIPTION
This pull request addresses a bug fix in the `qase-newman` package related to parent suite hierarchy handling in test results. It includes changes to the changelog, version bump, and a functional fix in the reporter logic.

### Bug Fixes:

* **Parent Suite Hierarchy Handling**:
  - Fixed the logic in `getParentTitles` within `qase-newman/src/reporter.ts` to ensure the titles array is updated correctly when traversing parent items. This resolves the issue of improperly displayed suite structures in test results.

### Documentation Updates:

* **Changelog Update**:
  - Added an entry in `qase-newman/changelog.md` for version `2.1.1`, describing the fix for the parent suite hierarchy issue.

### Versioning:

* **Version Bump**:
  - Updated the package version in `qase-newman/package.json` from `2.1.0` to `2.1.1` to reflect the bug fix.