### PR TITLE
chore: bump version to 3.1.1 and fix skipped test reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,22 @@
         "typescript": "^5.9.3"
       }
     },
+    "examples/cypressBadeballCucumber/node_modules/cypress-qase-reporter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cypress-qase-reporter/-/cypress-qase-reporter-3.1.0.tgz",
+      "integrity": "sha512-nZNIsbPpq2xDuPeAH67V/ESsqim/vcooFrK0Q7XwB50b6AF4jD9R+/xU2rhl8KWVrRug9VtDZjZ7tOEI1GBdBA==",
+      "dev": true,
+      "dependencies": {
+        "qase-javascript-commons": "~2.4.5",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "cypress": ">=8.0.0"
+      }
+    },
     "examples/cypressCucumber": {
       "name": "cypress-cucumber",
       "devDependencies": {
@@ -20390,7 +20406,7 @@
       }
     },
     "qase-api-client": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.13.2",
@@ -21438,7 +21454,7 @@
       }
     },
     "qase-api-v2-client": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.13.2",
@@ -22509,10 +22525,10 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.4.10",
+        "qase-javascript-commons": "~2.4.13",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -22688,7 +22704,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.4.10",
+      "version": "2.4.13",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -22700,8 +22716,8 @@
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "mime-types": "^2.1.35",
-        "qase-api-client": "~1.1.0",
-        "qase-api-v2-client": "~1.0.3",
+        "qase-api-client": "~1.1.1",
+        "qase-api-v2-client": "~1.0.4",
         "strip-ansi": "^6.0.1",
         "uuid": "^9.0.1"
       },
@@ -22767,7 +22783,7 @@
     },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "deasync-promise": "^1.0.1",

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,9 @@
+# cypress-qase-reporter@3.1.1
+
+## What's new
+
+- Fixed an issue where the reporter was not reporting skipped tests due to failing beforeEach hooks.
+
 # cypress-qase-reporter@3.1.0
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -51,7 +51,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.4.10",
+    "qase-javascript-commons": "~2.4.13",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
- Updated version from 3.1.0 to 3.1.1 in package.json.
- Enhanced the reporter to correctly report skipped tests when beforeEach hooks fail.
- Updated changelog to reflect the new version and changes.

These improvements enhance the accuracy of test reporting in the Cypress Qase Reporter.