### PR TITLE
chore: bump version to 2.1.6 and update changelog

### DIFF
--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,9 @@
+# qase-cucumberjs@2.1.6
+
+## Bug fixes
+
+Fixed issue where cucumber-specific statuses like `AMBIGUOUS` were incorrectly mapped using generic status mapping instead of cucumber-specific mapping. Now cucumber-specific statuses are properly mapped according to cucumberjs conventions.
+
 # qase-cucumberjs@2.1.5
 
 ## What's new

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/messages": "^22.0.0",
-    "qase-javascript-commons": "~2.4.2"
+    "qase-javascript-commons": "~2.4.8"
   },
   "peerDependencies": {
     "@cucumber/cucumber": ">=7.0.0"

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -199,7 +199,7 @@ export class Storage {
     }
     
     // Determine status based on error type
-    const newStatus = determineTestStatus(error, testCaseStep.testStepResult.status);
+    const newStatus = determineTestStatus(error, Storage.statusMap[testCaseStep.testStepResult.status]);
 
     this.testCaseSteps[testCaseStep.testStepId] = testCaseStep;
 
@@ -214,7 +214,7 @@ export class Storage {
       }
 
       if (oldStatus) {
-        if (oldStatus !== TestStatusEnum.failed) {
+        if (oldStatus !== TestStatusEnum.failed && oldStatus !== TestStatusEnum.invalid) {
           this.testCaseStartedResult[testCaseStep.testCaseStartedId] = newStatus;
         }
       } else {
@@ -278,6 +278,8 @@ export class Storage {
       }
     }
 
+    const steps = this.convertSteps(pickle.steps, tc);
+
     return {
       attachments: this.attachments[testCase.testCaseStartedId] ?? [],
       author: null,
@@ -297,7 +299,7 @@ export class Storage {
       relations: relations,
       run_id: null,
       signature: this.getSignature(pickle, metadata.ids),
-      steps: this.convertSteps(pickle.steps, tc),
+      steps: steps,
       testops_id: metadata.ids.length > 0 ? metadata.ids : null,
       id: tcs.id,
       title: metadata.title ?? pickle.name,
@@ -359,7 +361,7 @@ export class Storage {
     [Status.PASSED]: TestStatusEnum.passed,
     [Status.FAILED]: TestStatusEnum.failed,
     [Status.SKIPPED]: TestStatusEnum.skipped,
-    [Status.AMBIGUOUS]: TestStatusEnum.failed,
+    [Status.AMBIGUOUS]: TestStatusEnum.invalid,
     [Status.PENDING]: TestStatusEnum.skipped,
     [Status.UNDEFINED]: TestStatusEnum.skipped,
     [Status.UNKNOWN]: TestStatusEnum.skipped,


### PR DESCRIPTION
- Updated version from 2.1.5 to 2.1.6 in package.json.
- Added changelog entry for bug fix addressing incorrect mapping of cucumber-specific statuses.
- Adjusted status mapping logic in storage.ts to ensure proper handling of `AMBIGUOUS` status.