### PR TITLE
fix: issue with test result upload for skipped tests

### DIFF
--- a/qase-wdio/README.md
+++ b/qase-wdio/README.md
@@ -28,14 +28,12 @@ For example:
 import {qase} from "wdio-qase-reporter";
 
 describe('My First Test', () => {
-  it('Several ids', () => {
-    qase.id(1);
+  it(qase(1, 'Several ids'), () => {
     expect(true).to.equal(true);
   });
 
   // a test can check multiple test cases
-  it('Correct test', () => {
-    qase.id([2, 3]);
+  it(qase([2,3], 'Correct test'), () => {
     expect(true).to.equal(true);
   });
 

--- a/qase-wdio/changelog.md
+++ b/qase-wdio/changelog.md
@@ -1,3 +1,11 @@
+# qase-wdio@1.1.2
+
+## What's new
+
+- Fixed an issue where the test result was not uploaded to the Qase TMS when the test has skipped status.
+- Added a new function `qase` to set the test case ID.
+- Marked the function `qase.id` as deprecated.
+
 # qase-wdio@1.1.0
 
 ## What's new

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -32,7 +32,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.3.3",
+    "qase-javascript-commons": "~2.3.5",
     "uuid": "^9.0.1",
     "@types/node": "^20.1.0",
     "@wdio/reporter": "^8.39.0",

--- a/qase-wdio/src/wdio.ts
+++ b/qase-wdio/src/wdio.ts
@@ -13,108 +13,199 @@ const sendEvent = (event: string, msg: any = {}) => {
   process.emit(event as any, msg);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
-export class qase {
-  /**
-   * Assign QaseID to test
-   * @name id
-   * @param {number | number[]} value
-   */
-  public static id(value: number | number[]) {
-    sendEvent(events.addQaseID, { ids: Array.isArray(value) ? value : [value] });
-    return this;
+/**
+ * Set IDs for the test case
+ *
+ * @param qaseId
+ * @param name
+ * @example
+ * describe('suite', () => {
+ *  it(qase(1, 'should work'), () => {
+ *    // test code
+ *  });
+ * });
+ * @returns {string}
+ */
+export const qase = (
+  qaseId: number | string | number[] | string[],
+  name: string,
+): string => {
+  const caseIds = Array.isArray(qaseId) ? qaseId : [qaseId];
+  const ids: number[] = [];
+
+  for (const id of caseIds) {
+    if (typeof id === 'number') {
+      ids.push(id);
+      continue;
+    }
+
+    const parsedId = parseInt(id);
+
+    if (!isNaN(parsedId)) {
+      ids.push(parsedId);
+      continue;
+    }
+
+    console.log(`qase: qase ID ${id} should be a number`);
   }
 
-  /**
-   * Assign title to test
-   * @name title
-   * @param {string} value
-   */
-  public static title(value: string) {
-    sendEvent(events.addTitle, { title: value });
-    return this;
-  }
+  const newName = `${name} (Qase ID: ${caseIds.join(',')})`;
 
-  /**
-   * Assign parameters to test
-   * @name parameters
-   * @param {Record<string, string>} values
-   */
-  public static parameters(values: Record<string, string>) {
-    sendEvent(events.addParameters, { records: values });
+  return newName;
+};
 
-    return this;
-  }
+/**
+ * Set IDs for the test case.
+ * Deprecated: Use qase(qaseId, name) instead.
+ *
+ * @param value
+ * @returns {string}
+ * @example
+ * describe('suite', () => {
+ *  it('should work', () => {
+ *    qase.id(1);
+ *    // test code
+ *  });
+ * });
+ */
+qase.id = (value: number | number[]) => {
+  sendEvent(events.addQaseID, { ids: Array.isArray(value) ? value : [value] });
+  return this;
+};
 
-  /**
-   * Assign group parameters to test
-   * @name groupParameters
-   * @param {Record<string, string>} values
-   */
-  public static groupParameters(values: Record<string, string>) {
-    sendEvent(events.addGroupParameters, { records: values });
+/**
+ * Set a title for the test case
+ * @param {string} value
+ * @example
+ * describe('suite', () => {
+ *  it('should work', () => {
+ *    qase.title("Title");
+ *    // test code
+ *  });
+ * });
+ */
+qase.title = (value: string) => {
+  sendEvent(events.addTitle, { title: value });
+  return this;
+};
 
-    return this;
-  }
+/**
+ * Set parameters for the test case
+ * @param {Record<string, string>} values
+ * @example
+ * describe('suite', () => {
+ *  it('should work', () => {
+ *    qase.parameters({ param1: 'value1', param2: 'value2' });
+ *    // test code
+ *  });
+ * });
+ */
+qase.parameters = (values: Record<string, string>) => {
+  sendEvent(events.addParameters, { records: values });
+  return this;
+};
 
-  /**
-   * Assign fields to test
-   * @name fields
-   * @param {Record<string, string>} values
-   */
-  public static fields(values: Record<string, string>) {
-    sendEvent(events.addFields, { records: values });
+/**
+ * Set group parameters for the test case
+ * @param {Record<string, string>} values
+ * @example
+ * describe('suite', () => {
+ *  it('should work', () => {
+ *    qase.groupParameters({ param1: 'value1', param2: 'value2' });
+ *    // test code
+ *  });
+ * });
+ */
+qase.groupParameters = (values: Record<string, string>) => {
+  sendEvent(events.addGroupParameters, { records: values });
+  return this;
+};
 
-    return this;
-  }
+/**
+ * Set fields for the test case
+ * @param {Record<string, string>} values
+ * @example
+ * describe('suite', () => {
+ *  it('should work', () => {
+ *    qase.fields({ field1: 'value1', field2: 'value2' });
+ *    // test code
+ *  });
+ * });
+ */
+qase.fields = (values: Record<string, string>) => {
+  sendEvent(events.addFields, { records: values });
+  return this;
+};
 
-  /**
-   * Assign suite to test
-   * @name suite
-   * @param {string} value
-   */
-  public static suite(value: string) {
-    sendEvent(events.addSuite, { suite: value });
+/**
+ * Set suite for the test case
+ * @param {string} value
+ * @example
+ * describe('suite', () => {
+ *  it('should work', () => {
+ *    qase.suite('Suite');
+ *    // test code
+ *  });
+ * });
+ */
+qase.suite = (value: string) => {
+  sendEvent(events.addSuite, { suite: value });
+  return this;
+};
 
-    return this;
-  }
+/**
+ * Set ignore for the test case
+ * @example
+ * describe('suite', () => {
+ *  it('should work', () => {
+ *    qase.ignore();
+ *    // test code
+ *  });
+ * });
+ */
+qase.ignore = () => {
+  sendEvent(events.addIgnore, {});
+  return this;
+};
 
-  /**
-   * Assign ignore mark to test
-   * @name ignore
-   */
-  public static ignore() {
-    sendEvent(events.addIgnore, {});
+/**
+ * Set attachment for the test case
+ * @param {object} attach
+ * @example
+ * describe('suite', () => {
+ *  it('should work', () => {
+ *    qase.attach({ name: 'attachment', type: 'text/plain', content: 'attachment content' });   
+ *    // test code
+ *  });
+ * });
+ */
+qase.attach = (attach: {
+  name?: string;
+  type?: string;
+  content?: string;
+  paths?: string[];
+}) => {
+  sendEvent(events.addAttachment, attach);
+  return this;
+};
 
-    return this;
-  }
-
-
-  /**
-   * Assign attachment to test
-   * @name attach
-   * @param attach
-   */
-  public static attach(attach: {
-    name?: string;
-    type?: string;
-    content?: string;
-    paths?: string[];
-  }) {
-    sendEvent(events.addAttachment, attach);
-
-    return this;
-  }
-
-
-  /**
-   * Starts step
-   * @param {string} name - the step name
-   * @param {StepFunction} body - the step content function
-   */
-  public static async step(name: string, body: StepFunction) {
-    const runningStep = new QaseStep(name);
-    // eslint-disable-next-line @typescript-eslint/require-await
-    await runningStep.run(body, async (message) => sendEvent(events.addStep, message));
-  }
-}
+/**
+ * Set step for the test case
+ * @param {string} name
+ * @param {StepFunction} body
+ * @example
+ * describe('suite', () => {
+ *  it('should work', () => {
+ *    qase.step('step', async () => {
+ *      // step code
+ *    });
+ *    // test code
+ *  });
+ * });
+ */
+qase.step = async (name: string, body: StepFunction) => {
+  const runningStep = new QaseStep(name);
+  // eslint-disable-next-line @typescript-eslint/require-await
+  await runningStep.run(body, async (message) => sendEvent(events.addStep, message));
+  return this;
+};


### PR DESCRIPTION
- Updated package version to 1.1.2
- Fixed issue with test result upload for skipped tests
- Introduced new `qase` function for setting test case IDs
- Marked `qase.id` function as deprecated
- Updated README examples to reflect new usage