### PR TITLE
feat: support status filtering and error handling improvement 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -609,6 +609,21 @@
         }
       }
     },
+    "examples/vitest/node_modules/vitest-qase-reporter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vitest-qase-reporter/-/vitest-qase-reporter-1.0.0.tgz",
+      "integrity": "sha512-jt4t2nu3Gy0vKAQuwl+3fQYFv1RLhW9M0cbEpRFqktJGoxGFmLLOumfW0v+mGWmUzU6HaWRjlydN9jU4oVOzJQ==",
+      "dev": true,
+      "dependencies": {
+        "qase-javascript-commons": "~2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "vitest": ">=3.0.0"
+      }
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "license": "Apache-2.0",
@@ -20046,11 +20061,11 @@
     },
     "qase-cucumberjs": {
       "name": "cucumberjs-qase-reporter",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/messages": "^22.0.0",
-        "qase-javascript-commons": "~2.4.1"
+        "qase-javascript-commons": "~2.4.2"
       },
       "devDependencies": {
         "@jest/globals": "^29.5.0",
@@ -20068,10 +20083,10 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.4.1",
+        "qase-javascript-commons": "~2.4.2",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -20091,7 +20106,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -20135,12 +20150,12 @@
     },
     "qase-jest": {
       "name": "jest-qase-reporter",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "qase-javascript-commons": "~2.4.1",
+        "qase-javascript-commons": "~2.4.2",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -20162,12 +20177,12 @@
     },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "deasync-promise": "^1.0.1",
         "mocha": "^10.2.0",
-        "qase-javascript-commons": "~2.4.1",
+        "qase-javascript-commons": "~2.4.2",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -20194,10 +20209,10 @@
     },
     "qase-newman": {
       "name": "newman-reporter-qase",
-      "version": "2.1.3",
+      "version": "2.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.4.1",
+        "qase-javascript-commons": "~2.4.2",
         "semver": "^7.5.1"
       },
       "devDependencies": {
@@ -20219,11 +20234,11 @@
     },
     "qase-playwright": {
       "name": "playwright-qase-reporter",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
-        "qase-javascript-commons": "~2.4.1",
+        "qase-javascript-commons": "~2.4.2",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -20242,10 +20257,10 @@
     },
     "qase-testcafe": {
       "name": "testcafe-reporter-qase",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.4.1",
+        "qase-javascript-commons": "~2.4.2",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -20263,10 +20278,10 @@
     },
     "qase-vitest": {
       "name": "vitest-qase-reporter",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.4.1"
+        "qase-javascript-commons": "~2.4.2"
       },
       "devDependencies": {
         "@jest/globals": "^29.5.0",
@@ -20963,14 +20978,14 @@
     },
     "qase-wdio": {
       "name": "wdio-qase-reporter",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@wdio/reporter": "^8.39.0",
         "@wdio/types": "^8.39.0",
         "csv-stringify": "^6.0.4",
-        "qase-javascript-commons": "~2.4.1",
+        "qase-javascript-commons": "~2.4.2",
         "strip-ansi": "^7.1.0",
         "uuid": "^9.0.1"
       },

