### PR TITLE
test: add unit tests

### DIFF
--- a/qase-cypress/test/configSchema.test.ts
+++ b/qase-cypress/test/configSchema.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable */
+import { expect } from '@jest/globals';
+import { configSchema } from '../src/configSchema';
+
+describe('configSchema', () => {
+  it('should have correct schema structure', () => {
+    expect(configSchema).toBeDefined();
+    expect(typeof configSchema).toBe('object');
+  });
+
+  it('should have required properties', () => {
+    expect(configSchema).toHaveProperty('type');
+    expect(configSchema).toHaveProperty('properties');
+    expect(configSchema).toHaveProperty('nullable');
+  });
+
+  it('should have correct type', () => {
+    expect(configSchema.type).toBe('object');
+  });
+
+  it('should be nullable', () => {
+    expect(configSchema['nullable']).toBe(true);
+  });
+
+  it('should have framework property', () => {
+    expect(configSchema.properties).toHaveProperty('framework');
+    expect(configSchema.properties.framework).toHaveProperty('type');
+    expect(configSchema.properties.framework.type).toBe('object');
+  });
+
+  it('should have cypress property in framework', () => {
+    const framework = configSchema.properties.framework;
+    expect(framework.properties).toHaveProperty('cypress');
+    expect(framework.properties.cypress).toHaveProperty('type');
+    expect(framework.properties.cypress.type).toBe('object');
+  });
+
+  it('should have screenshotsFolder property in cypress', () => {
+    const cypress = configSchema.properties.framework.properties.cypress;
+    expect(cypress.properties).toHaveProperty('screenshotsFolder');
+    expect(cypress.properties.screenshotsFolder).toHaveProperty('type');
+    expect(cypress.properties.screenshotsFolder.type).toBe('string');
+  });
+
+  it('should have nullable properties', () => {
+    expect(configSchema.properties.framework['nullable']).toBe(true);
+    expect(configSchema.properties.framework.properties.cypress['nullable']).toBe(true);
+    expect(configSchema.properties.framework.properties.cypress.properties.screenshotsFolder['nullable']).toBe(true);
+  });
+}); 

--- a/qase-cypress/test/fileSearcher.test.ts
+++ b/qase-cypress/test/fileSearcher.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable */
+import { expect } from '@jest/globals';
+import { FileSearcher } from '../src/fileSearcher';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Mock fs and path modules
+jest.mock('fs');
+jest.mock('path');
+
+const mockFs = fs as jest.Mocked<typeof fs>;
+const mockPath = path as jest.Mocked<typeof path>;
+
+describe('FileSearcher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Mock process.cwd
+    Object.defineProperty(process, 'cwd', {
+      value: jest.fn(() => '/mock/cwd'),
+      writable: true,
+    });
+    
+    // Mock path.resolve to return absolute path
+    mockPath.resolve.mockImplementation((cwd, folder) => `${cwd}/${folder}`);
+    
+    // Mock path.join to return joined path
+    mockPath.join.mockImplementation((...args) => args.join('/'));
+  });
+
+  describe('findFilesBeforeTime', () => {
+    it('should return empty array when no matching folders found', () => {
+      mockFs.existsSync.mockReturnValue(false);
+      mockFs.readdirSync.mockReturnValue([]);
+
+      const result = FileSearcher.findFilesBeforeTime('/screenshots', 'test.cy.js', new Date());
+
+      expect(result).toEqual([]);
+      expect(mockFs.existsSync).toHaveBeenCalledWith('/mock/cwd//screenshots');
+    });
+
+    it('should find files in matching folder', () => {
+      const mockTime = new Date('2023-01-01T10:00:00Z');
+      const fileTime = new Date('2023-01-01T11:00:00Z'); // After mockTime
+      
+      // Mock folder structure
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync
+        .mockReturnValueOnce([
+          { name: 'test.cy.js', isDirectory: () => true, isFile: () => false },
+        ] as any)
+        .mockReturnValueOnce([
+          { name: 'screenshot1.png', isDirectory: () => false, isFile: () => true },
+          { name: 'screenshot2.png', isDirectory: () => false, isFile: () => true },
+        ] as any);
+
+      mockFs.statSync.mockReturnValue({
+        birthtime: fileTime,
+      } as any);
+
+      const result = FileSearcher.findFilesBeforeTime('/screenshots', 'test.cy.js', mockTime);
+
+      expect(result).toEqual([
+        '/mock/cwd//screenshots/test.cy.js/screenshot1.png',
+        '/mock/cwd//screenshots/test.cy.js/screenshot2.png',
+      ]);
+    });
+
+    it('should skip files created before the specified time', () => {
+      const mockTime = new Date('2023-01-01T11:00:00Z');
+      const fileTime = new Date('2023-01-01T10:00:00Z'); // Before mockTime
+      
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readdirSync
+        .mockReturnValueOnce([
+          { name: 'test.cy.js', isDirectory: () => true, isFile: () => false },
+        ] as any)
+        .mockReturnValueOnce([
+          { name: 'screenshot.png', isDirectory: () => false, isFile: () => true },
+        ] as any);
+
+      mockFs.statSync.mockReturnValue({
+        birthtime: fileTime,
+      } as any);
+
+      const result = FileSearcher.findFilesBeforeTime('/screenshots', 'test.cy.js', mockTime);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle non-existent directories gracefully', () => {
+      mockFs.existsSync.mockReturnValue(false);
+
+      const result = FileSearcher.findFilesBeforeTime('/non-existent', 'test.cy.js', new Date());
+
+      expect(result).toEqual([]);
+    });
+  });
+}); 

