### PR TITLE
chore: bump version to 1.1.7 and enhance extra reporters handling

### DIFF
--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-mocha/src/extraReporters.ts
+++ b/qase-mocha/src/extraReporters.ts
@@ -101,20 +101,14 @@ export function createExtraReporters(
         // Create reporter instance with clean options (without main reporter options)
         const cleanOptions = {
           ...options,
-          // Remove main reporter specific options
+          // Remove main reporter property
           reporter: undefined,
-          reporterOptions: undefined,
-          'reporter-option': undefined,
-          reporterOption: undefined,
-          // Add extra reporter specific options
-          ...reporterOptions
+          // Add extra reporter specific options to all reporter option properties
+          // This ensures compatibility with different reporters that may expect different property names
+          reporterOptions,
+          reporterOption: reporterOptions,
+          'reporter-option': reporterOptions
         };
-        
-        // Special handling for JSON reporter
-        if (reporterName === 'json' && reporterOptions['output']) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          (cleanOptions as any).reporterOption = { output: reporterOptions['output'] };
-        }
         
         const reporter = new ReporterClass(runner, cleanOptions);
         reporters.push(reporter);


### PR DESCRIPTION
- Updated version from 1.1.6 to 1.1.7 in package.json.
- Improved the handling of extra reporter options to ensure compatibility with different reporter configurations.
- Streamlined the removal of main reporter specific options and added support for various reporter option properties.

These changes enhance the flexibility and usability of the mocha-qase-reporter.

Fixed #858