### PR TITLE
feat: add status mapping support for test results

### DIFF
--- a/qase-javascript-commons/README.md
+++ b/qase-javascript-commons/README.md
@@ -40,6 +40,7 @@ All configuration options are listed in the table below:
 | Root suite                                                                                                            | `rootSuite`                | `QASE_ROOT_SUITE`               | undefined                               | No       | Any string                 |
 | Enable debug logs                                                                                                     | `debug`                    | `QASE_DEBUG`                    | `False`                                 | No       | `True`, `False`            |
 | Enable capture logs from `stdout` and `stderr`                                                                        | `testops.defect`           | `QASE_CAPTURE_LOGS`             | `False`                                 | No       | `True`, `False`            |
+| Map test result statuses to different values (format: `fromStatus=toStatus`)                                          | `statusMapping`                     | `QASE_STATUS_MAPPING`                    | undefined                               | No       | Object mapping statuses (e.g., `{"invalid": "failed", "skipped": "passed"}`) |
 | **Qase Report configuration**                                                                                         |                            |                                 |                                         |          |                            |
 | Driver used for report mode                                                                                           | `report.driver`            | `QASE_REPORT_DRIVER`            | `local`                                 | No       | `local`                    |
 | Path to save the report                                                                                               | `report.connection.path`   | `QASE_REPORT_CONNECTION_PATH`   | `./build/qase-report`                   |          |                            |
@@ -72,6 +73,10 @@ All configuration options are listed in the table below:
   "debug": false,
   "environment": "local",
   "captureLogs": false,