--- a/qase-cypress/test/reporter.test.ts
+++ b/qase-cypress/test/reporter.test.ts
@@ -1,0 +1,342 @@
+/* eslint-disable */
+import { expect } from '@jest/globals';
+import { CypressQaseReporter } from '../src/reporter';
+import { Test, Suite } from 'mocha';
+import { TestStatusEnum } from 'qase-javascript-commons';
+
+// Mock dependencies
+const qaseReporterMock = {
+  addTestResult: jest.fn(),
+  getResults: jest.fn(() => [{ id: 'test-result' }]),
+  publish: jest.fn(),
+};
+
+jest.mock('qase-javascript-commons', () => ({
+  QaseReporter: {
+    getInstance: jest.fn(() => qaseReporterMock),
+  },
+  composeOptions: jest.fn(() => ({ 
+    framework: { cypress: { screenshotsFolder: '/screenshots' } },
+    frameworkPackage: 'cypress',
+    frameworkName: 'cypress',
+    reporterName: 'cypress-qase-reporter',
+  })),
+  TestStatusEnum: {
+    passed: 'passed',
+    failed: 'failed',
+    skipped: 'skipped',
+  },
+  generateSignature: jest.fn(() => 'mock-signature'),
+  ConfigLoader: jest.fn().mockImplementation(() => ({
+    load: jest.fn(() => ({})),
+  })),
+}));
+
+jest.mock('../src/metadata/manager', () => {
+  const metadataManagerMock = {
+    getMetadata: jest.fn(() => ({ ignore: false, attachments: [] })),
+    clear: jest.fn(),
+  };
+  return {
+    MetadataManager: metadataManagerMock,
+  };
+});
+
+jest.mock('../src/fileSearcher', () => ({
+  FileSearcher: {
+    findFilesBeforeTime: jest.fn(() => ['/screenshots/test.png']),
+  },
+}));
+
+jest.mock('child_process', () => ({
+  spawnSync: jest.fn(),
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-uuid'),
+}));
+
+describe('CypressQaseReporter', () => {
+  let runner: any;
+  let eventHandlers: Record<string, Function>;
+  let test: Test;
+  let suite: Suite;
+  let metadataManagerMock: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Get the mocked MetadataManager
+    const { MetadataManager } = require('../src/metadata/manager');
+    metadataManagerMock = MetadataManager;
+    
+    eventHandlers = {};
+    runner = {
+      on: jest.fn((event, handler) => {
+        eventHandlers[event] = handler;
+      }),
+      once: jest.fn((event, handler) => {
+        eventHandlers[event] = handler;
+      }),
+    };
+
+    suite = {
+      title: 'Test Suite',
+      titlePath: jest.fn(() => ['Root Suite', 'Test Suite']),
+    } as unknown as Suite;
+
+    test = {
+      title: 'Test Case (Qase ID: 123)',
+      parent: suite,
+      file: '/path/to/test.cy.js',
+      state: 'passed',
+      duration: 1000,
+      slow: jest.fn(),
+      fullTitle: jest.fn(() => 'Test Case (Qase ID: 123)'),
+    } as unknown as Test;
+  });
+
+  describe('static methods', () => {
+    it('should extract case IDs from title', () => {
+      const result = (CypressQaseReporter as any).getCaseId('Test (Qase ID: 123,456)');
+      expect(result).toEqual([123, 456]);
+    });
+
+    it('should return empty array for title without Qase ID', () => {
+      const result = (CypressQaseReporter as any).getCaseId('Test without Qase ID');
+      expect(result).toEqual([]);
+    });
+
+    it('should map cypress states to test statuses', () => {
+      expect(CypressQaseReporter.statusMap.failed).toBe(TestStatusEnum.failed);
+      expect(CypressQaseReporter.statusMap.passed).toBe(TestStatusEnum.passed);
+      expect(CypressQaseReporter.statusMap.pending).toBe(TestStatusEnum.skipped);
+    });
+  });
+
+  describe('constructor', () => {
+    it('should initialize reporter with correct options', () => {
+      const options = {
+        reporterOptions: {
+          screenshotsFolder: '/screenshots',
+        },
+      };
+
+      new CypressQaseReporter(runner, options);
+
+      const { QaseReporter } = require('qase-javascript-commons');
+      expect(QaseReporter.getInstance).toHaveBeenCalledWith({
+        frameworkPackage: 'cypress',
+        frameworkName: 'cypress',
+        reporterName: 'cypress-qase-reporter',
+      });
+    });
+
+    it('should add event listeners to runner', () => {
+      const options = {
+        reporterOptions: {
+          screenshotsFolder: '/screenshots',
+        },
+      };
+
+      new CypressQaseReporter(runner, options);
+
+      expect(runner.on).toHaveBeenCalledWith('pass', expect.any(Function));
+      expect(runner.on).toHaveBeenCalledWith('pending', expect.any(Function));
+      expect(runner.on).toHaveBeenCalledWith('fail', expect.any(Function));
+      expect(runner.on).toHaveBeenCalledWith('test', expect.any(Function));
+      expect(runner.once).toHaveBeenCalledWith('end', expect.any(Function));
+    });
+  });
+
+  describe('addTestResult', () => {
+    it('should add test result for passed test', () => {
+      const options = {
+        reporterOptions: {
+          screenshotsFolder: '/screenshots',
+        },
+      };
+
+      new CypressQaseReporter(runner, options);
+
+      const passedTest = { ...test, state: 'passed' };
+      
+      if (eventHandlers['pass']) eventHandlers['pass'](passedTest);
+
+      expect(qaseReporterMock.addTestResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          execution: expect.objectContaining({
+            status: TestStatusEnum.passed,
+          }),
+        })
+      );
+    });
+
+    it('should add test result for failed test', () => {
+      const options = {
+        reporterOptions: {
+          screenshotsFolder: '/screenshots',
+        },
+      };
+
+      new CypressQaseReporter(runner, options);
+
+      const failedTest = { ...test, state: 'failed' };
+      
+      if (eventHandlers['fail']) eventHandlers['fail'](failedTest);
+
+      expect(qaseReporterMock.addTestResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          execution: expect.objectContaining({
+            status: TestStatusEnum.failed,
+          }),
+        })
+      );
+    });
+
+    it('should add test result for pending test', () => {
+      const options = {
+        reporterOptions: {
+          screenshotsFolder: '/screenshots',
+        },
+      };
+
+      new CypressQaseReporter(runner, options);
+
+      const pendingTest = { ...test, state: 'pending' };
+      
+      if (eventHandlers['pending']) eventHandlers['pending'](pendingTest);
+
+      expect(qaseReporterMock.addTestResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          execution: expect.objectContaining({
+            status: TestStatusEnum.skipped,
+          }),
+        })
+      );
+    });
+
+    it('should not add test result if test is ignored', () => {
+      const options = {
+        reporterOptions: {
+          screenshotsFolder: '/screenshots',
+        },
+      };
+
+      new CypressQaseReporter(runner, options);
+
+      metadataManagerMock.getMetadata.mockReturnValue({ ignore: true, attachments: [] });
+      
+      if (eventHandlers['pass']) eventHandlers['pass'](test);
+
+      expect(qaseReporterMock.addTestResult).not.toHaveBeenCalled();
+      expect(metadataManagerMock.clear).toHaveBeenCalled();
+    });
+
+    it('should include attachments from metadata', () => {
+      const options = {
+        reporterOptions: {
+          screenshotsFolder: '/screenshots',
+        },
+      };
+
+      new CypressQaseReporter(runner, options);
+
+      const mockAttachment = {
+        content: 'test',
+        id: 'attachment-id',
+        mime_type: 'text/plain',
+        size: 10,
+        file_name: 'test.txt',
+        file_path: null,
+      };
+      
+      metadataManagerMock.getMetadata.mockReturnValue({
+        ignore: false,
+        attachments: [mockAttachment as any],
+      });
+      
+      if (eventHandlers['pass']) eventHandlers['pass'](test);
+
+      expect(qaseReporterMock.addTestResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: expect.arrayContaining([
+            expect.objectContaining({
+              file_name: 'test.png',
+              mime_type: 'image/png',
+            }),
+            mockAttachment,
+          ]),
+        })
+      );
+    });
+
+    it('should include suite relations', () => {
+      const options = {
+        reporterOptions: {
+          screenshotsFolder: '/screenshots',
+        },
+      };
+
+      new CypressQaseReporter(runner, options);
+
+      if (eventHandlers['pass']) eventHandlers['pass'](test);
+
+      expect(qaseReporterMock.addTestResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          relations: {
+            suite: {
+              data: [
+                { title: 'Root Suite', public_id: null },
+                { title: 'Test Suite', public_id: null },
+              ],
+            },
+          },
+        })
+      );
+    });
+  });
+
+  describe('test begin handler', () => {
+    it('should clear metadata and update test begin time', () => {
+      const options = {
+        reporterOptions: {
+          screenshotsFolder: '/screenshots',
+        },
+      };
+
+      new CypressQaseReporter(runner, options);
+
+      if (eventHandlers['test']) eventHandlers['test']();
+
+      expect(metadataManagerMock.clear).toHaveBeenCalled();
+    });
+  });
+
+  describe('run end handler', () => {
+    it('should spawn child process with results', () => {
+      const options = {
+        reporterOptions: {
+          screenshotsFolder: '/screenshots',
+        },
+      };
+
+      new CypressQaseReporter(runner, options);
+
+      const { spawnSync } = require('child_process');
+      
+      if (eventHandlers['end']) eventHandlers['end']();
+
+      expect(spawnSync).toHaveBeenCalledWith(
+        'node',
+        [expect.stringContaining('child.js')],
+        expect.objectContaining({
+          stdio: 'inherit',
+          env: expect.objectContaining({
+            results: JSON.stringify([{ id: 'test-result' }]),
+          }),
+        })
+      );
+    });
+  });
+}); 

