### PR TITLE
chore: bump version to 2.4.11 and add retry mechanism for attachment uploads

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.4.11
+
+## What's new
+
+Added retry mechanism for uploading attachments.
+
 # qase-javascript-commons@2.4.10
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Updated version from 2.4.10 to 2.4.11 in package.json.
- Added a retry mechanism for uploading attachments to handle rate limiting.
- Implemented delay between requests to avoid hitting rate limits.

These changes improve the reliability of attachment uploads in the client.