### PR TITLE
fix: tag parsing from `QASE_TESTOPS_RUN_TAGS`

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.3.4
+
+## What's new
+
+Fixed an issue with parsing tags from the `QASE_TESTOPS_RUN_TAGS` environment variable. Now tags can be passed as a comma-separated string.
+
 # qase-javascript-commons@2.3.3
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/env/env-to-config.ts
+++ b/qase-javascript-commons/src/env/env-to-config.ts
@@ -37,7 +37,7 @@ export const envToConfig = (env: EnvType): ConfigType => ({
       title: env[EnvRunEnum.title],
       description: env[EnvRunEnum.description],
       complete: env[EnvRunEnum.complete],
-      tags: env[EnvRunEnum.tags],
+      tags: env[EnvRunEnum.tags]?.split(',').map(tag => tag.trim()) ?? [],
     },
 
     plan: {

--- a/qase-javascript-commons/src/env/env-type.ts
+++ b/qase-javascript-commons/src/env/env-type.ts
@@ -29,7 +29,7 @@ export interface EnvType {
   [EnvRunEnum.title]?: string;
   [EnvRunEnum.description]?: string;
   [EnvRunEnum.complete]?: boolean;
-  [EnvRunEnum.tags]?: string[];
+  [EnvRunEnum.tags]?: string;
 
   [EnvPlanEnum.id]?: number;
 

--- a/qase-javascript-commons/src/env/env-validation-schema.ts
+++ b/qase-javascript-commons/src/env/env-validation-schema.ts
@@ -86,10 +86,7 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
       nullable: true,
     },
     [EnvRunEnum.tags]: {
-      type: 'array',
-      items: {
-        type: 'string',
-      },
+      type: 'string',
       nullable: true,
     },
 


### PR DESCRIPTION
- Updated package version to 2.3.4
- Fixed tag parsing from `QASE_TESTOPS_RUN_TAGS` environment variable to accept comma-separated strings
- Updated changelog to reflect the new version and changes