--- a/qase-cypress/test/tagParser.test.ts
+++ b/qase-cypress/test/tagParser.test.ts
@@ -1,0 +1,191 @@
+/* eslint-disable */
+import { expect } from '@jest/globals';
+import { extractTags } from '../src/utils/tagParser';
+import * as fs from 'fs';
+
+// Mock fs module
+jest.mock('fs');
+
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+describe('tagParser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('extractTags', () => {
+    it('should extract tags for a scenario', () => {
+      const fileContent = `
+@feature-tag
+@another-tag
+Feature: Test Feature
+
+@scenario-tag1 @scenario-tag2
+Scenario: Test Scenario
+  Given some step
+  When another step
+  Then final step
+`;
+
+      mockFs.readFileSync.mockReturnValue(fileContent);
+
+      const result = extractTags('/path/to/feature.feature', 'Test Scenario');
+
+      expect(result).toEqual(['@scenario-tag1', '@scenario-tag2']);
+      expect(mockFs.readFileSync).toHaveBeenCalledWith('/path/to/feature.feature', 'utf-8');
+    });
+
+    it('should return empty array when scenario not found', () => {
+      const fileContent = `
+@feature-tag
+Feature: Test Feature
+
+Scenario: Different Scenario
+  Given some step
+`;
+
+      mockFs.readFileSync.mockReturnValue(fileContent);
+
+      const result = extractTags('/path/to/feature.feature', 'Test Scenario');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when no tags found for scenario', () => {
+      const fileContent = `
+@feature-tag
+Feature: Test Feature
+
+Scenario: Test Scenario
+  Given some step
+`;
+
+      mockFs.readFileSync.mockReturnValue(fileContent);
+
+      const result = extractTags('/path/to/feature.feature', 'Test Scenario');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle multiple tags on separate lines', () => {
+      const fileContent = `
+@feature-tag
+Feature: Test Feature
+
+@tag1
+@tag2
+@tag3
+Scenario: Test Scenario
+  Given some step
+`;
+
+      mockFs.readFileSync.mockReturnValue(fileContent);
+
+      const result = extractTags('/path/to/feature.feature', 'Test Scenario');
+
+      expect(result).toEqual(['@tag3']);
+    });
+
+    it('should stop searching at empty line', () => {
+      const fileContent = `
+@feature-tag
+Feature: Test Feature
+
+@ignored-tag
+
+@scenario-tag
+Scenario: Test Scenario
+  Given some step
+`;
+
+      mockFs.readFileSync.mockReturnValue(fileContent);
+
+      const result = extractTags('/path/to/feature.feature', 'Test Scenario');
+
+      expect(result).toEqual(['@scenario-tag']);
+    });
+
+    it('should stop searching at Feature line', () => {
+      const fileContent = `
+@feature-tag
+Feature: Test Feature
+
+@scenario-tag
+Scenario: Test Scenario
+  Given some step
+
+Feature: Another Feature
+@ignored-tag
+Scenario: Another Scenario
+`;
+
+      mockFs.readFileSync.mockReturnValue(fileContent);
+
+      const result = extractTags('/path/to/feature.feature', 'Test Scenario');
+
+      expect(result).toEqual(['@scenario-tag']);
+    });
+
+    it('should handle scenario with exact name match', () => {
+      const fileContent = `
+Feature: Test Feature
+
+@tag1 @tag2
+Scenario: Exact Match Scenario
+  Given some step
+
+@tag3
+Scenario: Exact Match Scenario
+  Given another step
+`;
+
+      mockFs.readFileSync.mockReturnValue(fileContent);
+
+      const result = extractTags('/path/to/feature.feature', 'Exact Match Scenario');
+
+      expect(result).toEqual(['@tag1', '@tag2']);
+    });
+
+    it('should handle file with only whitespace', () => {
+      const fileContent = '   \n  \n  ';
+
+      mockFs.readFileSync.mockReturnValue(fileContent);
+
+      const result = extractTags('/path/to/feature.feature', 'Test Scenario');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle scenario with special characters in name', () => {
+      const fileContent = `
+Feature: Test Feature
+
+@tag1
+Scenario: Test Scenario (with parentheses)
+  Given some step
+`;
+
+      mockFs.readFileSync.mockReturnValue(fileContent);
+
+      const result = extractTags('/path/to/feature.feature', 'Test Scenario (with parentheses)');
+
+      expect(result).toEqual(['@tag1']);
+    });
+
+    it('should handle tags with special characters', () => {
+      const fileContent = `
+Feature: Test Feature
+
+@tag-with-dashes @tag_with_underscores @tag123
+Scenario: Test Scenario
+  Given some step
+`;
+
+      mockFs.readFileSync.mockReturnValue(fileContent);
+
+      const result = extractTags('/path/to/feature.feature', 'Test Scenario');
+
+      expect(result).toEqual(['@tag-with-dashes', '@tag_with_underscores', '@tag123']);
+    });
+  });
+}); 

