### PR TITLE
feat:  add browser parameter support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18208,6 +18208,7 @@
       "devDependencies": {
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.5.2",
+        "ajv": "^8.12.0",
         "jest": "^29.5.0",
         "ts-jest": "^29.1.0"
       },

--- a/qase-playwright/README.md
+++ b/qase-playwright/README.md
@@ -18,11 +18,13 @@ npm install -D playwright-qase-reporter
 
 # Contents
 
-- [Getting started](#getting-started)
-- [Updating from v1](#updating-from-v1)
-- [Example of usage](#example-of-usage)
-- [Configuration](#configuration)
-- [Requirements](#requirements)
+- [Qase TMS Playwright reporter](#qase-tms-playwright-reporter)
+- [Contents](#contents)
+  - [Getting started](#getting-started)
+  - [Updating from v1](#updating-from-v1)
+  - [Example of usage](#example-of-usage)
+  - [Configuration](#configuration)
+  - [Requirements](#requirements)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -172,6 +174,8 @@ Reporter options (\* - required):
 - `testops.run.title` - Set custom Run name, when new run is created
 - `testops.run.description` - Set custom Run description, when new run is created
 - `testops.run.complete` - Whether the run should be completed
+- `framework.browser.addAsParameter` - Whether to add the browser name as a parameter, default - `false`
+- `framework.browser.parameterName` - The name of the parameter to add the browser name to, default - `browser`
 
 Example `playwright.config.js` config:
 
@@ -195,6 +199,12 @@ const config = {
           uploadAttachments: true,
           run: {
             complete: true,
+          },
+        },
+        framework: {
+          browser: {
+            addAsParameter: true,
+            parameterName: 'Browser Name',
           },
         },
       },

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,28 @@
+# playwright-qase-reporter@2.1.3
+
+## What's new
+
+Support specifying the browser name as a parameter.
+New section `framework` was added to the playwright config.
+
+```ts
+[
+  'playwright-qase-reporter',
+   {
+     debug: true,
+     testops: {
+      ...
+     },
+     framework: {
+      browser: {
+       addAsParameter: true,
+       parameterName: 'Browser Name',
+      },
+    },
+  },
+],
+```
+
 # playwright-qase-reporter@2.1.1
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@jest/globals": "^29.5.0",
     "@types/jest": "^29.5.2",
+    "ajv": "^8.12.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0"
   }

--- a/qase-playwright/src/configSchema.ts
+++ b/qase-playwright/src/configSchema.ts
@@ -1,0 +1,42 @@
+import { JSONSchemaType } from 'ajv'
+
+import { FrameworkOptionsType } from 'qase-javascript-commons'
+
+import { ReporterOptionsType } from './options'
+
+export const configSchema: JSONSchemaType<FrameworkOptionsType<'playwright', ReporterOptionsType>> = {
+  type: 'object',
+  nullable: true,
+
+  properties: {
+    framework: {
+      type: 'object',
+      nullable: true,
+
+      properties: {
+        playwright: {
+          type: 'object',
+          nullable: true,
+
+          properties: {
+            browser: {
+              type: 'object',
+              nullable: true,
+
+              properties: {
+                addAsParameter: {
+                  type: 'boolean',
+                  nullable: true,
+                },
+                parameterName: {
+                  type: 'string',
+                  nullable: true,
+                },
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};

--- a/qase-playwright/src/options.ts
+++ b/qase-playwright/src/options.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type ReporterOptionsType = {
+  browser?: {
+    addAsParameter?: boolean;
+    parameterName?: string;
+  };
+};


### PR DESCRIPTION
- Updated changelog to reflect new version 2.1.3
- Added support for specifying the browser name as a parameter in the Playwright configuration
- Introduced new properties in the configuration schema for browser parameter options
- Updated README to include new configuration options for browser parameter