### PR TITLE
refactor: update test cases to use addQaseId and improve attachment handling

### DIFF
--- a/examples/vitest/suite01/simple.test.ts
+++ b/examples/vitest/suite01/simple.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { qase } from 'vitest-qase-reporter/vitest';
+import { addQaseId } from 'vitest-qase-reporter/vitest';
 
 describe('Suite 01 - Basic Test Examples', () => {
-  it(qase(1, 'should pass basic assertion'), () => {
+  it(addQaseId('should pass basic assertion', [1]), () => {
     expect(1 + 1).toBe(2);
   });
 
-  it(qase(2, 'should fail basic assertion'), () => {
+  it(addQaseId('should fail basic assertion', [2]), () => {
     expect(1 + 1).toBe(3);
   });
 
-  it.skip(qase(3, 'should be skipped'), () => {
+  it.skip(addQaseId('should be skipped', [3]), () => {
     expect(true).toBe(true);
   });
 
-  it(qase(4, 'test with multiple calculations'), () => {
+  it(addQaseId('test with multiple calculations', [4]), () => {
     expect(Math.max(1, 2, 3)).toBe(3);
     expect(Math.min(1, 2, 3)).toBe(1);
   });

--- a/examples/vitest/suite02/simple2.test.ts
+++ b/examples/vitest/suite02/simple2.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, test, expect } from 'vitest';
-import { qase, withQase } from 'vitest-qase-reporter/vitest';
+import { addQaseId, withQase } from 'vitest-qase-reporter/vitest';
 
 describe('Suite 02 - Advanced Test Examples', () => {
-  test(qase(10, 'should demonstrate withQase annotations'), withQase(async ({ qase }) => {
+  test(addQaseId('should demonstrate withQase annotations', [10]), withQase(async ({ qase }) => {
     await qase.title('Advanced test with annotations');
     await qase.comment('This test demonstrates advanced Qase features');
     await qase.suite('Advanced Test Suite from annotations');
@@ -22,17 +22,17 @@ describe('Suite 02 - Advanced Test Examples', () => {
     });
   }));
 
-  it(qase(11, 'should demonstrate priority field'), withQase(async ({ qase }) => {
+  it(addQaseId('should demonstrate priority field', [11]), withQase(async ({ qase }) => {
     await qase.fields({ priority: 'high' });
     expect(1 + 1).toBe(2);
   }));
 
-  it(qase(12, 'should demonstrate severity field'), withQase(async ({ qase }) => {
+  it(addQaseId('should demonstrate severity field', [12]), withQase(async ({ qase }) => {
     await qase.fields({ severity: 'critical' });
     expect(1 + 1).toBe(2);
   }));
 
-  it(qase(13, 'should demonstrate layer field'), withQase(async ({ qase }) => {
+  it(addQaseId('should demonstrate layer field', [13]), withQase(async ({ qase }) => {
     await qase.fields({ layer: 'e2e' });
     expect(1 + 1).toBe(2);
   }));

--- a/examples/vitest/test/attach.test.ts
+++ b/examples/vitest/test/attach.test.ts
@@ -18,7 +18,7 @@ describe("Example: attach.test.ts", () => {
     await qase.attach({
       name: "attachment.txt",
       content: "Hello, world!",
-      contentType: "text/plain",
+      type: "text/plain",
     });
 
     expect(true).toBe(true);

--- a/examples/vitest/test/e2e.test.ts
+++ b/examples/vitest/test/e2e.test.ts
@@ -59,7 +59,7 @@ describe("Example: E2E Testing with Qase", () => {
       await qase.attach({
         name: "dashboard-screenshot.png",
         content: screenshot,
-        contentType: "image/png"
+        type: "image/png"
       });
     });
   }));

--- a/examples/vitest/test/for.test.ts
+++ b/examples/vitest/test/for.test.ts
@@ -1,0 +1,26 @@
+import { withQase } from "vitest-qase-reporter/vitest";
+import { describe, it, expect } from "vitest";
+
+describe("For loop example", () => {
+  it.for([
+    { id: 100, name: "Should be true" },
+    { id: 200, name: "Should be false" },
+  ])(
+    "Should be true (Qase ID: $id)",
+    ((params: { id: number; name: string }, context: { annotate: any }) => {
+      const testFn = withQase<[{ id: number; name: string }]>(async ({ qase, name }) => {
+        console.log(name);
+
+        await qase.step(name, () => {
+          expect(true).toBe(true);
+        });
+
+        await qase.step(name, () => {
+          expect(false).toBe(true);
+        });
+      });
+      // Combine params from it.for with Vitest context
+      return testFn({ ...params, annotate: context.annotate });
+    }) as any
+  );
+});

--- a/examples/vitest/test/id.test.ts
+++ b/examples/vitest/test/id.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect } from 'vitest';
-import { qase, withQase } from 'vitest-qase-reporter/vitest';
+import { addQaseId } from 'vitest-qase-reporter/vitest';
 
 describe("Example: id.test.ts", () => {
   // Please, change the Id from `1` to any case Id present in your project before uncommenting the test.
-  test(qase(1, "A test with Qase Id"), () => {
+  test(addQaseId("A test with Qase Id", [1]), () => {
     expect(true).toBe(true);
   });
 });

--- a/examples/vitest/test/ignore.test.ts
+++ b/examples/vitest/test/ignore.test.ts
@@ -1,9 +1,0 @@
-import { describe, test, expect } from 'vitest';
-import { withQase } from 'vitest-qase-reporter/vitest';
-
-describe("Example: ignore.test.ts", () => {
-  test("This test is executed using Vitest; however, it is NOT reported to Qase", withQase(async ({ qase }) => {
-    await qase.ignore();
-    expect(true).toBe(true);
-  }));
-});

--- a/qase-vitest/README.md
+++ b/qase-vitest/README.md
@@ -98,19 +98,19 @@ import { describe, it, test, expect } from 'vitest';
 import { addQaseId, withQase } from 'vitest-qase-reporter/vitest';
 
 describe('My First Test', () => {
-  test(addQaseId([1, 2], 'Several ids'), () => {
+  test(addQaseId('Several ids', [1, 2]), () => {
     expect(true).toBe(true);
   });
 
-  test(addQaseId(3, 'Correct test'), () => {
+  test(addQaseId('Correct test', [3]), () => {
     expect(true).toBe(true);
   });
 
-  test.skip(addQaseId('4', 'Skipped test'), () => {
+  test.skip(addQaseId('Skipped test', [4]), () => {
     expect(true).toBe(true);
   });
 
-  test(addQaseId(['5', '6'], 'Failed test'), () => {
+  test(addQaseId('Failed test', ['5', '6']), () => {
     expect(true).toBe(false);
   });
 });


### PR DESCRIPTION
- Replaced usage of `qase` with `addQaseId` in test cases across multiple files for consistency.
- Updated attachment method parameters from `contentType` to `type` in attachment tests.
- Added a new test file demonstrating the use of `it.for` for parameterized tests.

These changes enhance the clarity and functionality of the test suite while ensuring compatibility with the latest reporting features.