--- a/qase-wdio/jest.config.js
+++ b/qase-wdio/jest.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+  ],
+  moduleNameMapper: {
+    '^qase-javascript-commons$': '<rootDir>/../qase-javascript-commons/src/index.ts',
+  },
+  setupFilesAfterEnv: [],
+  testTimeout: 10000,
+}; 

--- a/qase-wdio/test/hooks.test.ts
+++ b/qase-wdio/test/hooks.test.ts
@@ -1,0 +1,56 @@
+/* eslint-disable */
+import { expect } from '@jest/globals';
+import { beforeRunHook, afterRunHook } from '../src/hooks';
+
+// Mock dependencies
+const mockReporter = {
+  startTestRunAsync: jest.fn().mockResolvedValue(undefined),
+  complete: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock('qase-javascript-commons', () => ({
+  QaseReporter: {
+    getInstance: jest.fn(() => mockReporter),
+  },
+  ConfigLoader: jest.fn().mockImplementation(() => ({
+    load: jest.fn(() => ({})),
+  })),
+}));
+
+describe('hooks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('beforeRunHook', () => {
+    it('should initialize reporter and start test run', async () => {
+      const { QaseReporter, ConfigLoader } = require('qase-javascript-commons');
+
+      await beforeRunHook();
+
+      expect(ConfigLoader).toHaveBeenCalled();
+      expect(QaseReporter.getInstance).toHaveBeenCalledWith({
+        frameworkPackage: '@wdio/cli',
+        frameworkName: 'wdio',
+        reporterName: 'wdio-qase-reporter',
+      });
+      expect(mockReporter.startTestRunAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe('afterRunHook', () => {
+    it('should get reporter instance and complete test run', async () => {
+      const { QaseReporter, ConfigLoader } = require('qase-javascript-commons');
+
+      await afterRunHook();
+
+      expect(ConfigLoader).toHaveBeenCalled();
+      expect(QaseReporter.getInstance).toHaveBeenCalledWith({
+        frameworkPackage: 'wdio',
+        frameworkName: 'wdio',
+        reporterName: 'wdio-qase-reporter',
+      });
+      expect(mockReporter.complete).toHaveBeenCalled();
+    });
+  });
+}); 

--- a/qase-wdio/test/storage.test.ts
+++ b/qase-wdio/test/storage.test.ts
@@ -1,0 +1,220 @@
+/* eslint-disable */
+import { expect } from '@jest/globals';
+import { Storage, findLast } from '../src/storage';
+import { TestResultType, TestStepType } from 'qase-javascript-commons';
+
+// Mock TestResultType and TestStepType
+const MockTestResult = class extends TestResultType {
+  constructor() {
+    super('Mock Test');
+  }
+};
+
+const MockTestStep = class extends TestStepType {
+  constructor() {
+    super();
+  }
+};
+
+describe('Storage', () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = new Storage();
+  });
+
+  describe('clear', () => {
+    it('should clear currentFile and items', () => {
+      storage.currentFile = '/path/to/test.js';
+      storage.items = [new MockTestResult()];
+      storage.ignore = true;
+      storage.suites = ['Suite 1', 'Suite 2'];
+
+      storage.clear();
+
+      expect(storage.currentFile).toBeUndefined();
+      expect(storage.items).toEqual([]);
+      expect(storage.ignore).toBe(false);
+      expect(storage.suites).toEqual(['Suite 1']);
+    });
+
+    it('should clear all suites when empty', () => {
+      storage.suites = [];
+
+      storage.clear();
+
+      expect(storage.suites).toEqual([]);
+    });
+  });
+
+  describe('push', () => {
+    it('should add item to items array', () => {
+      const testResult = new MockTestResult();
+      const testStep = new MockTestStep();
+
+      storage.push(testResult);
+      storage.push(testStep);
+
+      expect(storage.items).toHaveLength(2);
+      expect(storage.items[0]).toBe(testResult);
+      expect(storage.items[1]).toBe(testStep);
+    });
+  });
+
+  describe('pop', () => {
+    it('should remove and return last item', () => {
+      const testResult = new MockTestResult();
+      const testStep = new MockTestStep();
+
+      storage.push(testResult);
+      storage.push(testStep);
+
+      const popped = storage.pop();
+
+      expect(popped).toBe(testStep);
+      expect(storage.items).toHaveLength(1);
+      expect(storage.items[0]).toBe(testResult);
+    });
+
+    it('should return undefined when items array is empty', () => {
+      const popped = storage.pop();
+
+      expect(popped).toBeUndefined();
+      expect(storage.items).toHaveLength(0);
+    });
+  });
+
+  describe('getCurrentTest', () => {
+    it('should return last TestResultType from items', () => {
+      const testResult1 = new MockTestResult();
+      const testStep = new MockTestStep();
+      const testResult2 = new MockTestResult();
+
+      storage.push(testResult1);
+      storage.push(testStep);
+      storage.push(testResult2);
+
+      const currentTest = storage.getCurrentTest();
+
+      expect(currentTest).toBe(testResult2);
+    });
+
+    it('should return undefined when no TestResultType found', () => {
+      const testStep = new MockTestStep();
+      storage.push(testStep);
+
+      const currentTest = storage.getCurrentTest();
+
+      expect(currentTest).toBeUndefined();
+    });
+
+    it('should return undefined when items array is empty', () => {
+      const currentTest = storage.getCurrentTest();
+
+      expect(currentTest).toBeUndefined();
+    });
+  });
+
+  describe('getCurrentStep', () => {
+    it('should return last TestStepType from items', () => {
+      const testResult = new MockTestResult();
+      const testStep1 = new MockTestStep();
+      const testStep2 = new MockTestStep();
+
+      storage.push(testResult);
+      storage.push(testStep1);
+      storage.push(testStep2);
+
+      const currentStep = storage.getCurrentStep();
+
+      expect(currentStep).toBe(testStep2);
+    });
+
+    it('should return undefined when no TestStepType found', () => {
+      const testResult = new MockTestResult();
+      storage.push(testResult);
+
+      const currentStep = storage.getCurrentStep();
+
+      expect(currentStep).toBeUndefined();
+    });
+
+    it('should return undefined when items array is empty', () => {
+      const currentStep = storage.getCurrentStep();
+
+      expect(currentStep).toBeUndefined();
+    });
+  });
+
+  describe('getLastItem', () => {
+    it('should return last item from items array', () => {
+      const testResult = new MockTestResult();
+      const testStep = new MockTestStep();
+
+      storage.push(testResult);
+      storage.push(testStep);
+
+      const lastItem = storage.getLastItem();
+
+      expect(lastItem).toBe(testStep);
+    });
+
+    it('should return undefined when items array is empty', () => {
+      const lastItem = storage.getLastItem();
+
+      expect(lastItem).toBeUndefined();
+    });
+  });
+});
+
+describe('findLast', () => {
+  it('should find last element matching predicate', () => {
+    const arr = [1, 2, 3, 4, 5];
+    const predicate = (num: number) => num % 2 === 0; // even numbers
+
+    const result = findLast(arr, predicate);
+
+    expect(result).toBe(4);
+  });
+
+  it('should return undefined when no element matches predicate', () => {
+    const arr = [1, 3, 5, 7];
+    const predicate = (num: number) => num % 2 === 0; // even numbers
+
+    const result = findLast(arr, predicate);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined for empty array', () => {
+    const arr: number[] = [];
+    const predicate = (num: number) => num > 0;
+
+    const result = findLast(arr, predicate);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should find last element in array with one element', () => {
+    const arr = [1];
+    const predicate = (num: number) => num > 0;
+
+    const result = findLast(arr, predicate);
+
+    expect(result).toBe(1);
+  });
+
+  it('should work with complex objects', () => {
+    const arr = [
+      { id: 1, type: 'test' },
+      { id: 2, type: 'step' },
+      { id: 3, type: 'test' },
+      { id: 4, type: 'step' },
+    ];
+    const predicate = (item: any) => item.type === 'test';
+
+    const result = findLast(arr, predicate);
+
+    expect(result).toEqual({ id: 3, type: 'test' });
+  });
+}); 

