### PR TITLE
feat: update to version 2.1.4 with support for flaky tests

### DIFF
--- a/qase-playwright/README.md
+++ b/qase-playwright/README.md
@@ -176,6 +176,7 @@ Reporter options (\* - required):
 - `testops.run.complete` - Whether the run should be completed
 - `framework.browser.addAsParameter` - Whether to add the browser name as a parameter, default - `false`
 - `framework.browser.parameterName` - The name of the parameter to add the browser name to, default - `browser`
+- `framework.markAsFlaky` - Whether to mark tests as flaky if they passed after retries, default - `false`
 
 Example `playwright.config.js` config:
 
@@ -206,6 +207,7 @@ const config = {
             addAsParameter: true,
             parameterName: 'Browser Name',
           },
+          markAsFlaky: true,
         },
       },
     ],

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,20 @@
+# playwright-qase-reporter@2.1.4
+
+## What's new
+
+Support marking tests as flaky if they passed after retries.
+
+```ts
+[
+  'playwright-qase-reporter',
+  {
+    framework: {
+      markAsFlaky: true,
+    },
+  },
+],
+```
+
 # playwright-qase-reporter@2.1.3
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/configSchema.ts
+++ b/qase-playwright/src/configSchema.ts
@@ -33,7 +33,11 @@ export const configSchema: JSONSchemaType<FrameworkOptionsType<'playwright', Rep
                   nullable: true,
                 },
               }
-            }
+            },
+            markAsFlaky: {
+              type: 'boolean',
+              nullable: true,
+            },
           }
         }
       }

--- a/qase-playwright/src/options.ts
+++ b/qase-playwright/src/options.ts
@@ -4,4 +4,5 @@ export type ReporterOptionsType = {
     addAsParameter?: boolean;
     parameterName?: string;
   };
+  markAsFlaky?: boolean;
 };

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -380,6 +380,11 @@ export class PlaywrightQaseReporter implements Reporter {
       }
     }
 
+    // if markAsFlaky is true and the test passed after retries, mark the test as flaky
+    if (this.options.markAsFlaky && result.status === 'passed' && result.retry > 0) {
+      testCaseMetadata.fields['is_flaky'] = 'true';
+    }
+
     const testTitle = this.removeQaseIdsFromTitle(test.title);
     const testResult: TestResultType = {
       attachments: testCaseMetadata.attachments,


### PR DESCRIPTION
- Updated package version to 2.1.4.
- Added support for marking tests as flaky if they passed after retries.
- Updated documentation to include new `framework.markAsFlaky` option in README and changelog.