### PR TITLE
feat: add configuration support

### DIFF
--- a/qase-javascript-commons/README.md
+++ b/qase-javascript-commons/README.md
@@ -58,6 +58,8 @@ All configuration options are listed in the table below:
 | Size of batch for sending test results                                                                                | `testops.batch.size`       | `QASE_TESTOPS_BATCH_SIZE`       | `200`                                   | No       | Any integer                |
 | Enable defects for failed test cases                                                                                  | `testops.defect`           | `QASE_TESTOPS_DEFECT`           | `False`                                 | No       | `True`, `False`            |
 | Enable/disable attachment uploads                                                                                     | `testops.uploadAttachments`        | `QASE_TESTOPS_UPLOAD_ATTACHMENTS`       | `true`                                  | No       | `True`, `False`            |
+| Configuration values to create/find in groups (format: `group1=value1,group2=value2`)                                | `testops.configurations.values`     | `QASE_TESTOPS_CONFIGURATIONS_VALUES`     | undefined                               | No       | Comma-separated key=value pairs |
+| Create configuration groups if they don't exist                                                                       | `testops.configurations.createIfNotExists` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `false`                          | No       | `True`, `False`            |
 
 ### Example `qase.config.json` config:
 
@@ -92,6 +94,19 @@ All configuration options are listed in the table below:
     "project": "<project_code>",
     "batch": {
       "size": 100
+    },
+    "configurations": {
+      "values": [
+        {
+          "name": "group1",
+          "value": "value1"
+        },
+        {
+          "name": "group2", 
+          "value": "value2"
+        }
+      ],
+      "createIfNotExists": true
     }
   }
 }

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.3.6
+
+## What's new
+
+Added support for configurations in the test run.
+
 # qase-javascript-commons@2.3.5
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/config/config-validation-schema.ts
+++ b/qase-javascript-commons/src/config/config-validation-schema.ts
@@ -1,13 +1,10 @@
-import { JSONSchemaType } from 'ajv';
-
 import { ModeEnum } from '../options';
 import { DriverEnum, FormatEnum } from '../writer';
-import { ConfigType } from './config-type';
 
 /**
  * @type {JSONSchemaType<ConfigType>}
  */
-export const configValidationSchema: JSONSchemaType<ConfigType> = {
+export const configValidationSchema = {
   type: 'object',
 
   properties: {
@@ -128,6 +125,36 @@ export const configValidationSchema: JSONSchemaType<ConfigType> = {
         defect: {
           type: 'boolean',
           nullable: true,
+        },
+
+        configurations: {
+          type: 'object',
+          nullable: true,
+
+          properties: {
+            values: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                    nullable: true,
+                  },
+                  value: {
+                    type: 'string',
+                    nullable: true,
+                  },
+                },
+                required: ['name', 'value'],
+              },
+            },
+            createIfNotExists: {
+              type: 'boolean',
+              nullable: true,
+            },
+          },
+          required: ['values'],
         },
       },
     },

