### PR TITLE
chore: bump version to 2.4.10 and update changelog

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.4.10
+
+## What's new
+
+Fixed an issue with report link for enterprise customers.
+
 # qase-javascript-commons@2.4.9
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/client/clientV1.ts
+++ b/qase-javascript-commons/src/client/clientV1.ts
@@ -25,7 +25,7 @@ import FormData from 'form-data';
 
 const DEFAULT_API_HOST = 'qase.io';
 const API_BASE_URL = 'https://api-';
-const APP_BASE_URL = 'https://app-';
+const APP_BASE_URL = 'https://';
 const API_VERSION = '/v1';
 
 enum ApiErrorCode {


### PR DESCRIPTION
- Updated version from 2.4.9 to 2.4.10 in package.json.
- Added changelog entry for fixing report link issue for enterprise customers.
- Adjusted APP_BASE_URL in clientV1.ts for improved URL handling.