### PR TITLE
chore: bump version to 2.4.8 and update changelog

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.4.8
+
+## What's new
+
+Improved error handling for timeout errors.
+
 # qase-javascript-commons@2.4.7
 
 ## Bug fixes

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/utils/test-status-utils.ts
+++ b/qase-javascript-commons/src/utils/test-status-utils.ts
@@ -71,12 +71,26 @@ function isAssertionError(error: Error): boolean {
     'internal error'
   ];
 
-  // Check for non-assertion patterns first
-  const hasNonAssertionPattern = nonAssertionPatterns.some(pattern => 
+  // Special case: timeout errors with expect should be treated as assertion errors
+  const isTimeoutWithExpect = errorMessage.includes('timeout') && 
+    errorMessage.includes('expect');
+
+  if (isTimeoutWithExpect) {
+    return true;
+  }
+
+  // Check for non-assertion patterns (excluding timeout for special handling above)
+  const nonAssertionPatternsWithoutTimeout = nonAssertionPatterns.filter(pattern => pattern !== 'timeout');
+  const hasNonAssertionPattern = nonAssertionPatternsWithoutTimeout.some(pattern => 
     errorMessage.includes(pattern) || errorStack.includes(pattern)
   );
 
   if (hasNonAssertionPattern) {
+    return false;
+  }
+
+  // For timeout errors without expect, treat as invalid
+  if (errorMessage.includes('timeout')) {
     return false;
   }
 

--- a/qase-javascript-commons/test/utils/test-status-utils.test.ts
+++ b/qase-javascript-commons/test/utils/test-status-utils.test.ts
@@ -68,6 +68,18 @@ describe('determineTestStatus', () => {
       const result = determineTestStatus(error, 'failed');
       expect(result).toBe(TestStatusEnum.failed);
     });
+
+    it('should return failed for timeout error with expect assertion', () => {
+      const error = new Error('Error: Timed out 5000ms waiting for expect(locator).toBeVisible()');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for timeout error with expect and toBe', () => {
+      const error = new Error('Timeout of 5000ms exceeded waiting for expect(element).toBe(true)');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
   });
 
   describe('when non-assertion error', () => {
@@ -77,8 +89,26 @@ describe('determineTestStatus', () => {
       expect(result).toBe(TestStatusEnum.invalid);
     });
 
-    it('should return invalid for timeout error', () => {
+    it('should return invalid for timeout error without assertion patterns', () => {
       const error = new Error('Timeout of 5000ms exceeded');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.invalid);
+    });
+
+    it('should return invalid for timeout error with network context', () => {
+      const error = new Error('Timeout waiting for network request');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.invalid);
+    });
+
+    it('should return invalid for timeout error with toBe pattern (no expect)', () => {
+      const error = new Error('Timeout waiting for element.toBe(true)');
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.invalid);
+    });
+
+    it('should return invalid for timeout error with matcher pattern (no expect)', () => {
+      const error = new Error('Timed out 5000ms waiting for element.toContain("text")');
       const result = determineTestStatus(error, 'failed');
       expect(result).toBe(TestStatusEnum.invalid);
     });


### PR DESCRIPTION
- Updated version from 2.4.7 to 2.4.8 in package.json.
- Added a changelog entry for improved error handling of timeout errors.
- Enhanced test-status-utils to treat timeout errors with expect as assertion errors.
- Added new tests to verify the behavior of timeout errors in various scenarios.