### PR TITLE
fix: ensure run start time is before first test execution

### DIFF
--- a/qase-api-client/package.json
+++ b/qase-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Qase TMS Javascript API V1 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-api-v2-client/package.json
+++ b/qase-api-v2-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-v2-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Qase TMS Javascript API V2 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -32,8 +32,8 @@
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
     "mime-types": "^2.1.33",
-    "qase-api-client": "~1.0.0",
-    "qase-api-v2-client": "~1.0.0",
+    "qase-api-client": "~1.0.1",
+    "qase-api-v2-client": "~1.0.1",
     "strip-ansi": "^6.0.1",
     "uuid": "^9.0.0",
     "async-mutex": "~0.5.0"

--- a/qase-javascript-commons/src/client/clientV1.ts
+++ b/qase-javascript-commons/src/client/clientV1.ts
@@ -9,7 +9,7 @@ import { LoggerInterface } from '../utils/logger';
 import chalk from 'chalk';
 import { createReadStream } from 'fs';
 import { Readable } from 'stream';
-import { formatUTCDate } from './dateUtils';
+import { getStartTime } from './dateUtils';
 import FormData from 'form-data';
 
 const DEFAULT_API_HOST = 'qase.io';
@@ -78,11 +78,11 @@ export class ClientV1 implements IClient {
       return this.config.run.id;
     }
 
-    this.logger.logDebug('Creating test run');
-
     try {
       const environmentId = await this.getEnvironmentId();
       const runObject = this.prepareRunObject(environmentId);
+
+      this.logger.logDebug(`Creating test run: ${JSON.stringify(runObject)}`);
 
       const { data } = await this.runClient.createRun(
         this.config.project,
@@ -181,7 +181,7 @@ export class ClientV1 implements IClient {
       description: this.config.run.description ?? '',
       is_autotest: true,
       cases: [],
-      start_time: formatUTCDate(new Date()),
+      start_time: getStartTime(),
     };
 
     if (environmentId !== undefined) {

--- a/qase-javascript-commons/src/client/dateUtils.ts
+++ b/qase-javascript-commons/src/client/dateUtils.ts
@@ -2,18 +2,17 @@
 const pad = (num: number) => num.toString().padStart(2, '0');
 
 export function formatUTCDate(date: Date): string {
-    const year = date.getUTCFullYear();
-    const month = pad(date.getUTCMonth() + 1);
-    const day = pad(date.getUTCDate());
-    const hours = pad(date.getUTCHours());
-    const minutes = pad(date.getUTCMinutes());
-    const seconds = pad(date.getUTCSeconds());
+  const year = date.getUTCFullYear();
+  const month = pad(date.getUTCMonth() + 1);
+  const day = pad(date.getUTCDate());
+  const hours = pad(date.getUTCHours());
+  const minutes = pad(date.getUTCMinutes());
+  const seconds = pad(date.getUTCSeconds());
 
-    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 }
 
 export function getStartTime(): string {
-    const date = new Date();
-    date.setSeconds(-10);
-    return formatUTCDate(date);
+  const date = new Date();
+  return formatUTCDate(new Date(date.getTime() - 10000));
 }

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.2",
-    "qase-javascript-commons": "~2.3.0",
+    "qase-javascript-commons": "~2.3.1",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qaseio/package.json
+++ b/qaseio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qaseio",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Qase TMS Javascript API Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This pull request includes version updates across multiple packages and enhancements to the `qase-javascript-commons` codebase. The version updates ensure compatibility between dependencies, while the code improvements focus on logging clarity and time handling.

### Version updates:
* Updated the version of `qase-api-client` to `1.0.1` in its `package.json` file.
* Updated the version of `qase-api-v2-client` to `1.0.1` in its `package.json` file.
* Updated the version of `qase-javascript-commons` to `2.3.1` in its `package.json` file and updated its dependencies to use `qase-api-client@~1.0.1` and `qase-api-v2-client@~1.0.1`. [[1]](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL3-R3) [[2]](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL35-R36)
* Updated the version of `playwright-qase-reporter` to `2.1.2` in its `package.json` file and updated its dependency on `qase-javascript-commons` to `~2.3.1`. [[1]](diffhunk://#diff-ff5b095bcae2fc44c7fdf71ab36e999f0bd057eef0ec05c9df5b73971c5a3defL3-R3) [[2]](diffhunk://#diff-ff5b095bcae2fc44c7fdf71ab36e999f0bd057eef0ec05c9df5b73971c5a3defL47-R47)
* Updated the version of `qaseio` to `2.4.4` in its `package.json` file.

### Code improvements in `qase-javascript-commons`:
* Replaced `formatUTCDate` with a new `getStartTime` function for calculating the start time of a test run, improving time handling logic. [[1]](diffhunk://#diff-439bb924963ba7bb678cca45dc47ab181e10c9ca8194dc483a15bdf0b4522674L12-R12) [[2]](diffhunk://#diff-439bb924963ba7bb678cca45dc47ab181e10c9ca8194dc483a15bdf0b4522674L184-R184) [[3]](diffhunk://#diff-a25774e2c61d3967f9db3f29e3c22ae577b31a6f40ed32da006fe278dd26e913L17-R17)
* Enhanced logging in the `ClientV1` class to include detailed information about the test run being created.