### PR TITLE
feat: bump package versions and add new test step status

### DIFF
--- a/qase-api-client/package.json
+++ b/qase-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Qase TMS Javascript API V1 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-api-client/src/model/test-step-result-create.ts
+++ b/qase-api-client/src/model/test-step-result-create.ts
@@ -78,7 +78,8 @@ export interface TestStepResultCreate {
 export enum TestStepResultCreateStatusEnum {
     PASSED = 'passed',
     FAILED = 'failed',
-    BLOCKED = 'blocked'
+    BLOCKED = 'blocked',
+    IN_PROGRESS = 'in_progress'
 }
 
 

--- a/qase-api-client/src/model/test-step-result.ts
+++ b/qase-api-client/src/model/test-step-result.ts
@@ -22,7 +22,7 @@ import { Attachment } from './attachment';
  */
 export interface TestStepResult {
     /**
-     * 
+     * 1 - passed, 2 - failed, 3 - blocked, 5 - skipped, 7 - in_progress
      * @type {number}
      * @memberof TestStepResult
      */

--- a/qase-api-v2-client/docs/ResultStepStatus.md
+++ b/qase-api-v2-client/docs/ResultStepStatus.md
@@ -12,6 +12,7 @@ Enumeration of possible test step statuses.
 | failed | Step failed |
 | blocked | Step is blocked |
 | skipped | Step was skipped |
+| in_progress | Step is in progress |
 
 ## Example
 

--- a/qase-api-v2-client/package.json
+++ b/qase-api-v2-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-v2-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Qase TMS Javascript API V2 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-api-v2-client/src/model/result-step-status.ts
+++ b/qase-api-v2-client/src/model/result-step-status.ts
@@ -24,7 +24,8 @@ export enum ResultStepStatus {
     PASSED = 'passed',
     FAILED = 'failed',
     BLOCKED = 'blocked',
-    SKIPPED = 'skipped'
+    SKIPPED = 'skipped',
+    IN_PROGRESS = 'in_progress'
 }
 
 


### PR DESCRIPTION
- Updated package versions for qase-api-client and qase-api-v2-client to 1.0.2
- Added 'in_progress' status to TestStepResultCreateStatusEnum and ResultStepStatus enums
- Updated documentation to reflect the new 'in_progress' status