--- a/qase-wdio/test/utils.test.ts
+++ b/qase-wdio/test/utils.test.ts
@@ -1,0 +1,136 @@
+/* eslint-disable */
+import { expect } from '@jest/globals';
+import { isEmpty, isScreenshotCommand } from '../src/utils';
+
+describe('utils', () => {
+  describe('isEmpty', () => {
+    it('should return true for null', () => {
+      expect(isEmpty(null)).toBe(true);
+    });
+
+    it('should return true for undefined', () => {
+      expect(isEmpty(undefined)).toBe(true);
+    });
+
+    it('should return true for empty object', () => {
+      expect(isEmpty({})).toBe(true);
+    });
+
+    it('should return false for object with properties', () => {
+      expect(isEmpty({ key: 'value' })).toBe(false);
+    });
+
+    it('should return true for empty array', () => {
+      expect(isEmpty([])).toBe(true);
+    });
+
+    it('should return false for array with elements', () => {
+      expect(isEmpty([1, 2, 3])).toBe(false);
+    });
+
+    it('should return true for empty string', () => {
+      expect(isEmpty('')).toBe(true);
+    });
+
+    it('should return false for non-empty string', () => {
+      expect(isEmpty('hello')).toBe(false);
+    });
+
+    it('should return true for numbers (not objects)', () => {
+      expect(isEmpty(0)).toBe(true);
+      expect(isEmpty(42)).toBe(true);
+    });
+
+    it('should return true for booleans (not objects)', () => {
+      expect(isEmpty(false)).toBe(true);
+      expect(isEmpty(true)).toBe(true);
+    });
+  });
+
+  describe('isScreenshotCommand', () => {
+    it('should return true for WebDriver screenshot endpoint', () => {
+      const command = {
+        sessionId: 'abc123',
+        endpoint: '/session/abc123/screenshot',
+        method: 'GET',
+        body: {},
+      };
+
+      expect(isScreenshotCommand(command)).toBe(true);
+    });
+
+    it('should return true for WebDriver element screenshot endpoint', () => {
+      const command = {
+        sessionId: 'abc123',
+        endpoint: '/session/abc123/element/def456/screenshot',
+        method: 'GET',
+        body: {},
+      };
+
+      expect(isScreenshotCommand(command)).toBe(true);
+    });
+
+    it('should return true for DevTools takeScreenshot command', () => {
+      const command = {
+        sessionId: 'abc123',
+        command: 'takeScreenshot',
+        params: {},
+      };
+
+      expect(isScreenshotCommand(command)).toBe(true);
+    });
+
+    it('should return false for non-screenshot WebDriver endpoint', () => {
+      const command = {
+        sessionId: 'abc123',
+        endpoint: '/session/abc123/element',
+        method: 'POST',
+        body: { using: 'id', value: 'test' },
+      };
+
+      expect(isScreenshotCommand(command)).toBe(false);
+    });
+
+    it('should return false for other DevTools command', () => {
+      const command = {
+        sessionId: 'abc123',
+        command: 'getPageSource',
+        params: {},
+      };
+
+      expect(isScreenshotCommand(command)).toBe(false);
+    });
+
+    it('should return false for command without endpoint and command', () => {
+      const command = {
+        sessionId: 'abc123',
+        method: 'GET',
+        body: {},
+      };
+
+      expect(isScreenshotCommand(command)).toBe(false);
+    });
+
+    it('should handle complex session IDs in endpoint', () => {
+      const command = {
+        sessionId: 'abc-123-def_456',
+        endpoint: '/session/abc-123-def_456/screenshot',
+        method: 'GET',
+        body: {},
+      };
+
+      expect(isScreenshotCommand(command)).toBe(true);
+    });
+
+    it('should handle complex element IDs in endpoint', () => {
+      const command = {
+        sessionId: 'abc123',
+        endpoint: '/session/abc123/element/def-456-ghi_789/screenshot',
+        method: 'GET',
+        body: {},
+      };
+
+      expect(isScreenshotCommand(command)).toBe(true);
+    });
+  });
+}); 


