### PR TITLE
fix: link to failed test in the console output

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.3.5
+
+## What's new
+
+Fixed a link to failed test in the console output.
+
 # qase-javascript-commons@2.3.4
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -202,7 +202,7 @@ export class TestOpsReporter extends AbstractReporter {
     }
     const baseLink = `${this.baseUrl}/run/${this.projectCode}/dashboard/${this.runId}?source=logs&status=%5B2%5D&search=`;
     if (id) {
-      return `${baseLink}${id}`;
+      return `${baseLink}${this.projectCode}-${id}`;
     }
 
     return `${baseLink}${encodeURI(title)}`;


### PR DESCRIPTION
- Updated package version to 2.3.5
- Fixed a link to failed test in the console output
- Updated changelog to reflect the new version and changes