### PR TITLE
chore: bump version to 1.1.1 and update custom fields API documentation

### DIFF
--- a/qase-api-client/docs/CustomFieldsApi.md
+++ b/qase-api-client/docs/CustomFieldsApi.md
@@ -5,10 +5,10 @@ All URIs are relative to *https://api.qase.io/v1*
 |Method | HTTP request | Description|
 |------------- | ------------- | -------------|
 |[**createCustomField**](#createcustomfield) | **POST** /custom_field | Create new Custom Field|
-|[**deleteCustomField**](#deletecustomfield) | **DELETE** /custom_field/{id} | Delete Custom Field by id|
-|[**getCustomField**](#getcustomfield) | **GET** /custom_field/{id} | Get Custom Field by id|
+|[**deleteCustomField**](#deletecustomfield) | **DELETE** /custom_field/{id} | Delete Custom Field|
+|[**getCustomField**](#getcustomfield) | **GET** /custom_field/{id} | Get Custom Field|
 |[**getCustomFields**](#getcustomfields) | **GET** /custom_field | Get all Custom Fields|
-|[**updateCustomField**](#updatecustomfield) | **PATCH** /custom_field/{id} | Update Custom Field by id|
+|[**updateCustomField**](#updatecustomfield) | **PATCH** /custom_field/{id} | Update Custom Field|
 
 # **createCustomField**
 > IdResponse createCustomField(customFieldCreate)

--- a/qase-api-client/package.json
+++ b/qase-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Qase TMS Javascript API V1 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-api-client/src/api/attachments-api.ts
+++ b/qase-api-client/src/api/attachments-api.ts
@@ -12,7 +12,6 @@
  * Do not edit the class manually.
  */
 
-
 import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
 import { Configuration } from '../configuration';
 // Some imports not used depending on template conditions
@@ -182,9 +181,9 @@ export const AttachmentsApiAxiosParamCreator = function (configuration?: Configu
       if (file) {
         file.forEach((element) => {
           if (element?.name !== undefined && element?.value !== undefined) {
-            localVarFormParams.append('file', element.value, element.name);
+            localVarFormParams.append('file[]', element.value, element.name);
           } else {
-            localVarFormParams.append('file', element as any);
+            localVarFormParams.append('file[]', element as any);
           }
         });
       }

--- a/qase-api-client/src/api/custom-fields-api.ts
+++ b/qase-api-client/src/api/custom-fields-api.ts
@@ -78,7 +78,7 @@ export const CustomFieldsApiAxiosParamCreator = function (configuration?: Config
         },
         /**
          * This method allows to delete custom field. 
-         * @summary Delete Custom Field by id
+         * @summary Delete Custom Field
          * @param {number} id Identifier.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -115,7 +115,7 @@ export const CustomFieldsApiAxiosParamCreator = function (configuration?: Config
         },
         /**
          * This method allows to retrieve custom field. 
-         * @summary Get Custom Field by id
+         * @summary Get Custom Field
          * @param {number} id Identifier.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -205,7 +205,7 @@ export const CustomFieldsApiAxiosParamCreator = function (configuration?: Config
         },
         /**
          * This method allows to update custom field. 
-         * @summary Update Custom Field by id
+         * @summary Update Custom Field
          * @param {number} id Identifier.
          * @param {CustomFieldUpdate} customFieldUpdate 
          * @param {*} [options] Override http request option.
@@ -269,7 +269,7 @@ export const CustomFieldsApiFp = function(configuration?: Configuration) {
         },
         /**
          * This method allows to delete custom field. 
-         * @summary Delete Custom Field by id
+         * @summary Delete Custom Field
          * @param {number} id Identifier.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -280,7 +280,7 @@ export const CustomFieldsApiFp = function(configuration?: Configuration) {
         },
         /**
          * This method allows to retrieve custom field. 
-         * @summary Get Custom Field by id
+         * @summary Get Custom Field
          * @param {number} id Identifier.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -305,7 +305,7 @@ export const CustomFieldsApiFp = function(configuration?: Configuration) {
         },
         /**
          * This method allows to update custom field. 
-         * @summary Update Custom Field by id
+         * @summary Update Custom Field
          * @param {number} id Identifier.
          * @param {CustomFieldUpdate} customFieldUpdate 
          * @param {*} [options] Override http request option.
@@ -337,7 +337,7 @@ export const CustomFieldsApiFactory = function (configuration?: Configuration, b
         },
         /**
          * This method allows to delete custom field. 
-         * @summary Delete Custom Field by id
+         * @summary Delete Custom Field
          * @param {number} id Identifier.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -347,7 +347,7 @@ export const CustomFieldsApiFactory = function (configuration?: Configuration, b
         },
         /**
          * This method allows to retrieve custom field. 
-         * @summary Get Custom Field by id
+         * @summary Get Custom Field
          * @param {number} id Identifier.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -370,7 +370,7 @@ export const CustomFieldsApiFactory = function (configuration?: Configuration, b
         },
         /**
          * This method allows to update custom field. 
-         * @summary Update Custom Field by id
+         * @summary Update Custom Field
          * @param {number} id Identifier.
          * @param {CustomFieldUpdate} customFieldUpdate 
          * @param {*} [options] Override http request option.
@@ -403,7 +403,7 @@ export class CustomFieldsApi extends BaseAPI {
 
     /**
      * This method allows to delete custom field. 
-     * @summary Delete Custom Field by id
+     * @summary Delete Custom Field
      * @param {number} id Identifier.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -415,7 +415,7 @@ export class CustomFieldsApi extends BaseAPI {
 
     /**
      * This method allows to retrieve custom field. 
-     * @summary Get Custom Field by id
+     * @summary Get Custom Field
      * @param {number} id Identifier.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -442,7 +442,7 @@ export class CustomFieldsApi extends BaseAPI {
 
     /**
      * This method allows to update custom field. 
-     * @summary Update Custom Field by id
+     * @summary Update Custom Field
      * @param {number} id Identifier.
      * @param {CustomFieldUpdate} customFieldUpdate 
      * @param {*} [options] Override http request option.

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,10 @@
+# qase-javascript-commons@2.4.13
+
+## What's new
+
+Improved the upload mechanism for attachments.
+Now the reporter will upload attachments in batches of 20 files.
+
 # qase-javascript-commons@2.4.12
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.12",
+  "version": "2.4.13",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -33,8 +33,8 @@
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
     "mime-types": "^2.1.35",
-    "qase-api-client": "~1.1.0",
-    "qase-api-v2-client": "~1.0.3",
+    "qase-api-client": "~1.1.1",
+    "qase-api-v2-client": "~1.0.4",
     "strip-ansi": "^6.0.1",
     "uuid": "^9.0.1"
   },


### PR DESCRIPTION
- Updated version from 1.1.0 to 1.1.1 in package.json.
- Enhanced custom fields API documentation by removing redundant "by id" phrases for clarity.
- Improved attachment upload mechanism to support batch uploads of up to 20 files, with size limits enforced.

These changes enhance the API's usability and improve the efficiency of attachment uploads.