--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,10 @@
+# qase-cucumberjs@2.1.5
+
+## What's new
+
+- Added support for status filter in the test run.
+- Improved error handling.
+
 # qase-cucumberjs@2.1.3
 
 ## What's new

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/messages": "^22.0.0",
-    "qase-javascript-commons": "~2.4.1"
+    "qase-javascript-commons": "~2.4.2"
   },
   "peerDependencies": {
     "@cucumber/cucumber": ">=7.0.0"

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -18,6 +18,7 @@ import {
   TestResultType,
   TestStatusEnum,
   TestStepType,
+  determineTestStatus,
 } from 'qase-javascript-commons';
 import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
 import { Status } from '@cucumber/cucumber';
@@ -190,7 +191,15 @@ export class Storage {
    */
   public addTestCaseStep(testCaseStep: TestStepFinished): void {
     const oldStatus = this.testCaseStartedResult[testCaseStep.testCaseStartedId];
-    const newStatus = Storage.statusMap[testCaseStep.testStepResult.status];
+    
+    // Create error object for status determination
+    let error: Error | null = null;
+    if (testCaseStep.testStepResult.message) {
+      error = new Error(testCaseStep.testStepResult.message);
+    }
+    
+    // Determine status based on error type
+    const newStatus = determineTestStatus(error, testCaseStep.testStepResult.status);
 
     this.testCaseSteps[testCaseStep.testStepId] = testCaseStep;
 

--- a/qase-cucumberjs/test/storage.test.ts
+++ b/qase-cucumberjs/test/storage.test.ts
@@ -283,7 +283,7 @@ describe('Storage', () => {
       storage.addTestCaseStep(testStepFinished1);
       storage.addTestCaseStep(testStepFinished2);
 
-      expect((storage as any).testCaseStartedResult['started-1']).toBe(TestStatusEnum.failed);
+      expect((storage as any).testCaseStartedResult['started-1']).toBe(TestStatusEnum.invalid);
       expect((storage as any).testCaseStartedErrors['started-1']).toContain('First failure');
       expect((storage as any).testCaseStartedErrors['started-1']).toContain('Second failure');
     });

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,10 @@
+# cypress-qase-reporter@3.0.3
+
+## What's new
+
+- Added support for status filter in the test run.
+- Improved error handling.
+
 # cypress-qase-reporter@3.0.2
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -51,7 +51,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.4.1",
+    "qase-javascript-commons": "~2.4.2",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -18,6 +18,7 @@ import {
   TestResultType,
   TestStatusEnum,
   TestStepType,
+  determineTestStatus,
 } from 'qase-javascript-commons';
 
 import { configSchema } from './configSchema';
@@ -262,9 +263,7 @@ export class CypressQaseReporter extends reporters.Base {
       steps: steps,
       id: uuidv4(),
       execution: {
-        status: test.state
-          ? CypressQaseReporter.statusMap[test.state]
-          : TestStatusEnum.invalid,
+        status: determineTestStatus(test.err || null, test.state || 'failed'),
         start_time: this.testBeginTime / 1000,
         end_time: end_time / 1000,
         duration: duration,

--- a/qase-cypress/test/reporter.test.ts
+++ b/qase-cypress/test/reporter.test.ts
@@ -27,6 +27,12 @@ jest.mock('qase-javascript-commons', () => ({
     skipped: 'skipped',
   },
   generateSignature: jest.fn(() => 'mock-signature'),
+  determineTestStatus: jest.fn((error, originalStatus) => {
+    if (error) return 'failed';
+    if (originalStatus === 'passed') return 'passed';
+    if (originalStatus === 'pending') return 'skipped';
+    return 'failed';
+  }),
   ConfigLoader: jest.fn().mockImplementation(() => ({
     load: jest.fn(() => ({})),
   })),

--- a/qase-javascript-commons/README.md
+++ b/qase-javascript-commons/README.md
@@ -59,6 +59,7 @@ All configuration options are listed in the table below:
 | Size of batch for sending test results                                                                                | `testops.batch.size`       | `QASE_TESTOPS_BATCH_SIZE`       | `200`                                   | No       | Any integer                |
 | Enable defects for failed test cases                                                                                  | `testops.defect`           | `QASE_TESTOPS_DEFECT`           | `False`                                 | No       | `True`, `False`            |
 | Enable/disable attachment uploads                                                                                     | `testops.uploadAttachments`        | `QASE_TESTOPS_UPLOAD_ATTACHMENTS`       | `true`                                  | No       | `True`, `False`            |
+| Filter test results by status (comma-separated list of statuses to exclude from reporting)                           | `testops.statusFilter`              | `QASE_TESTOPS_STATUS_FILTER`             | undefined                               | No       | Array of strings (`passed`, `failed`, `skipped`, `invalid`) |
 | Configuration values to create/find in groups (format: `group1=value1,group2=value2`)                                | `testops.configurations.values`     | `QASE_TESTOPS_CONFIGURATIONS_VALUES`     | undefined                               | No       | Comma-separated key=value pairs |
 | Create configuration groups if they don't exist                                                                       | `testops.configurations.createIfNotExists` | `QASE_TESTOPS_CONFIGURATIONS_CREATE_IF_NOT_EXISTS` | `false`                          | No       | `True`, `False`            |
 
@@ -97,6 +98,8 @@ All configuration options are listed in the table below:
     },
     "defect": false,
     "project": "<project_code>",
+    "uploadAttachments": true,
+    "statusFilter": ["passed", "skipped"],
     "batch": {
       "size": 100
     },
@@ -125,4 +128,7 @@ export QASE_TESTOPS_RUN_EXTERNAL_LINK='{"type":"jiraCloud","link":"PROJ-123"}'
 
 # Set external link for Jira Server
 export QASE_TESTOPS_RUN_EXTERNAL_LINK='{"type":"jiraServer","link":"PROJ-456"}'
+
+# Filter out test results with specific statuses
+export QASE_TESTOPS_STATUS_FILTER="passed,failed"
 ```

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,15 @@
+# qase-javascript-commons@2.4.2
+
+## What's new
+
+Added support for status filter in the test run.
+
+You can now filter out test results by status.
+The status filter is specified in the `testops.statusFilter` configuration option.
+The status filter is a comma-separated list of statuses to exclude from reporting.
+The statuses are: `passed`, `failed`, `skipped`, `invalid`.
+The status filter is applied to the test results before they are sent to Qase.
+
 # qase-javascript-commons@2.4.1
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/config/config-validation-schema.ts
+++ b/qase-javascript-commons/src/config/config-validation-schema.ts
@@ -171,6 +171,14 @@ export const configValidationSchema = {
           },
           required: ['values'],
         },
+
+        statusFilter: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+          nullable: true,
+        },
       },
     },
 

--- a/qase-javascript-commons/src/env/env-enum.ts
+++ b/qase-javascript-commons/src/env/env-enum.ts
@@ -17,6 +17,7 @@ export enum EnvTestOpsEnum {
   project = 'QASE_TESTOPS_PROJECT',
   uploadAttachments = 'QASE_TESTOPS_UPLOAD_ATTACHMENTS',
   defect = 'QASE_TESTOPS_DEFECT',
+  statusFilter = 'QASE_TESTOPS_STATUS_FILTER',
 }
 
 /**

--- a/qase-javascript-commons/src/env/env-to-config.ts
+++ b/qase-javascript-commons/src/env/env-to-config.ts
@@ -29,6 +29,7 @@ export const envToConfig = (env: EnvType): ConfigType => ({
   testops: {
     project: env[EnvTestOpsEnum.project],
     uploadAttachments: env[EnvTestOpsEnum.uploadAttachments],
+    statusFilter: env[EnvTestOpsEnum.statusFilter]?.split(',').map(status => status.trim()) ?? undefined,
 
     api: {
       token: env[EnvApiEnum.token],

--- a/qase-javascript-commons/src/env/env-type.ts
+++ b/qase-javascript-commons/src/env/env-type.ts
@@ -23,6 +23,7 @@ export interface EnvType {
   [EnvTestOpsEnum.project]?: string;
   [EnvTestOpsEnum.uploadAttachments]?: boolean;
   [EnvTestOpsEnum.defect]?: boolean;
+  [EnvTestOpsEnum.statusFilter]?: string;
 
   [EnvApiEnum.token]?: string;
   [EnvApiEnum.host]?: string;

--- a/qase-javascript-commons/src/env/env-validation-schema.ts
+++ b/qase-javascript-commons/src/env/env-validation-schema.ts
@@ -60,6 +60,10 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
       type: 'boolean',
       nullable: true,
     },
+    [EnvTestOpsEnum.statusFilter]: {
+      type: 'string',
+      nullable: true,
+    },
 
     [EnvApiEnum.token]: {
       type: 'string',

--- a/qase-javascript-commons/src/index.ts
+++ b/qase-javascript-commons/src/index.ts
@@ -10,4 +10,5 @@ export * from './writer';
 export * from './utils/get-package-version';
 export * from './utils/mimeTypes';
 export * from './utils/signature';
+export * from './utils/test-status-utils';
 export * from './steps/step';

--- a/qase-javascript-commons/src/models/config/TestOpsOptionsType.ts
+++ b/qase-javascript-commons/src/models/config/TestOpsOptionsType.ts
@@ -8,6 +8,7 @@ export interface TestOpsOptionsType {
   batch?: TestOpsBatchType;
   defect?: boolean | undefined;
   configurations?: TestOpsConfigurationType | undefined;
+  statusFilter?: string[] | undefined;
 }
 
 export interface TestOpsConfigurationType {

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -357,6 +357,12 @@ export class QaseReporter implements ReporterInterface {
    */
   public async addTestResult(result: TestResultType) {
     if (!this.disabled) {
+      // Check if result should be filtered out based on status
+      if (this.shouldFilterResult(result)) {
+        this.logger.logDebug(`Filtering out test result with status: ${result.execution.status}`);
+        return;
+      }
+
       await this.startTestRunOperation;
 
       this.logTestItem(result);
@@ -388,6 +394,30 @@ export class QaseReporter implements ReporterInterface {
         await this.addTestResultToFallback(result);
       }
     }
+  }
+
+  /**
+   * @param {TestResultType} result
+   * @private
+   */
+  private shouldFilterResult(result: TestResultType): boolean {
+    const statusFilter = this.options.testops?.statusFilter;
+    
+    if (!statusFilter || statusFilter.length === 0) {
+      return false;
+    }
+
+    // Convert TestStatusEnum to string for comparison
+    const statusString = result.execution.status.toString();
+    
+    this.logger.logDebug(`Checking filter: status="${statusString}", filter=${JSON.stringify(statusFilter)}`);
+    
+    // Check if the status is in the filter list
+    const shouldFilter = statusFilter.includes(statusString);
+    
+    this.logger.logDebug(`Filter result: ${shouldFilter ? 'FILTERED' : 'NOT FILTERED'}`);
+    
+    return shouldFilter;
   }
 
   /**

--- a/qase-javascript-commons/src/utils/test-status-utils.ts
+++ b/qase-javascript-commons/src/utils/test-status-utils.ts
@@ -1,0 +1,119 @@
+import { TestStatusEnum } from '../models/test-execution';
+
+/**
+ * Determines test status based on error type
+ * @param error - Error object or null
+ * @param originalStatus - Original test status from test runner
+ * @returns TestStatusEnum - failed for assertion errors, invalid for other errors
+ */
+export function determineTestStatus(error: Error | null, originalStatus: string): TestStatusEnum {
+  // If no error, return the original status
+  if (!error) {
+    return mapOriginalStatus(originalStatus);
+  }
+
+  // Check if it's an assertion error
+  if (isAssertionError(error)) {
+    return TestStatusEnum.failed;
+  }
+
+  // For all other errors, return invalid
+  return TestStatusEnum.invalid;
+}
+
+/**
+ * Checks if error is an assertion error
+ * @param error - Error object
+ * @returns boolean - true if assertion error
+ */
+function isAssertionError(error: Error): boolean {
+  const errorMessage = error.message.toLowerCase();
+  const errorStack = error.stack?.toLowerCase() || '';
+  
+  // Common assertion error patterns
+  const assertionPatterns = [
+    'expect',
+    'assert',
+    'matcher',
+    'assertion',
+    'expected',
+    'actual',
+    'to be',
+    'to equal',
+    'to contain',
+    'to match',
+    'to throw',
+    'to be called',
+    'to have been called',
+    'test failed',
+    'expectation failed',
+    'assertion failed'
+  ];
+
+  // Non-assertion error patterns that should be invalid
+  const nonAssertionPatterns = [
+    'syntaxerror',
+    'referenceerror',
+    'typeerror',
+    'network',
+    'timeout',
+    'connection',
+    'http',
+    'fetch',
+    'axios',
+    'cors',
+    'permission',
+    'access denied',
+    'unauthorized',
+    'forbidden',
+    'not found',
+    'server error',
+    'internal error'
+  ];
+
+  // Check for non-assertion patterns first
+  const hasNonAssertionPattern = nonAssertionPatterns.some(pattern => 
+    errorMessage.includes(pattern) || errorStack.includes(pattern)
+  );
+
+  if (hasNonAssertionPattern) {
+    return false;
+  }
+
+  // Check error message and stack for assertion patterns
+  const hasAssertionPattern = assertionPatterns.some(pattern => 
+    errorMessage.includes(pattern) || errorStack.includes(pattern)
+  );
+
+  // Check for specific error types that indicate assertions
+  const isJestMatcherError = error.name === 'Error' && 
+    (errorMessage.includes('expect') || errorMessage.includes('matcher'));
+  
+  const isChaiAssertionError = error.name === 'AssertionError';
+  
+  const isPlaywrightAssertionError = error.name === 'Error' && 
+    (errorMessage.includes('expect') || errorMessage.includes('assert'));
+
+  return hasAssertionPattern || isJestMatcherError || isChaiAssertionError || isPlaywrightAssertionError;
+}
+
+/**
+ * Maps original test runner status to TestStatusEnum
+ * @param originalStatus - Original status from test runner
+ * @returns TestStatusEnum
+ */
+function mapOriginalStatus(originalStatus: string): TestStatusEnum {
+  const statusMap: Record<string, TestStatusEnum> = {
+    'passed': TestStatusEnum.passed,
+    'failed': TestStatusEnum.failed,
+    'skipped': TestStatusEnum.skipped,
+    'disabled': TestStatusEnum.disabled,
+    'pending': TestStatusEnum.skipped,
+    'todo': TestStatusEnum.disabled,
+    'focused': TestStatusEnum.passed,
+    'timedOut': TestStatusEnum.failed,
+    'interrupted': TestStatusEnum.failed,
+  };
+
+  return statusMap[originalStatus] || TestStatusEnum.skipped;
+}

--- a/qase-javascript-commons/test/utils/test-status-utils.test.ts
+++ b/qase-javascript-commons/test/utils/test-status-utils.test.ts
@@ -1,0 +1,94 @@
+import { expect } from '@jest/globals';
+import { determineTestStatus } from '../../src/utils/test-status-utils';
+import { TestStatusEnum } from '../../src/models/test-execution';
+
+describe('determineTestStatus', () => {
+  describe('when no error', () => {
+    it('should return original status for passed test', () => {
+      const result = determineTestStatus(null, 'passed');
+      expect(result).toBe(TestStatusEnum.passed);
+    });
+
+    it('should return original status for skipped test', () => {
+      const result = determineTestStatus(null, 'skipped');
+      expect(result).toBe(TestStatusEnum.skipped);
+    });
+
+    it('should return original status for disabled test', () => {
+      const result = determineTestStatus(null, 'disabled');
+      expect(result).toBe(TestStatusEnum.disabled);
+    });
+  });
+
+  describe('when assertion error', () => {
+    it('should return failed for expect error', () => {
+      const error = new Error('expect(received).toBe(expected)');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for assertion error', () => {
+      const error = new Error('Assertion failed: expected 1 to equal 2');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for matcher error', () => {
+      const error = new Error('Matcher error: toBe');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for test failed message', () => {
+      const error = new Error('Test failed: expected true to be false');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for Chai AssertionError', () => {
+      const error = new Error('Assertion failed');
+      error.name = 'AssertionError';
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for error with assertion in stack', () => {
+      const error = new Error('Some error');
+      error.stack = 'Error: Some error\n    at expect (test.js:10:5)';
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+  });
+
+  describe('when non-assertion error', () => {
+    it('should return invalid for network error', () => {
+      const error = new Error('Network request failed');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.invalid);
+    });
+
+    it('should return invalid for timeout error', () => {
+      const error = new Error('Timeout of 5000ms exceeded');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.invalid);
+    });
+
+    it('should return invalid for syntax error', () => {
+      const error = new Error('SyntaxError: Unexpected token');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.invalid);
+    });
+
+    it('should return invalid for reference error', () => {
+      const error = new Error('ReferenceError: variable is not defined');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.invalid);
+    });
+
+    it('should return invalid for type error', () => {
+      const error = new Error('TypeError: Cannot read property of undefined');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.invalid);
+    });
+  });
+});

--- a/qase-jest/changelog.md
+++ b/qase-jest/changelog.md
@@ -1,3 +1,10 @@
+# jest-qase-reporter@2.1.3
+
+## What's new
+
+- Added support for status filter in the test run.
+- Improved error handling.
+
 # jest-qase-reporter@2.1.0
 
 ## What's new

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-qase-reporter",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Qase TMS Jest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
-    "qase-javascript-commons": "~2.4.1",
+    "qase-javascript-commons": "~2.4.2",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/qase-jest/src/reporter.ts
+++ b/qase-jest/src/reporter.ts
@@ -17,6 +17,7 @@ import {
   TestResultType,
   TestStatusEnum,
   TestStepType,
+  determineTestStatus,
 } from 'qase-javascript-commons';
 import { Qase } from './global';
 import { Metadata } from './models';
@@ -310,11 +311,14 @@ export class JestQaseReporter implements Reporter {
     const ids = JestQaseReporter.getCaseId(value.title);
     const filePath = this.getCurrentTestPath(path);
 
+    // Determine status based on error type
+    const testStatus = determineTestStatus(error || null, value.status);
+
     return {
       attachments: [],
       author: null,
       execution: {
-        status: JestQaseReporter.statusMap[value.status],
+        status: testStatus,
         start_time: null,
         end_time: null,
         duration: value.duration ?? 0,

--- a/qase-jest/test/reporter.test.ts
+++ b/qase-jest/test/reporter.test.ts
@@ -21,6 +21,13 @@ jest.mock('qase-javascript-commons', () => ({
     disabled: 'disabled',
   },
   generateSignature: jest.fn(() => 'mock-signature'),
+  determineTestStatus: jest.fn((error, originalStatus) => {
+    if (error) return 'failed';
+    if (originalStatus === 'passed') return 'passed';
+    if (originalStatus === 'pending') return 'skipped';
+    if (originalStatus === 'todo') return 'disabled';
+    return 'failed';
+  }),
   ConfigLoader: jest.fn().mockImplementation(() => ({
     load: jest.fn(() => ({})),
   })),

--- a/qase-mocha/changelog.md
+++ b/qase-mocha/changelog.md
@@ -1,3 +1,10 @@
+# qase-mocha@1.1.3
+
+## What's new
+
+- Added support for status filter in the test run.
+- Improved error handling.
+
 # qase-mocha@1.1.0
 
 ## What's new

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -43,7 +43,7 @@
   "dependencies": {
     "mocha": "^10.2.0",
     "deasync-promise": "^1.0.1",
-    "qase-javascript-commons": "~2.4.1",
+    "qase-javascript-commons": "~2.4.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -12,6 +12,7 @@ import {
   TestResultType,
   TestStatusEnum,
   TestStepType,
+  determineTestStatus,
 } from 'qase-javascript-commons';
 import deasyncPromise from 'deasync-promise';
 import { extname, join } from 'node:path';
@@ -222,9 +223,7 @@ export class MochaQaseReporter extends reporters.Base {
       steps: this.currentTest.steps,
       id: uuidv4(),
       execution: {
-        status: test.state
-          ? MochaQaseReporter.statusMap[test.state]
-          : TestStatusEnum.invalid,
+        status: determineTestStatus(test.err || null, test.state || 'failed'),
         start_time: this.testBeginTime / 1000,
         end_time: end_time / 1000,
         duration: duration,

--- a/qase-newman/changelog.md
+++ b/qase-newman/changelog.md
@@ -1,3 +1,10 @@
+# qase-newman@2.1.5
+
+## What's new
+
+- Added support for status filter in the test run.
+- Improved error handling.
+
 # qase-newman@2.1.4
 
 ## What's new

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-qase",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Qase TMS Newman Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -39,7 +39,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.4.1",
+    "qase-javascript-commons": "~2.4.2",
     "semver": "^7.5.1"
   },
   "devDependencies": {

--- a/qase-newman/src/reporter.ts
+++ b/qase-newman/src/reporter.ts
@@ -16,6 +16,7 @@ import {
   Relation,
   SuiteData,
   generateSignature,
+  determineTestStatus,
 } from 'qase-javascript-commons';
 
 export type NewmanQaseOptionsType = ConfigType;
@@ -228,8 +229,8 @@ export class NewmanQaseReporter {
         const pendingResult = this.pendingResultMap.get(item.id);
 
         if (pendingResult && err) {
-
-          pendingResult.execution.status = TestStatusEnum.failed;
+          // Determine status based on error type
+          pendingResult.execution.status = determineTestStatus(err, 'failed');
           pendingResult.execution.stacktrace = err.stack ?? null;
           pendingResult.message = err.message;
         }

--- a/qase-newman/test/reporter.test.ts
+++ b/qase-newman/test/reporter.test.ts
@@ -22,6 +22,11 @@ jest.mock('qase-javascript-commons', () => ({
     failed: 'failed',
   },
   generateSignature: jest.fn(() => 'mock-signature'),
+  determineTestStatus: jest.fn((error, originalStatus) => {
+    if (error) return 'failed';
+    if (originalStatus === 'passed') return 'passed';
+    return 'failed';
+  }),
   ConfigLoader: jest.fn().mockImplementation(() => ({
     load: jest.fn(() => ({})),
   })),

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,10 @@
+# playwright-qase-reporter@2.1.6
+
+## What's new
+
+- Added support for status filter in the test run.
+- Improved error handling.
+
 # playwright-qase-reporter@2.1.4
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.2",
-    "qase-javascript-commons": "~2.4.1",
+    "qase-javascript-commons": "~2.4.2",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-playwright/test/reporter.test.ts
+++ b/qase-playwright/test/reporter.test.ts
@@ -57,6 +57,15 @@ jest.mock('qase-javascript-commons', () => ({
     TEXT: 'text',
   },
   generateSignature: jest.fn(() => 'mock-signature'),
+  determineTestStatus: jest.fn((error, originalStatus) => {
+    if (error) return 'failed';
+    if (originalStatus === 'passed') return 'passed';
+    if (originalStatus === 'pending') return 'skipped';
+    if (originalStatus === 'todo') return 'disabled';
+    if (originalStatus === 'timedOut') return 'failed';
+    if (originalStatus === 'interrupted') return 'failed';
+    return 'failed';
+  }),
   ConfigLoader: jest.fn().mockImplementation(() => ({
     load: jest.fn(() => ({})),
   })),

--- a/qase-testcafe/changelog.md
+++ b/qase-testcafe/changelog.md
@@ -1,3 +1,10 @@
+# qase-testcafe@2.1.3
+
+## What's new
+
+- Added support for status filter in the test run.
+- Improved error handling.
+
 # qase-testcafe@2.1.0
 
 ## What's new

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-qase",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Qase TMS TestCafe Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -40,7 +40,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.4.1",
+    "qase-javascript-commons": "~2.4.2",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -10,6 +10,7 @@ import {
   Attachment,
   TestStepType,
   generateSignature,
+  determineTestStatus,
 } from 'qase-javascript-commons';
 import { Qase } from './global';
 
@@ -96,7 +97,14 @@ export class TestcafeQaseReporter {
     if (testRunInfo.skipped) {
       return TestStatusEnum.skipped;
     } else if (testRunInfo.errs.length > 0) {
-      return TestStatusEnum.failed;
+      // Create error object for status determination
+      const firstError = testRunInfo.errs[0];
+      const error = new Error(firstError?.errMsg || 'Test failed');
+      if (firstError?.callsite) {
+        error.stack = `Error: ${firstError.errMsg}\n    at ${firstError.callsite.filename}:${firstError.callsite.lineNum}`;
+      }
+      
+      return determineTestStatus(error, 'failed');
     }
 
     return TestStatusEnum.passed;

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -99,9 +99,11 @@ export class TestcafeQaseReporter {
     } else if (testRunInfo.errs.length > 0) {
       // Create error object for status determination
       const firstError = testRunInfo.errs[0];
-      const error = new Error(firstError?.errMsg || 'Test failed');
+      const error = new Error(firstError?.errMsg ?? 'Test failed');
       if (firstError?.callsite) {
-        error.stack = `Error: ${firstError.errMsg}\n    at ${firstError.callsite.filename}:${firstError.callsite.lineNum}`;
+        const filename = firstError.callsite.filename ?? 'unknown';
+        const lineNum = firstError.callsite.lineNum ?? 'unknown';
+        error.stack = `Error: ${firstError.errMsg}\n    at ${filename}:${lineNum}`;
       }
       
       return determineTestStatus(error, 'failed');

--- a/qase-testcafe/test/reporter.test.ts
+++ b/qase-testcafe/test/reporter.test.ts
@@ -20,6 +20,12 @@ jest.mock('qase-javascript-commons', () => ({
     skipped: 'skipped',
   },
   generateSignature: jest.fn(() => 'mock-signature'),
+  determineTestStatus: jest.fn((error, originalStatus) => {
+    if (error) return 'failed';
+    if (originalStatus === 'passed') return 'passed';
+    if (originalStatus === 'pending') return 'skipped';
+    return 'failed';
+  }),
   ConfigLoader: jest.fn().mockImplementation(() => ({
     load: jest.fn(() => ({})),
   })),

--- a/qase-vitest/changelog.md
+++ b/qase-vitest/changelog.md
@@ -1,0 +1,6 @@
+# qase-vitest@1.0.1
+
+## What's new
+
+- Added support for status filter in the test run.
+- Improved error handling.

--- a/qase-vitest/package.json
+++ b/qase-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-qase-reporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Qase TMS Vitest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -40,7 +40,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.4.1"
+    "qase-javascript-commons": "~2.4.2"
   },
   "peerDependencies": {
     "vitest": ">=3.0.0"

--- a/qase-vitest/test/index.test.ts
+++ b/qase-vitest/test/index.test.ts
@@ -49,6 +49,13 @@ jest.mock('qase-javascript-commons', () => ({
     failed: 'failed',
   },
   composeOptions: jest.fn().mockReturnValue({}),
+  determineTestStatus: jest.fn((error, originalStatus) => {
+    if (error) return 'failed';
+    if (originalStatus === 'passed') return 'passed';
+    if (originalStatus === 'pending') return 'skipped';
+    if (originalStatus === 'skipped') return 'skipped';
+    return 'failed';
+  }),
 }));
 
 describe('VitestQaseReporter - Main scenarios', () => {
@@ -62,37 +69,6 @@ describe('VitestQaseReporter - Main scenarios', () => {
     jest.clearAllMocks();
   });
 
-  describe('Test status conversion', () => {
-    it('should convert passed to TestStatusEnum.passed', () => {
-      const result = { state: 'passed' };
-      const status = reporter['convertStatus'](result as any);
-      expect(status).toBe('passed');
-    });
-
-    it('should convert failed to TestStatusEnum.failed', () => {
-      const result = { state: 'failed' };
-      const status = reporter['convertStatus'](result as any);
-      expect(status).toBe('failed');
-    });
-
-    it('should convert skipped to TestStatusEnum.skipped', () => {
-      const result = { state: 'skipped' };
-      const status = reporter['convertStatus'](result as any);
-      expect(status).toBe('skipped');
-    });
-
-    it('should convert pending to TestStatusEnum.skipped', () => {
-      const result = { state: 'pending' };
-      const status = reporter['convertStatus'](result as any);
-      expect(status).toBe('skipped');
-    });
-
-    it('should convert unknown status to TestStatusEnum.skipped', () => {
-      const result = { state: 'unknown' };
-      const status = reporter['convertStatus'](result as any);
-      expect(status).toBe('skipped');
-    });
-  });
 
   describe('Extracting Qase ID from test name', () => {
     it('should extract single Qase ID', () => {

--- a/qase-wdio/changelog.md
+++ b/qase-wdio/changelog.md
@@ -1,3 +1,10 @@
+# qase-wdio@1.1.4
+
+## What's new
+
+- Added support for status filter in the test run.
+- Improved error handling.
+
 # qase-wdio@1.1.2
 
 ## What's new

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -32,7 +32,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.4.1",
+    "qase-javascript-commons": "~2.4.2",
     "uuid": "^9.0.1",
     "@types/node": "^20.1.0",
     "@wdio/reporter": "^8.39.0",

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -21,6 +21,7 @@ import {
   TestResultType,
   TestStatusEnum,
   TestStepType,
+  determineTestStatus,
 } from 'qase-javascript-commons';
 
 import { v4 as uuidv4 } from 'uuid';
@@ -301,7 +302,19 @@ export default class WDIOQaseReporter extends WDIOReporter {
     }
 
     testResult.execution.duration = testResult.execution.start_time ? Math.round(end_time - testResult.execution.start_time) : 0;
-    testResult.execution.status = status;
+    
+    // Convert CompoundError to regular Error for status determination
+    let error: Error | null = null;
+    if (err) {
+      error = new Error(err.message || 'Test failed');
+      if (err.stacktrace) {
+        error.stack = err.stacktrace;
+      }
+    }
+    
+    // Determine status based on error type
+    testResult.execution.status = determineTestStatus(error, status);
+    
     testResult.execution.stacktrace = err === null ?
       null : err.stacktrace === undefined ?
         null : err.stacktrace;


### PR DESCRIPTION
This pull request introduces support for filtering test results by status across Qase JS reporters, improves error handling, and updates dependencies. The main changes enable users to exclude specific test statuses from reporting (like `passed`, `failed`, `skipped`, or `invalid`) via configuration, and enhance how errors are classified and reported. These updates are reflected in both the codebase and documentation.

**Status filtering and configuration support:**

* Added a `statusFilter` configuration option to allow filtering out test results by status before reporting. This is supported via environment variables and configuration files, with documentation and schema updates in `qase-javascript-commons` (`README.md`, `config-validation-schema.ts`, `env-enum.ts`, `env-to-config.ts`, `env-type.ts`, `env-validation-schema.ts`, `TestOpsOptionsType.ts`, `changelog.md`). [[1]](diffhunk://#diff-a86b9b2bf39ba11a85fcbbda1d3ef20cf0156c82eee3cd7acff6192547c7e3a7R62) [[2]](diffhunk://#diff-a86b9b2bf39ba11a85fcbbda1d3ef20cf0156c82eee3cd7acff6192547c7e3a7R101-R102) [[3]](diffhunk://#diff-a86b9b2bf39ba11a85fcbbda1d3ef20cf0156c82eee3cd7acff6192547c7e3a7R131-R133) [[4]](diffhunk://#diff-2b42981a145c5e36a847bd71def325e59262826aaa902f04896c3ceccf62ed5cR174-R181) [[5]](diffhunk://#diff-a422543bf5c529a2367c91915c783898fe75a9bc7dc1e7bfca25250ae04117d8R20) [[6]](diffhunk://#diff-daf99ab7abd6f779b2c9b45911b9e685aad35fdeac5a177966e0093c5c2db199R32) [[7]](diffhunk://#diff-dae907d0db2bd40c5dba07aa567d484b3a57da0bb6afbc631fbb24ce5325599eR26) [[8]](diffhunk://#diff-3b1f38bea6db6f09e5278c8fdc1206d313b4464cbc3958644aba588d1abda7a0R63-R66) [[9]](diffhunk://#diff-6cbeefa90e75a04bfb753e9fd8c69cbbe7afafcc66cc7c3b873d06035fc30fe6R11) [[10]](diffhunk://#diff-52f0da163733bdd7a580e506366bdc1f0dc9d4b727e3d061da2385ed7d86d770R1-R12)
* Implemented logic in `QaseReporter` to skip reporting results whose status matches the filter, with debug logging for filtered results (`qase-javascript-commons/src/qase.ts`). [[1]](diffhunk://#diff-bf5e5e0a0a05c3ddc53d346352e2e96cc31e4eb0278fdcd0a93ce5219d51b04cR360-R365) [[2]](diffhunk://#diff-bf5e5e0a0a05c3ddc53d346352e2e96cc31e4eb0278fdcd0a93ce5219d51b04cR399-R422)

**Error handling improvements:**

* Introduced the `determineTestStatus` utility to classify errors as assertion failures (`failed`) or other errors (`invalid`), and updated reporters to use this logic for more accurate status reporting (`test-status-utils.ts`, usages in `src/reporter.ts` and `src/storage.ts`). [[1]](diffhunk://#diff-bb483ea6d382d2d5a5c8dac8e1647b9a957d21a374b6f8c79fddd9054d7cbb16R1-R119) [[2]](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1R21) [[3]](diffhunk://#diff-efec16f566a83cc38003751fae999771a55cb5b4765edeb6df860afd59eea2e1L265-R266) [[4]](diffhunk://#diff-b70a3b5b898c3a7bd91062af6785c9f3a77927767b96fcbd4b2a93d3fe4ee0a1R21) [[5]](diffhunk://#diff-b70a3b5b898c3a7bd91062af6785c9f3a77927767b96fcbd4b2a93d3fe4ee0a1L193-R202)
* Added comprehensive tests for `determineTestStatus` to verify correct status assignment for different error types (`test/utils/test-status-utils.test.ts`).

**Dependency updates:**

* Updated `qase-javascript-commons` dependency to version `2.4.2` in both `cucumberjs-qase-reporter` and `cypress-qase-reporter` to bring in the new features and fixes (`package.json` in both packages). [[1]](diffhunk://#diff-1eb2b5a6fc55e1cd1bac74043ca9f57955736d82f4481c5af5ec361f3b8ea5c2L43-R43) [[2]](diffhunk://#diff-f50f25410e8641426bca1d154b56935d9f8ae5fcbce8c26b153cefcdbc5b7509L54-R54) [[3]](diffhunk://#diff-ceddde62b79232841e644c4ff2b16bedf8bfa08c98c3193e2e034bd8875d7f9cL3-R3)

**Documentation and changelog updates:**

* Updated changelogs and documentation to reflect new features, configuration options, and usage examples for status filtering and error handling improvements (`changelog.md` and `README.md` in all relevant packages). [[1]](diffhunk://#diff-3b18c0566f17bdd15fea91ee24dc404665d9094ce21d2a35c3e23d7c59c60cf6R1-R7) [[2]](diffhunk://#diff-2a371c9549af06539aa3565c286f4a826afe99ffec7641cecf8cbfe5253b198bR1-R7) [[3]](diffhunk://#diff-52f0da163733bdd7a580e506366bdc1f0dc9d4b727e3d061da2385ed7d86d770R1-R12) [[4]](diffhunk://#diff-a86b9b2bf39ba11a85fcbbda1d3ef20cf0156c82eee3cd7acff6192547c7e3a7R62) [[5]](diffhunk://#diff-a86b9b2bf39ba11a85fcbbda1d3ef20cf0156c82eee3cd7acff6192547c7e3a7R101-R102) [[6]](diffhunk://#diff-a86b9b2bf39ba11a85fcbbda1d3ef20cf0156c82eee3cd7acff6192547c7e3a7R131-R133)

These changes help users control which test results are reported and improve the accuracy of test status classification, making the reporters more robust and configurable.