### PR TITLE
refactor: remove unnecessary clearPreviousResults call in ReportReporter

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.4.3
+
+## What's new
+
+Fixed an issue with the `report` mode not sending results.
+
 # qase-javascript-commons@2.4.2
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/report-reporter.ts
+++ b/qase-javascript-commons/src/reporters/report-reporter.ts
@@ -91,8 +91,6 @@ export class ReportReporter extends AbstractReporter {
   }
 
   public async complete(): Promise<void> {
-    this.writer.clearPreviousResults();
-
     const report: Report = {
       title: 'Test report',
       execution: {

--- a/qase-javascript-commons/test/reporters/report-reporter.test.ts
+++ b/qase-javascript-commons/test/reporters/report-reporter.test.ts
@@ -61,8 +61,6 @@ describe('ReportReporter', () => {
     reporter['results'] = [testResult];
     await reporter.sendResults();
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(writer.clearPreviousResults).toHaveBeenCalled();
-    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(writer.writeAttachment).toHaveBeenCalled();
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(writer.writeTestResult).toHaveBeenCalledWith(expect.objectContaining({ id: 't1' }));
@@ -95,8 +93,6 @@ describe('ReportReporter', () => {
   it('should write report and log path on complete', async () => {
     reporter['results'] = [];
     await reporter.complete();
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(writer.clearPreviousResults).toHaveBeenCalled();
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(writer.writeReport).toHaveBeenCalled();
     // eslint-disable-next-line @typescript-eslint/unbound-method


### PR DESCRIPTION
- Eliminated the clearPreviousResults method call in the complete function of ReportReporter to streamline the reporting process.