### PR TITLE
chore: bump version to 1.1.6 and update changelog

### DIFF
--- a/qase-mocha/changelog.md
+++ b/qase-mocha/changelog.md
@@ -1,3 +1,9 @@
+# qase-mocha@1.1.6
+
+## What's new
+
+- Improved the handling of extra reporters in the reporter.
+
 # qase-mocha@1.1.5
 
 ## What's new

--- a/qase-mocha/docs/usage.md
+++ b/qase-mocha/docs/usage.md
@@ -277,7 +277,7 @@ The Qase reporter supports additional reporters alongside the main Qase reporter
 
 ### Configuration
 
-You can configure extra reporters using the `extraReporters` option in the reporter options:
+You can configure extra reporters using the `extraReporters` option in the `qase.config.json` file or via command line:
 
 #### Command Line
 
@@ -292,43 +292,24 @@ QASE_MODE=testops mocha --reporter mocha-qase-reporter --reporter-options extraR
 QASE_MODE=testops mocha --reporter mocha-qase-reporter --reporter-options extraReporters=spec --parallel
 ```
 
-#### Configuration File
+#### qase.config.json
 
 ```json
 {
-  "reporter": "mocha-qase-reporter",
-  "reporterOptions": {
-    "extraReporters": "spec"
-  }
-}
-```
-
-#### Multiple Reporters
-
-```json
-{
-  "reporter": "mocha-qase-reporter",
-  "reporterOptions": {
-    "extraReporters": ["spec", "json"]
-  }
-}
-```
-
-#### Reporters with Options
-
-```json
-{
-  "reporter": "mocha-qase-reporter",
-  "reporterOptions": {
-    "extraReporters": [
-      "spec",
-      {
-        "name": "json",
-        "options": {
-          "output": "results.json"
-        }
+  "extraReporters": [
+    "spec",
+    {
+      "name": "json",
+      "options": {
+        "output": "results.json"
       }
-    ]
+    }
+  ],
+  "testops": {
+    "api": {
+      "token": "your-api-token"
+    },
+    "project": "your-project"
   }
 }
 ```

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -79,7 +79,7 @@ export class MochaQaseReporter extends reporters.Base {
     const config = configLoader.load();
 
     // Parse and validate extraReporters configuration
-    const extraReportersConfig = parseExtraReporters(options);
+    const extraReportersConfig = parseExtraReporters(options, config || undefined);
 
     this.reporter = QaseReporter.getInstance({
       ...composeOptions(options, config),


### PR DESCRIPTION
- Updated version from 1.1.5 to 1.1.6 in package.json.
- Enhanced the handling of extra reporters in the reporter, allowing configuration from both Mocha options and qase.config.json.
- Updated documentation to reflect changes in extra reporters configuration.