+  "statusMapping": {
+    "invalid": "failed",
+    "skipped": "passed"
+  },
   "report": {
     "driver": "local",
     "connection": {
@@ -131,4 +136,7 @@ export QASE_TESTOPS_RUN_EXTERNAL_LINK='{"type":"jiraServer","link":"PROJ-456"}'
 
 # Filter out test results with specific statuses
 export QASE_TESTOPS_STATUS_FILTER="passed,failed"
+
+# Map test result statuses
+export QASE_STATUS_MAPPING="invalid=failed,skipped=passed"
 ```

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.4.5
+
+## What's new
+
+Added support for status mapping in the test run.
+You can now map test result statuses to different values.
+
 # qase-javascript-commons@2.4.4
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/config/config-validation-schema.ts
+++ b/qase-javascript-commons/src/config/config-validation-schema.ts
@@ -36,6 +36,14 @@ export const configValidationSchema = {
       nullable: true,
     },
 
+    statusMapping: {
+      type: 'object',
+      nullable: true,
+      additionalProperties: {
+        type: 'string',
+      },
+    },
+
     testops: {
       type: 'object',
       nullable: true,

--- a/qase-javascript-commons/src/env/env-enum.ts
+++ b/qase-javascript-commons/src/env/env-enum.ts
@@ -8,6 +8,7 @@ export enum EnvEnum {
   environment = 'QASE_ENVIRONMENT',
   captureLogs = 'QASE_CAPTURE_LOGS',
   rootSuite = 'QASE_ROOT_SUITE',
+  statusMapping = 'QASE_STATUS_MAPPING',
 }
 
 /**

--- a/qase-javascript-commons/src/env/env-to-config.ts
+++ b/qase-javascript-commons/src/env/env-to-config.ts
@@ -25,6 +25,13 @@ export const envToConfig = (env: EnvType): ConfigType => ({
   environment: env[EnvEnum.environment],
   captureLogs: env[EnvEnum.captureLogs],
   rootSuite: env[EnvEnum.rootSuite],
+  statusMapping: env[EnvEnum.statusMapping] ? 
+    Object.fromEntries(
+      env[EnvEnum.statusMapping].split(',').map(item => {
+        const [from, to] = item.split('=');
+        return [from?.trim() || '', to?.trim() || ''];
+      })
+    ) : undefined,
 
   testops: {
     project: env[EnvTestOpsEnum.project],

--- a/qase-javascript-commons/src/env/env-type.ts
+++ b/qase-javascript-commons/src/env/env-type.ts
@@ -19,6 +19,7 @@ export interface EnvType {
   [EnvEnum.environment]?: string;
   [EnvEnum.captureLogs]?: boolean;
   [EnvEnum.rootSuite]?: string;
+  [EnvEnum.statusMapping]?: string;
 
   [EnvTestOpsEnum.project]?: string;
   [EnvTestOpsEnum.uploadAttachments]?: boolean;

--- a/qase-javascript-commons/src/env/env-validation-schema.ts
+++ b/qase-javascript-commons/src/env/env-validation-schema.ts
@@ -47,6 +47,10 @@ export const envValidationSchema: JSONSchemaType<EnvType> = {
       type: 'string',
       nullable: true,
     },
+    [EnvEnum.statusMapping]: {
+      type: 'string',
+      nullable: true,
+    },
 
     [EnvTestOpsEnum.project]: {
       type: 'string',

--- a/qase-javascript-commons/src/options/options-type.ts
+++ b/qase-javascript-commons/src/options/options-type.ts
@@ -29,6 +29,7 @@ export type OptionsType = {
   debug?: boolean | undefined;
   environment?: string | undefined;
   rootSuite?: string | undefined;
+  statusMapping?: Record<string, string> | undefined;
   testops?:
     | RecursivePartial<TestOpsOptionsType>
     | undefined;

--- a/qase-javascript-commons/src/utils/status-mapping-utils.ts
+++ b/qase-javascript-commons/src/utils/status-mapping-utils.ts
@@ -1,0 +1,52 @@
+import { TestStatusEnum } from '../models/test-execution';
+
+/**
+ * Applies status mapping configuration to a test status
+ * @param status - Original test status
+ * @param statusMapping - Status mapping configuration
+ * @returns Mapped test status or original if no mapping found
+ */
+export function applyStatusMapping(
+  status: TestStatusEnum, 
+  statusMapping?: Record<string, string>
+): TestStatusEnum {
+  if (!statusMapping) {
+    return status;
+  }
+
+  const mappedStatus = statusMapping[status];
+  if (!mappedStatus) {
+    return status;
+  }
+
+  // Validate that the mapped status is a valid TestStatusEnum value
+  const validStatuses = Object.values(TestStatusEnum);
+  if (!validStatuses.includes(mappedStatus as TestStatusEnum)) {
+    console.warn(`Invalid status mapping: "${status}" -> "${mappedStatus}". Valid statuses are: ${validStatuses.join(', ')}`);
+    return status;
+  }
+
+  return mappedStatus as TestStatusEnum;
+}
+
+/**
+ * Validates status mapping configuration
+ * @param statusMapping - Status mapping configuration to validate
+ * @returns Array of validation errors (empty if valid)
+ */
+export function validateStatusMapping(statusMapping: Record<string, string>): string[] {
+  const errors: string[] = [];
+  const validStatuses = Object.values(TestStatusEnum);
+
+  for (const [fromStatus, toStatus] of Object.entries(statusMapping)) {
+    if (!validStatuses.includes(fromStatus as TestStatusEnum)) {
+      errors.push(`Invalid source status "${fromStatus}". Valid statuses are: ${validStatuses.join(', ')}`);
+    }
+    
+    if (!validStatuses.includes(toStatus as TestStatusEnum)) {
+      errors.push(`Invalid target status "${toStatus}". Valid statuses are: ${validStatuses.join(', ')}`);
+    }
+  }
+
+  return errors;
+}

--- a/qase-javascript-commons/test/utils/status-mapping-utils.test.ts
+++ b/qase-javascript-commons/test/utils/status-mapping-utils.test.ts
@@ -1,0 +1,90 @@
+import { expect } from '@jest/globals';
+import { applyStatusMapping, validateStatusMapping } from '../../src/utils/status-mapping-utils';
+import { TestStatusEnum } from '../../src/models/test-execution';
+
+describe('status-mapping-utils', () => {
+  describe('applyStatusMapping', () => {
+    it('should return original status when no mapping provided', () => {
+      const result = applyStatusMapping(TestStatusEnum.passed);
+      expect(result).toBe(TestStatusEnum.passed);
+    });
+
+    it('should return original status when mapping is undefined', () => {
+      const result = applyStatusMapping(TestStatusEnum.passed, undefined);
+      expect(result).toBe(TestStatusEnum.passed);
+    });
+
+    it('should apply mapping when configured', () => {
+      const statusMapping = {
+        [TestStatusEnum.invalid]: TestStatusEnum.failed,
+        [TestStatusEnum.skipped]: TestStatusEnum.passed,
+      };
+      
+      const result1 = applyStatusMapping(TestStatusEnum.invalid, statusMapping);
+      expect(result1).toBe(TestStatusEnum.failed);
+      
+      const result2 = applyStatusMapping(TestStatusEnum.skipped, statusMapping);
+      expect(result2).toBe(TestStatusEnum.passed);
+    });
+
+    it('should return original status when no mapping found', () => {
+      const statusMapping = {
+        [TestStatusEnum.invalid]: TestStatusEnum.failed,
+      };
+      
+      const result = applyStatusMapping(TestStatusEnum.passed, statusMapping);
+      expect(result).toBe(TestStatusEnum.passed);
+    });
+
+    it('should handle invalid mapping gracefully', () => {
+      const invalidMapping = {
+        [TestStatusEnum.passed]: 'invalid_status',
+      };
+      
+      const result = applyStatusMapping(TestStatusEnum.passed, invalidMapping);
+      expect(result).toBe(TestStatusEnum.passed);
+    });
+  });
+
+  describe('validateStatusMapping', () => {
+    it('should return empty array for valid mapping', () => {
+      const validMapping = {
+        [TestStatusEnum.invalid]: TestStatusEnum.failed,
+        [TestStatusEnum.skipped]: TestStatusEnum.passed,
+      };
+      
+      const errors = validateStatusMapping(validMapping);
+      expect(errors).toEqual([]);
+    });
+
+    it('should return errors for invalid source status', () => {
+      const invalidMapping = {
+        'invalid_source': TestStatusEnum.failed,
+      };
+      
+      const errors = validateStatusMapping(invalidMapping);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('Invalid source status');
+    });
+
+    it('should return errors for invalid target status', () => {
+      const invalidMapping = {
+        [TestStatusEnum.passed]: 'invalid_target',
+      };
+      
+      const errors = validateStatusMapping(invalidMapping);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('Invalid target status');
+    });
+
+    it('should return multiple errors for multiple invalid mappings', () => {
+      const invalidMapping = {
+        'invalid_source': 'invalid_target',
+        [TestStatusEnum.passed]: 'another_invalid_target',
+      };
+      
+      const errors = validateStatusMapping(invalidMapping);
+      expect(errors).toHaveLength(3);
+    });
+  });
+});


### PR DESCRIPTION
- Introduced a new feature to map test result statuses to different values, enhancing flexibility in test reporting.
- Updated configuration options to include `statusMapping`, allowing users to define custom status mappings.
- Implemented utility functions for applying and validating status mappings.
- Enhanced documentation and examples in the README and changelog to reflect the new functionality.

 #834