### PR TITLE
chore: bump version to 2.3.2 and update changelog

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.3.2
+
+## What's new
+
+Fixed an issue with attachments content type.
+
 # qase-javascript-commons@2.3.0
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/client/clientV1.ts
+++ b/qase-javascript-commons/src/client/clientV1.ts
@@ -157,7 +157,7 @@ export class ClientV1 implements IClient {
     return {
       name: attachment.file_name,
       value: typeof attachment.content === 'string'
-        ? Buffer.from(attachment.content)
+        ? Buffer.from(attachment.content, attachment.content.match(/^[A-Za-z0-9+/=]+$/) ? 'base64' : undefined)
         : attachment.content,
     };
   }


### PR DESCRIPTION
- Updated package version to 2.3.2
- Added entry in changelog for fixing attachment content type issue