### PR TITLE
feat: support setting suite via annotations

### DIFF
--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,19 @@
+# playwright-qase-reporter@2.1.1
+
+## What's new
+
+Support specifying the test case suite in the `annotation`.
+
+```ts
+test('test',
+  {
+    annotation: { type: 'QaseSuite', description: 'My suite' },
+  },
+  async ({ page }) => {
+    await page.goto('https://example.com');
+  });
+```
+
 # playwright-qase-reporter@2.1.0
 
 ## What's new

--- a/qase-playwright/docs/usage.md
+++ b/qase-playwright/docs/usage.md
@@ -13,61 +13,72 @@ Here is the complete list of syntax options available for the reporter:
 - [Attach](#attach)
 - [Ignore](#ignore)
 
-If you do not use any Qase syntax, the reporter uses the title from the `describe` and `test` functions as the Suite and Test case title respectively, when publishing results.
+If you do not use any Qase syntax, the reporter uses the title from the `describe` and `test` functions as the Suite and
+Test case title respectively, when publishing results.
 
 <br>
 
 ### Import Statement
+
 ---
 Add the following statement at the beginning of your spec file, before any tests.
 
 ```javascript
 import { qase } from 'playwright-qase-reporter';
 ```
+
 <br>
 
 ### Example Spec file
+
 ---
+
 ```javascript
 import { qase } from 'playwright-qase-reporter';
 
 describe('Suite title', () => {
 
-  test(qase(1, "This is the test name"), () => {
+  test(qase(1, "This is the test name"), async () => {
     qase.title("This overrides the test name");
     qase.suite("Suite name");
     qase.fields({ 'severity': 'high', 'priority': 'medium' });
     qase.attach({ paths: './tests/examples/attachments/test-file.txt' });
     qase.comment("A comment for this result");
     qase.ignore(); // doesn't report his result to Qase.
-    qase.parameters({ Username: "@test" }); 
+    qase.parameters({ Username: "@test" });
     qase.groupParameters({ Username: username, Password: "123" });
-    await test.step('Test step title', async () => // step logic });
+    await test.step('Test step title', async () => {
+      // step logic 
+    });
   });
-
+});
 ```
+
 <br>
 
 ### Qase ID
+
 ---
 
-Qase IDs can be defined using two different methods. It is best to select one method and consistently use it throughout your tests. The first method is recommended.
+Qase IDs can be defined using two different methods. It is best to select one method and consistently use it throughout
+your tests. The first method is recommended.
 
-Only one Qase Id can be linked to a test. 
+Only one Qase Id can be linked to a test.
 
-**Inline with the `test` Function**: 
+**Inline with the `test` Function**:
 
 ```javascript
 test(qase(1, 'A simple test'), () => {
-    ..
+  // Test logic here
+});
 ```
 
-**Inside the `test` Body**: 
+**Inside the `test` Body**:
 
 ```javascript
 test('A simple test', () => {
-    qase.id(1);
-    // Test logic here
+  qase.id(1);
+  // Test logic here
 });
 ```
 
@@ -75,19 +86,22 @@ test('A simple test', () => {
 
 ```js
 test('A simple test',
-{
-  annotation: { type: 'QaseID', description: '1' },
-},
+  {
+    annotation: { type: 'QaseID', description: '1' },
+  },
   async () => {
     // Test logic here
-});
+  });
 ```
+
 <br>
 
 ### Qase Title
---- 
 
-The `qase.title()` method is used to set the title of a test case, both when creating a new test case from the result, and when updating the title of an existing test case - *if used with `qase.id()`.*
+---
+
+The `qase.title()` method is used to set the title of a test case, both when creating a new test case from the result,
+and when updating the title of an existing test case - *if used with `qase.id()`.*
 
 ```javascript
 test("This won't appear in Qase", () => {
@@ -96,16 +110,21 @@ test("This won't appear in Qase", () => {
 });
 ```
 
-If you don’t explicitly set a title using this method, the title specified in the `test(..)` function will be used for creating new test cases. However, if this method is defined, it always takes precedence and overrides the title from the `test(..)` function.
+If you don’t explicitly set a title using this method, the title specified in the `test(..)` function will be used for
+creating new test cases. However, if this method is defined, it always takes precedence and overrides the title from the
+`test(..)` function.
 
 <br>
 
 ### Steps
---- 
 
-The reporter uses the title from the `test.step` function as the step title. By providing clear and descriptive step names, you make it easier to understand the test’s flow when reviewing the test case.
+---
 
-Additionally, these steps get their own result in the Qase Test run, offering a well-organized summary of the test flow. This helps quickly identify the cause of any failures.
+The reporter uses the title from the `test.step` function as the step title. By providing clear and descriptive step
+names, you make it easier to understand the test’s flow when reviewing the test case.
+
+Additionally, these steps get their own result in the Qase Test run, offering a well-organized summary of the test flow.
+This helps quickly identify the cause of any failures.
 
 ```javascript
 test('A Test case with steps, updated from code', async () => {
@@ -122,7 +141,8 @@ test('A Test case with steps, updated from code', async () => {
 });
 ```
 
-You also can use the `qase.step()` method to set the expected result and data of the step, which will be used in the Qase report.
+You also can use the `qase.step()` method to set the expected result and data of the step, which will be used in the
+Qase report.
 
 ```javascript
 test('A Test case with steps, updated from code', async () => {
@@ -142,53 +162,71 @@ test('A Test case with steps, updated from code', async () => {
 <br>
 
 ### Fields
+
 ---
 
-You can define the `description`, `pre-conditions`, `post-conditions`, and fields such as `severity`, `priority`, and `layer` using this method, which enables you to specify and maintain the context of the case directly within your code.
+You can define the `description`, `pre-conditions`, `post-conditions`, and fields such as `severity`, `priority`, and
+`layer` using this method, which enables you to specify and maintain the context of the case directly within your code.
 
 ```javascript
 test('Maintain your test meta-data from code', async () => {
   qase.fields({
-      severity: 'high',
-      priority: 'medium',
-      layer: 'api',
-      precondition: 'add your precondition'
-      postcondition: 'add your postcondition'
-      description: `Code it quick, fix it slow,
+    severity: 'high',
+    priority: 'medium',
+    layer: 'api',
+    precondition: 'add your precondition',
+    postcondition: 'add your postcondition',
+    description: `Code it quick, fix it slow,
                     Tech debt grows where shortcuts go,
                     Refactor later? Ha! We know.`
-    })
-    //  test logic here
-});
-```
-
-<br>
-
-
-### Suite 
----
-
-You can use this method to nest the resulting test cases in a particular suite. There's something to note here – suites, unlike test cases, are not identified uniquely by the Reporter. Therefore, when defining an existing suite - the title of the suite is used for matching.
-
-```js
-test("Test with a defined suite", () => {
-  qase.suite("Suite defined with qase.suite()");
-    /*
-     *  Or, nest multiple levels of suites. 
-     *  `\t` is used for dividing each suite name.
-     */
-     
-test("Test with a nested suite", () => {
-  qase.suite("Application\tAuthentication\tLogin\tEdge_case");
+  })
   //  test logic here
 });
 ```
+
+<br>
+
+### Suite
+
+---
+
+You can use this method to nest the resulting test cases in a particular suite. There's something to note here – suites,
+unlike test cases, are not identified uniquely by the Reporter. Therefore, when defining an existing suite - the title
+of the suite is used for matching.
+
+```js
+test('Test with a defined suite', () => {
+  qase.suite('Suite defined with qase.suite()');
+});
+
+/*
+ *  Or, nest multiple levels of suites. 
+ *  `\t` is used for dividing each suite name.
+ */
+test('Test with a nested suite', () => {
+  qase.suite('Application\tAuthentication\tLogin\tEdge_case');
+  //  test logic here
+});
+
+test('Test with a suite from annotations',
+  {
+    annotation: {
+      type: 'QaseSuite', 
+      description: 'Suite defined in annotation',
+    },
+  },
+  async () => {
+    // Test logic here
+  });
+```
+
 <br>
 
 ### Parameters
----
-Parameters are a great way to make your tests more dynamic, reusable, and data-driven. By defining parameters in this method, you can ensure only one test case with all the parameters is created in your Qase project, avoiding duplication.
 
+---
+Parameters are a great way to make your tests more dynamic, reusable, and data-driven. By defining parameters in this
+method, you can ensure only one test case with all the parameters is created in your Qase project, avoiding duplication.
 
 ```javascript
 const testCases = [
@@ -197,69 +235,83 @@ const testCases = [
   { browser: "Webkit", username: "@charlie", password: "789" },
 ];
 
-testCases.forEach(({ browser, username, password,  }) => {
+testCases.forEach(({ browser, username, password, }) => {
   test(`Test login with ${browser}`, async () => {
     qase.title("Verify if page loads on all browsers");
 
     qase.parameters({ Browser: browser });  // Single parameter
-  // test logic
+    // test logic
 
-testCases.forEach(({ username, password }) => {
-  test(`Test login with ${username} using qase.groupParameters`, () => {
-    qase.title("Verify if user is able to login with their username.");
+    testCases.forEach(({ username, password }) => {
+      test(`Test login with ${username} using qase.groupParameters`, () => {
+        qase.title("Verify if user is able to login with their username.");
 
-    qase.groupParameters({  // Group parameters
-      Username: username,
-      Password: password,
+        qase.groupParameters({  // Group parameters
+          Username: username,
+          Password: password,
+        });
+        // test logic
+      });
     });
-  // test logic
+  });
+});
 ```
+
 <br>
 
 ### Comment
+
 ---
-In addition to `test.step()`, this method can be used to provide any additional context to your test, it helps maintiain the code by clarifying the expected result of the test.
+In addition to `test.step()`, this method can be used to provide any additional context to your test, it helps maintiain
+the code by clarifying the expected result of the test.
 
 ```js
 test("A test case with qase.comment()", () => {
-    /*
-     * Please note, this comment is added to a Result, not to the Test case.
-     */
+  /*
+   * Please note, this comment is added to a Result, not to the Test case.
+   */
   qase.comment("This comment is added to the result");
   // test logic here
 });
 ```
+
 <br>
 
 ### Attach
+
 ---
-This method can help attach one, or more files to the test's result. You can also add the file's contents directly from code. For example: 
+This method can help attach one, or more files to the test's result. You can also add the file's contents directly from
+code. For example:
 
 ```js
 test('Test result with attachment', async () => {
 
-       // To attach a single file
-    qase.attach({
-      paths: "./tests/examples/attachments/test-file.txt",
-    });
+  // To attach a single file
+  qase.attach({
+    paths: "./tests/examples/attachments/test-file.txt",
+  });
 
-       // Add multiple attachments. 
-    qase.attach({ paths: ['/path/to/file', '/path/to/another/file'] });
+  // Add multiple attachments. 
+  qase.attach({ paths: ['/path/to/file', '/path/to/another/file'] });
 
 
-       // Upload file's contents directly from code.
-    qase.attach({ name: 'attachment.txt', content: 'Hello, world!', contentType: 'text/plain' });
-      // test logic here
+  // Upload file's contents directly from code.
+  qase.attach({ name: 'attachment.txt', content: 'Hello, world!', contentType: 'text/plain' });
+  // test logic here
 });
 ```
+
 <br>
 
 ### Ignore
+
 ---
-If this method is added, the reporter will exclude the test’s result from the report sent to Qase. While the test will still executed by Playwright, its result will not be considered by the reporter.
+If this method is added, the reporter will exclude the test’s result from the report sent to Qase. While the test will
+still executed by Playwright, its result will not be considered by the reporter.
 
 ```js
-test("This test is executed using Playwright; however, it is NOT reported to Qase", () => {
+test('This test is executed using Playwright; however, it is NOT reported to Qase', () => {
   qase.ignore();
 //  test logic here
+});
 ```

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -340,7 +340,11 @@ export class PlaywrightQaseReporter implements Reporter {
     }
 
     const error = result.error ? PlaywrightQaseReporter.transformError(result.errors) : null;
-    const suites = testCaseMetadata.suite != '' ? [testCaseMetadata.suite] : PlaywrightQaseReporter.transformSuiteTitle(test);
+
+    const extractedSuites = this.extractSuiteFromAnnotation(test.annotations);
+    const suites = extractedSuites.length > 0
+      ? extractedSuites
+      : (testCaseMetadata.suite ? [testCaseMetadata.suite] : PlaywrightQaseReporter.transformSuiteTitle(test));
 
     let message: string | null = null;
     if (testCaseMetadata.comment !== '') {
@@ -515,6 +519,22 @@ export class PlaywrightQaseReporter implements Reporter {
   }
 
   /**
+   * @param annotation
+   * @returns {string[]}
+   * @private
+   */
+  private extractSuiteFromAnnotation(annotation: { type: string, description?: string }[]): string[] {
+    const suites: string[] = [];
+    for (const item of annotation) {
+      if (item.type.toLowerCase() === 'qasesuite' && item.description) {
+        suites.push(item.description);
+      }
+    }
+
+    return suites;
+  }
+
+  /**
    * @param {TestStep[]} steps
    * @returns {boolean}
    * @private
@@ -533,7 +553,11 @@ export class PlaywrightQaseReporter implements Reporter {
     return true;
   }
 
-  private extractAndCleanStep(input: string): { expectedResult: string | null; data: string | null; cleanedString: string } {
+  private extractAndCleanStep(input: string): {
+    expectedResult: string | null;
+    data: string | null;
+    cleanedString: string
+  } {
     let expectedResult: string | null = null;
     let data: string | null = null;
     let cleanedString = input;


### PR DESCRIPTION
This pull request introduces several updates to the `playwright-qase-reporter` package, including a new feature for specifying test case suites via annotations, documentation improvements, and internal code changes for better functionality and maintainability.

### New Feature:
* Added support for defining test case suites using the `annotation` property in test definitions. This allows users to specify suites directly in their test code for better organization. (`qase-playwright/src/reporter.ts`, [[1]](diffhunk://#diff-3f15218cd3a03d6ac76683c4437c053029f848df708978f79ff7c29c8818df1eL343-R347) [[2]](diffhunk://#diff-3f15218cd3a03d6ac76683c4437c053029f848df708978f79ff7c29c8818df1eR521-R536)

### Documentation Updates:
* Updated `qase-playwright/docs/usage.md` to improve readability and consistency. This includes reformatting text, improving examples, and clarifying the usage of various methods like `qase.suite`, `qase.fields`, and `qase.step`. [[1]](diffhunk://#diff-2319b36fd65e188f6bb37d8e5aae34b082bf5adaf73dc50baadd7c20a256995bL16-R41) [[2]](diffhunk://#diff-2319b36fd65e188f6bb37d8e5aae34b082bf5adaf73dc50baadd7c20a256995bL45-R73) [[3]](diffhunk://#diff-2319b36fd65e188f6bb37d8e5aae34b082bf5adaf73dc50baadd7c20a256995bR96-R104) [[4]](diffhunk://#diff-2319b36fd65e188f6bb37d8e5aae34b082bf5adaf73dc50baadd7c20a256995bL99-R127) [[5]](diffhunk://#diff-2319b36fd65e188f6bb37d8e5aae34b082bf5adaf73dc50baadd7c20a256995bL125-R145) [[6]](diffhunk://#diff-2319b36fd65e188f6bb37d8e5aae34b082bf5adaf73dc50baadd7c20a256995bR165-R178) [[7]](diffhunk://#diff-2319b36fd65e188f6bb37d8e5aae34b082bf5adaf73dc50baadd7c20a256995bL167-R229) [[8]](diffhunk://#diff-2319b36fd65e188f6bb37d8e5aae34b082bf5adaf73dc50baadd7c20a256995bR254-R266) [[9]](diffhunk://#diff-2319b36fd65e188f6bb37d8e5aae34b082bf5adaf73dc50baadd7c20a256995bR277-R284) [[10]](diffhunk://#diff-2319b36fd65e188f6bb37d8e5aae34b082bf5adaf73dc50baadd7c20a256995bR303-R316)

### Code Enhancements:
* Added a new private method `extractSuiteFromAnnotation` to parse and extract suite information from test annotations. This ensures that suite definitions from annotations are processed correctly. (`qase-playwright/src/reporter.ts`, [qase-playwright/src/reporter.tsR521-R536](diffhunk://#diff-3f15218cd3a03d6ac76683c4437c053029f848df708978f79ff7c29c8818df1eR521-R536))
* Refactored the `extractAndCleanStep` method to improve code readability by formatting its return type more clearly. (`qase-playwright/src/reporter.ts`, [qase-playwright/src/reporter.tsL536-R560](diffhunk://#diff-3f15218cd3a03d6ac76683c4437c053029f848df708978f79ff7c29c8818df1eL536-R560))

### Version Update:
* Updated the package version from `2.1.0` to `2.1.1` in `package.json` to reflect the new changes and feature additions. (`qase-playwright/package.json`, [qase-playwright/package.jsonL3-R3](diffhunk://#diff-ff5b095bcae2fc44c7fdf71ab36e999f0bd057eef0ec05c9df5b73971c5a3defL3-R3))

### Changelog:
* Added an entry for version `2.1.1` in `changelog.md`, highlighting the new feature for specifying test case suites using annotations. (`qase-playwright/changelog.md`, [qase-playwright/changelog.mdR1-R16](diffhunk://#diff-840ea994555c89eea28bf2c564a36f7312d4dc999a4664ef502440fbf6964525R1-R16))