### PR DESCRIPTION
This pull request introduces comprehensive test coverage across multiple components and modules in the `qase-cypress` and `qase-wdio` packages. The changes include the addition of unit tests for schema validation, file searching, reporting, tag parsing, and hook execution, as well as the setup of a Jest configuration for the `qase-wdio` package.

### New Unit Tests for `qase-cypress`:

* **Schema Validation:**
  - Added tests in `qase-cypress/test/configSchema.test.ts` to validate the structure and properties of the `configSchema`, ensuring it is correctly defined, nullable, and includes expected nested properties such as `framework` and `cypress`.

* **File Searching:**
  - Implemented tests in `qase-cypress/test/fileSearcher.test.ts` for the `FileSearcher` utility, covering scenarios such as finding files before a specific time, handling non-existent directories, and skipping files based on creation time.

* **Reporting:**
  - Added tests in `qase-cypress/test/reporter.test.ts` for the `CypressQaseReporter`, verifying static methods, event handling, test result addition (including attachments and suite relations), and metadata management.

* **Tag Parsing:**
  - Introduced tests in `qase-cypress/test/tagParser.test.ts` for the `extractTags` utility, ensuring correct tag extraction for scenarios, handling of special characters, and edge cases like empty files or multiple features.

### Updates for `qase-wdio`:

* **Jest Configuration:**
  - Created `jest.config.js` in `qase-wdio` to configure Jest for TypeScript testing, including coverage collection and module mapping for `qase-javascript-commons`.

* **Hook Execution:**
  - Added tests in `qase-wdio/test/hooks.test.ts` for `beforeRunHook` and `afterRunHook`, ensuring proper initialization and completion of test runs using the `QaseReporter`.