--- a/qase-javascript-commons/src/env/env-enum.ts
+++ b/qase-javascript-commons/src/env/env-enum.ts
@@ -55,6 +55,14 @@ export enum EnvBatchEnum {
 /**
  * @enum {string}
  */
+export enum EnvConfigurationsEnum {
+  values = 'QASE_TESTOPS_CONFIGURATIONS_VALUES',
+  createIfNotExists = 'QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS',
+}
+
+/**
+ * @enum {string}
+ */
 export enum EnvLocalEnum {
   path = 'QASE_REPORT_CONNECTION_PATH',
   format = 'QASE_REPORT_CONNECTION_FORMAT',

--- a/qase-javascript-commons/src/env/env-to-config.ts
+++ b/qase-javascript-commons/src/env/env-to-config.ts
@@ -5,7 +5,9 @@ import {
   EnvApiEnum,
   EnvRunEnum,
   EnvLocalEnum,
-  EnvPlanEnum, EnvBatchEnum,
+  EnvPlanEnum, 
+  EnvBatchEnum, 
+  EnvConfigurationsEnum,
 } from './env-enum';
 
 import { DriverEnum } from '../writer';
@@ -48,6 +50,13 @@ export const envToConfig = (env: EnvType): ConfigType => ({
       size: env[EnvBatchEnum.size],
     },
     defect: env[EnvTestOpsEnum.defect],
+    configurations: env[EnvConfigurationsEnum.values] ? {
+      values: env[EnvConfigurationsEnum.values].split(',').map(item => {
+        const [name, value] = item.split('=');
+        return { name: (name ?? '').trim(), value: value ? value.trim() : '' };
+      }),
+      createIfNotExists: env[EnvConfigurationsEnum.createIfNotExists],
+    } : undefined,
   },
 
   report: {

--- a/qase-javascript-commons/src/env/env-type.ts
+++ b/qase-javascript-commons/src/env/env-type.ts
@@ -4,7 +4,9 @@ import {
   EnvApiEnum,
   EnvRunEnum,
   EnvLocalEnum,
-  EnvPlanEnum, EnvBatchEnum,
+  EnvPlanEnum, 
+  EnvBatchEnum, 
+  EnvConfigurationsEnum,
 } from './env-enum';
 
 import { ModeEnum } from '../options';
@@ -34,6 +36,9 @@ export interface EnvType {
   [EnvPlanEnum.id]?: number;
 
   [EnvBatchEnum.size]?: number;
+
+  [EnvConfigurationsEnum.values]?: string;
+  [EnvConfigurationsEnum.createIfNotExists]?: boolean;
 
   [EnvLocalEnum.path]?: string;
   [EnvLocalEnum.format]?: `${FormatEnum}`;

--- a/qase-javascript-commons/src/env/env-validation-schema.ts
+++ b/qase-javascript-commons/src/env/env-validation-schema.ts
@@ -7,7 +7,8 @@ import {
   EnvLocalEnum,
   EnvPlanEnum,
   EnvRunEnum,
-  EnvTestOpsEnum,
+  EnvTestOpsEnum, 
+  EnvConfigurationsEnum,
 } from './env-enum';
 
 import { ModeEnum } from '../options';
@@ -97,6 +98,15 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
 
     [EnvBatchEnum.size]: {
       type: 'number',
+      nullable: true,
+    },
+
+    [EnvConfigurationsEnum.values]: {
+      type: 'string',
+      nullable: true,
+    },
+    [EnvConfigurationsEnum.createIfNotExists]: {
+      type: 'boolean',
       nullable: true,
     },
 

--- a/qase-javascript-commons/src/models/config/TestOpsOptionsType.ts
+++ b/qase-javascript-commons/src/models/config/TestOpsOptionsType.ts
@@ -7,6 +7,17 @@ export interface TestOpsOptionsType {
   plan: TestOpsPlanType;
   batch?: TestOpsBatchType;
   defect?: boolean | undefined;
+  configuration?: TestOpsConfigurationType | undefined;
+}
+
+export interface TestOpsConfigurationType {
+  values: TestOpsConfigurationValueType[];
+  createIfNotExists?: boolean | undefined;
+}
+
+export interface TestOpsConfigurationValueType {
+  name: string;
+  value: string;
 }
 
 export interface TestOpsRunType {

--- a/qase-javascript-commons/src/models/config/TestOpsOptionsType.ts
+++ b/qase-javascript-commons/src/models/config/TestOpsOptionsType.ts
@@ -7,7 +7,7 @@ export interface TestOpsOptionsType {
   plan: TestOpsPlanType;
   batch?: TestOpsBatchType;
   defect?: boolean | undefined;
-  configuration?: TestOpsConfigurationType | undefined;
+  configurations?: TestOpsConfigurationType | undefined;
 }
 
 export interface TestOpsConfigurationType {

--- a/qase-javascript-commons/src/models/configuration.ts
+++ b/qase-javascript-commons/src/models/configuration.ts
@@ -1,0 +1,14 @@
+export interface ConfigurationGroup {
+  id: number;
+  title: string;
+  configurations: ConfigurationItem[];
+}
+
+export interface ConfigurationItem {
+  id: number;
+  title: string;
+}
+
+export interface ConfigurationGroupResponse {
+  groups: ConfigurationGroup[];
+} 

--- a/qase-javascript-commons/src/models/index.ts
+++ b/qase-javascript-commons/src/models/index.ts
@@ -5,3 +5,4 @@ export { StepStatusEnum } from './step-execution';
 export { Attachment } from './attachment';
 export { Report } from './report';
 export { CompoundError } from './error';
+export { ConfigurationGroup, ConfigurationItem, ConfigurationGroupResponse } from './configuration';

--- a/qase-javascript-commons/test/config/config-validation-schema.test.ts
+++ b/qase-javascript-commons/test/config/config-validation-schema.test.ts
@@ -1,0 +1,145 @@
+import { expect } from '@jest/globals';
+import Ajv from 'ajv';
+import { configValidationSchema } from '../../src/config/config-validation-schema';
+
+describe('configValidationSchema', () => {
+  const ajv = new Ajv();
+  const validate = ajv.compile(configValidationSchema);
+
+  describe('testops.configurations', () => {
+    it('should validate valid configurations object', () => {
+      const validConfig = {
+        testops: {
+          configurations: {
+            values: [
+              { name: 'group1', value: 'value1' },
+              { name: 'group2', value: 'value2' },
+            ],
+            createIfNotExists: true,
+          },
+        },
+      };
+
+      const isValid = validate(validConfig);
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate configurations without createIfNotExists', () => {
+      const validConfig = {
+        testops: {
+          configurations: {
+            values: [
+              { name: 'group1', value: 'value1' },
+            ],
+          },
+        },
+      };
+
+      const isValid = validate(validConfig);
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate empty values array', () => {
+      const validConfig = {
+        testops: {
+          configurations: {
+            values: [],
+          },
+        },
+      };
+
+      const isValid = validate(validConfig);
+      expect(isValid).toBe(true);
+    });
+
+    it('should reject configurations without values', () => {
+      const invalidConfig = {
+        testops: {
+          configurations: {
+            createIfNotExists: true,
+          },
+        },
+      };
+
+      const isValid = validate(invalidConfig);
+      expect(isValid).toBe(false);
+      expect(validate.errors).toBeDefined();
+    });
+
+    it('should reject configurations with invalid values structure', () => {
+      const invalidConfig = {
+        testops: {
+          configurations: {
+            values: [
+              { name: 'group1' }, // missing value
+            ],
+          },
+        },
+      };
+
+      const isValid = validate(invalidConfig);
+      expect(isValid).toBe(false);
+      expect(validate.errors).toBeDefined();
+    });
+
+    it('should reject configurations with invalid name type', () => {
+      const invalidConfig = {
+        testops: {
+          configurations: {
+            values: [
+              { name: 123, value: 'value1' }, // name should be string
+            ],
+          },
+        },
+      };
+
+      const isValid = validate(invalidConfig);
+      expect(isValid).toBe(false);
+      expect(validate.errors).toBeDefined();
+    });
+
+    it('should reject configurations with invalid value type', () => {
+      const invalidConfig = {
+        testops: {
+          configurations: {
+            values: [
+              { name: 'group1', value: 123 }, // value should be string
+            ],
+          },
+        },
+      };
+
+      const isValid = validate(invalidConfig);
+      expect(isValid).toBe(false);
+      expect(validate.errors).toBeDefined();
+    });
+
+    it('should reject configurations with invalid createIfNotExists type', () => {
+      const invalidConfig = {
+        testops: {
+          configurations: {
+            values: [
+              { name: 'group1', value: 'value1' },
+            ],
+            createIfNotExists: 'true', // should be boolean
+          },
+        },
+      };
+
+      const isValid = validate(invalidConfig);
+      expect(isValid).toBe(false);
+      expect(validate.errors).toBeDefined();
+    });
+
+    it('should validate null configurations', () => {
+      const validConfig = {
+        testops: {
+          configurations: null,
+        },
+      };
+
+      const isValid = validate(validConfig);
+      expect(isValid).toBe(true);
+    });
+  });
+}); 

--- a/qase-javascript-commons/test/env/env-to-config.test.ts
+++ b/qase-javascript-commons/test/env/env-to-config.test.ts
@@ -1,0 +1,85 @@
+import { expect } from '@jest/globals';
+import { envToConfig } from '../../src/env/env-to-config';
+import { EnvType } from '../../src/env/env-type';
+import { EnvConfigurationsEnum } from '../../src/env/env-enum';
+
+describe('envToConfig', () => {
+  describe('configurations', () => {
+    it('should parse configurations values from environment variable', () => {
+      const env: EnvType = {
+        [EnvConfigurationsEnum.values]: 'group1=value1,group2=value2,group3=value3',
+        [EnvConfigurationsEnum.createIfNotExists]: true,
+      };
+
+      const result = envToConfig(env);
+
+      expect(result.testops?.configurations).toEqual({
+        values: [
+          { name: 'group1', value: 'value1' },
+          { name: 'group2', value: 'value2' },
+          { name: 'group3', value: 'value3' },
+        ],
+        createIfNotExists: true,
+      });
+    });
+
+    it('should handle configurations values with spaces', () => {
+      const env: EnvType = {
+        [EnvConfigurationsEnum.values]: 'group1=value1, group2 = value2 , group3= value3',
+        [EnvConfigurationsEnum.createIfNotExists]: false,
+      };
+
+      const result = envToConfig(env);
+
+      expect(result.testops?.configurations).toEqual({
+        values: [
+          { name: 'group1', value: 'value1' },
+          { name: 'group2', value: 'value2' },
+          { name: 'group3', value: 'value3' },
+        ],
+        createIfNotExists: false,
+      });
+    });
+
+    it('should handle empty value in configurations', () => {
+      const env: EnvType = {
+        [EnvConfigurationsEnum.values]: 'group1=value1,group2=,group3=value3',
+      };
+
+      const result = envToConfig(env);
+
+      expect(result.testops?.configurations).toEqual({
+        values: [
+          { name: 'group1', value: 'value1' },
+          { name: 'group2', value: '' },
+          { name: 'group3', value: 'value3' },
+        ],
+        createIfNotExists: undefined,
+      });
+    });
+
+    it('should return undefined when configurations values are not provided', () => {
+      const env: EnvType = {};
+
+      const result = envToConfig(env);
+
+      expect(result.testops?.configurations).toBeUndefined();
+    });
+
+    it('should handle single configurations value', () => {
+      const env: EnvType = {
+        [EnvConfigurationsEnum.values]: 'group1=value1',
+        [EnvConfigurationsEnum.createIfNotExists]: true,
+      };
+
+      const result = envToConfig(env);
+
+      expect(result.testops?.configurations).toEqual({
+        values: [
+          { name: 'group1', value: 'value1' },
+        ],
+        createIfNotExists: true,
+      });
+    });
+  });
+}); 

--- a/qase-javascript-commons/test/env/env-validation-schema.test.ts
+++ b/qase-javascript-commons/test/env/env-validation-schema.test.ts
@@ -1,0 +1,76 @@
+import { expect } from '@jest/globals';
+import envSchema from 'env-schema';
+import { envValidationSchema } from '../../src/env/env-validation-schema';
+import { EnvConfigurationsEnum } from '../../src/env/env-enum';
+
+describe('envValidationSchema', () => {
+  describe('configurations environment variables', () => {
+    it('should validate valid configurations values', () => {
+      const env = {
+        [EnvConfigurationsEnum.values]: 'group1=value1,group2=value2',
+        [EnvConfigurationsEnum.createIfNotExists]: true,
+      };
+
+      const result = envSchema({
+        schema: envValidationSchema,
+        data: env,
+      });
+
+      expect(result[EnvConfigurationsEnum.values]).toBe('group1=value1,group2=value2');
+      expect(result[EnvConfigurationsEnum.createIfNotExists]).toBe(true);
+    });
+
+    it('should validate configurations values as string', () => {
+      const env = {
+        [EnvConfigurationsEnum.values]: 'group1=value1',
+      };
+
+      const result = envSchema({
+        schema: envValidationSchema,
+        data: env,
+      });
+
+      expect(result[EnvConfigurationsEnum.values]).toBe('group1=value1');
+    });
+
+    it('should validate createIfNotExists as boolean', () => {
+      const env = {
+        [EnvConfigurationsEnum.createIfNotExists]: false,
+      };
+
+      const result = envSchema({
+        schema: envValidationSchema,
+        data: env,
+      });
+
+      expect(result[EnvConfigurationsEnum.createIfNotExists]).toBe(false);
+    });
+
+    it('should handle missing configurations values', () => {
+      const env = {};
+
+      const result = envSchema({
+        schema: envValidationSchema,
+        data: env,
+      });
+
+      expect(result[EnvConfigurationsEnum.values]).toBeUndefined();
+      expect(result[EnvConfigurationsEnum.createIfNotExists]).toBeUndefined();
+    });
+
+    it('should handle null configurations values', () => {
+      const env = {
+        [EnvConfigurationsEnum.values]: null,
+        [EnvConfigurationsEnum.createIfNotExists]: null,
+      };
+
+      const result = envSchema({
+        schema: envValidationSchema,
+        data: env,
+      });
+
+      expect(result[EnvConfigurationsEnum.values]).toBeNull();
+      expect(result[EnvConfigurationsEnum.createIfNotExists]).toBeNull();
+    });
+  });
+}); 


### PR DESCRIPTION
This pull request introduces support for managing configurations in Qase TestOps, including creating and associating configuration groups and values with test runs. The changes span documentation updates, new API integrations, configuration schema extensions, and validation tests. Below is a breakdown of the most important changes:

### Documentation Updates
* Updated `qase-javascript-commons/README.md` to document new configuration options (`testops.configurations.values` and `testops.configurations.createIfNotExists`) and provide an example configuration. [[1]](diffhunk://#diff-a86b9b2bf39ba11a85fcbbda1d3ef20cf0156c82eee3cd7acff6192547c7e3a7R61-R62) [[2]](diffhunk://#diff-a86b9b2bf39ba11a85fcbbda1d3ef20cf0156c82eee3cd7acff6192547c7e3a7R97-R109)

### API Integration for Configurations
* Added `ConfigurationsApi` and related models (`ConfigurationGroupCreate`, `ConfigurationCreate`) to `qase-javascript-commons/src/client/clientV1.ts`. Integrated methods to fetch, create, and manage configuration groups and values. [[1]](diffhunk://#diff-439bb924963ba7bb678cca45dc47ab181e10c9ca8194dc483a15bdf0b4522674L2-R13) [[2]](diffhunk://#diff-439bb924963ba7bb678cca45dc47ab181e10c9ca8194dc483a15bdf0b4522674R55) [[3]](diffhunk://#diff-439bb924963ba7bb678cca45dc47ab181e10c9ca8194dc483a15bdf0b4522674R68) [[4]](diffhunk://#diff-439bb924963ba7bb678cca45dc47ab181e10c9ca8194dc483a15bdf0b4522674L178-R196) [[5]](diffhunk://#diff-439bb924963ba7bb678cca45dc47ab181e10c9ca8194dc483a15bdf0b4522674R214-R349)

### Configuration Schema Extensions
* Extended `config-validation-schema` to include validation for `testops.configurations` and its properties (`values` and `createIfNotExists`).
* Added `EnvConfigurationsEnum` to map environment variables for configurations. Updated related files (`env-to-config.ts`, `env-type.ts`, `env-validation-schema.ts`) to support parsing and validation of these environment variables. [[1]](diffhunk://#diff-a422543bf5c529a2367c91915c783898fe75a9bc7dc1e7bfca25250ae04117d8R55-R62) [[2]](diffhunk://#diff-daf99ab7abd6f779b2c9b45911b9e685aad35fdeac5a177966e0093c5c2db199R53-R59) [[3]](diffhunk://#diff-dae907d0db2bd40c5dba07aa567d484b3a57da0bb6afbc631fbb24ce5325599eR40-R42) [[4]](diffhunk://#diff-3b1f38bea6db6f09e5278c8fdc1206d313b4464cbc3958644aba588d1abda7a0R104-R112)

### Models for Configuration Management
* Introduced new models (`ConfigurationGroup`, `ConfigurationItem`, `ConfigurationGroupResponse`) to represent configuration groups and values in `qase-javascript-commons/src/models`. [[1]](diffhunk://#diff-bf904e1c56a6f21a8c1aeb2f4b6bfbfa802ac074919a65e2b3ca6130cb35a7d7R1-R14) [[2]](diffhunk://#diff-e331485ad231a2f3209ecf77ed198b50ea4fce4beb184da12c65e50d8b88c37bR8)

### Validation Tests
* Added comprehensive tests for `config-validation-schema` to ensure proper validation of `testops.configurations` objects, including edge cases and invalid inputs.