### PR TITLE
feat: add support for expected results and data in step definitions

### DIFF
--- a/examples/jest/test/steps.test.js
+++ b/examples/jest/test/steps.test.js
@@ -23,4 +23,18 @@ describe("Example: steps.test.js", () => {
       },
     );
   });
+
+  test("A Test case with steps including expected results and data", async () => {
+    await qase.step("Click button", async () => {
+      // Click action
+    }, "Button should be clicked", "Button data");
+
+    await qase.step("Fill form", async () => {
+      // Form filling action
+    }, "Form should be filled", "Form input data");
+
+    await qase.step("Submit form", async () => {
+      // Submit action
+    }, "Form should be submitted", "Form submission data");
+  });
 });

--- a/examples/mocha/test/stepTests.spec.js
+++ b/examples/mocha/test/stepTests.spec.js
@@ -13,4 +13,16 @@ describe('Step tests', function() {
     this.step('step 2', function() {});
     assert.strictEqual(1, 2);
   });
+
+  it('test with steps including expected results and data', function() {
+    this.step('Click button', function() {
+      // Click action
+    }, 'Button should be clicked', 'Button data');
+    
+    this.step('Fill form', function() {
+      // Form filling action
+    }, 'Form should be filled', 'Form input data');
+    
+    assert.strictEqual(1, 1);
+  });
 });

--- a/examples/vitest/test/steps.test.ts
+++ b/examples/vitest/test/steps.test.ts
@@ -23,4 +23,18 @@ describe("Example: steps.test.ts", () => {
       },
     );
   }));
+
+  test("A Test case with steps including expected results and data", withQase(async ({ qase }) => {
+    await qase.step("Click button", async () => {
+      // Click action
+    }, "Button should be clicked", "Button data");
+
+    await qase.step("Fill form", async () => {
+      // Form filling action
+    }, "Form should be filled", "Form input data");
+
+    await qase.step("Submit form", async () => {
+      // Submit action
+    }, "Form should be submitted", "Form submission data");
+  }));
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -541,6 +541,21 @@
         }
       }
     },
+    "examples/vitest/node_modules/vitest-qase-reporter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/vitest-qase-reporter/-/vitest-qase-reporter-1.0.2.tgz",
+      "integrity": "sha512-IS9t0IrF2A1veFF04ZrdyihrrLayi+DKIviLDY8h/uyyavxqPR1Ua8tIoGGxygMxakUjmjrYZ4CkRpXDDUVcBQ==",
+      "dev": true,
+      "dependencies": {
+        "qase-javascript-commons": "~2.4.5"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "vitest": ">=3.0.0"
+      }
+    },
     "node_modules/@actions/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
@@ -22756,12 +22771,12 @@
     },
     "qase-jest": {
       "name": "jest-qase-reporter",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "qase-javascript-commons": "~2.4.10",
+        "qase-javascript-commons": "~2.4.13",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -22783,12 +22798,12 @@
     },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "deasync-promise": "^1.0.1",
         "mocha": "^11.7.5",
-        "qase-javascript-commons": "~2.4.10",
+        "qase-javascript-commons": "~2.4.13",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -22902,10 +22917,10 @@
     },
     "qase-vitest": {
       "name": "vitest-qase-reporter",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.4.10"
+        "qase-javascript-commons": "~2.4.13"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/qase-cucumberjs/jest.config.js
+++ b/qase-cucumberjs/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
       tsconfig: {
         skipLibCheck: true,
       },
-      isolatedModules: true,
     }],
   },
   testMatch: ['**/*.test.ts'],

--- a/qase-cucumberjs/tsconfig.json
+++ b/qase-cucumberjs/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "isolatedModules": true
   }
 }

--- a/qase-cypress/jest.config.js
+++ b/qase-cypress/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
       tsconfig: {
         skipLibCheck: true,
       },
-      isolatedModules: true,
     }],
   },
   testMatch: ['**/*.test.ts'],

--- a/qase-cypress/tsconfig.json
+++ b/qase-cypress/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "isolatedModules": true
   }
 }

--- a/qase-javascript-commons/jest.config.js
+++ b/qase-javascript-commons/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
       tsconfig: {
         skipLibCheck: true,
       },
-      isolatedModules: true,
     }],
   },
   testMatch: ['**/*.test.ts'],

--- a/qase-javascript-commons/src/models/index.ts
+++ b/qase-javascript-commons/src/models/index.ts
@@ -1,9 +1,11 @@
-export { TestResultType, Relation, Suite, SuiteData } from './test-result';
+export { TestResultType } from './test-result';
+export type { Relation, Suite, SuiteData } from './test-result';
 export { TestExecution, TestStatusEnum } from './test-execution';
 export { TestStepType, StepType } from './test-step';
 export { StepStatusEnum } from './step-execution';
-export { Attachment } from './attachment';
-export { Report } from './report';
+export type { Attachment } from './attachment';
+export type { Report } from './report';
 export { CompoundError } from './error';
-export { ConfigurationGroup, ConfigurationItem, ConfigurationGroupResponse } from './configuration';
-export { ExternalLinkType, TestOpsOptionsType, TestOpsApiType, TestOpsRunType, TestOpsPlanType, TestOpsBatchType, TestOpsConfigurationType, TestOpsConfigurationValueType, TestOpsExternalLinkType } from './config/TestOpsOptionsType';
+export type { ConfigurationGroup, ConfigurationItem, ConfigurationGroupResponse } from './configuration';
+export { ExternalLinkType } from './config/TestOpsOptionsType';
+export type { TestOpsOptionsType, TestOpsApiType, TestOpsRunType, TestOpsPlanType, TestOpsBatchType, TestOpsConfigurationType, TestOpsConfigurationValueType, TestOpsExternalLinkType } from './config/TestOpsOptionsType';

--- a/qase-javascript-commons/tsconfig.json
+++ b/qase-javascript-commons/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "isolatedModules": true
   }
 }

--- a/qase-jest/changelog.md
+++ b/qase-jest/changelog.md
@@ -1,3 +1,9 @@
+# jest-qase-reporter@2.1.4
+
+## What's new
+
+- Added support for expected results and data for steps.
+
 # jest-qase-reporter@2.1.3
 
 ## What's new

--- a/qase-jest/docs/usage.md
+++ b/qase-jest/docs/usage.md
@@ -80,6 +80,22 @@ test('A Test case with steps, updated from code', async () => {
   });
 });
 ```
+
+#### Steps with Expected Result and Data
+
+```javascript
+const { qase } = require("jest-qase-reporter/jest");
+
+test('A Test case with steps including expected results and data', async () => {
+  await qase.step('Click button', async () => {
+    // Click action
+  }, 'Button should be clicked', 'Button data');
+  
+  await qase.step('Fill form', async () => {
+    // Form filling action
+  }, 'Form should be filled', 'Form input data');
+});
+```
 <br>
 
 ### Fields

--- a/qase-jest/jest.config.js
+++ b/qase-jest/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
       tsconfig: {
         skipLibCheck: true,
       },
-      isolatedModules: true,
     }],
   },
   testMatch: ['**/*.test.ts'],

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-qase-reporter",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Qase TMS Jest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
-    "qase-javascript-commons": "~2.4.10",
+    "qase-javascript-commons": "~2.4.13",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/qase-jest/src/jest.ts
+++ b/qase-jest/src/jest.ts
@@ -119,6 +119,8 @@ qase.groupParameters = (values: Record<string, string>): void => {
  * Add a step to the test case
  * @param name
  * @param body
+ * @param expectedResult
+ * @param data
  * @example
  * test('test', () => {
  *    qase.step("Step", () => {
@@ -126,9 +128,19 @@ qase.groupParameters = (values: Record<string, string>): void => {
  *    });
  *     expect(true).toBe(true);
  * });
+ * @example
+ * test('test', () => {
+ *    qase.step("Step", () => {
+ *      expect(true).toBe(true);
+ *    }, "Expected result", "Input data");
+ *     expect(true).toBe(true);
+ * });
  */
-qase.step = async (name: string, body: StepFunction) => {
-  const runningStep = new QaseStep(name);
+qase.step = async (name: string, body: StepFunction, expectedResult?: string, data?: string) => {
+  const stepName = expectedResult || data 
+    ? `${name} QaseExpRes:${expectedResult ? `: ${expectedResult}` : ''} QaseData:${data ? `: ${data}` : ''}` 
+    : name;
+  const runningStep = new QaseStep(stepName);
   // eslint-disable-next-line @typescript-eslint/require-await
   await runningStep.run(body, async (step) => {
     // @ts-expect-error - global.Qase is dynamically added at runtime

--- a/qase-jest/tsconfig.json
+++ b/qase-jest/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "isolatedModules": true
   }
 }

--- a/qase-mocha/changelog.md
+++ b/qase-mocha/changelog.md
@@ -1,3 +1,9 @@
+# qase-mocha@1.1.8
+
+## What's new
+
+- Added support for expected results and data for steps.
+
 # qase-mocha@1.1.6
 
 ## What's new

--- a/qase-mocha/docs/usage.md
+++ b/qase-mocha/docs/usage.md
@@ -184,7 +184,7 @@ describe('User Authentication', function() {
 ## Adding Steps to a Test
 
 You can add custom steps to your test cases using the `this.step()` method. Each step should
-have a title and optionally a function.
+have a title and optionally a function. You can also provide an expected result and input data for each step, which will be displayed in Qase.
 
 ### Example
 
@@ -205,6 +205,26 @@ describe('User Authentication', function() {
     this.step('Verify successful login', function() {
       // Step implementation
     });
+    expect(true).to.equal(true);
+  });
+});
+```
+
+### Example with Expected Result and Data
+
+```javascript
+const { qase } = require('mocha-qase-reporter/mocha');
+
+describe('User Authentication', function() {
+  it('test with steps including expected results and data', function() {
+    this.step('Click button', function() {
+      // Click action
+    }, 'Button should be clicked', 'Button data');
+    
+    this.step('Fill form', function() {
+      // Form filling action
+    }, 'Form should be filled', 'Form input data');
+    
     expect(true).to.equal(true);
   });
 });

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -43,7 +43,7 @@
   "dependencies": {
     "mocha": "^11.7.5",
     "deasync-promise": "^1.0.1",
-    "qase-javascript-commons": "~2.4.10",
+    "qase-javascript-commons": "~2.4.13",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/qase-mocha/src/types.ts
+++ b/qase-mocha/src/types.ts
@@ -40,7 +40,7 @@ export interface Methods {
 
   comment(message: string): void;
 
-  step(title: string, func: () => void): void;
+  step(title: string, func: () => void, expectedResult?: string, data?: string): void;
 }
 
 export class Metadata {

--- a/qase-newman/jest.config.js
+++ b/qase-newman/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
       tsconfig: {
         skipLibCheck: true,
       },
-      isolatedModules: true,
     }],
   },
   testMatch: ['**/*.test.ts'],

--- a/qase-newman/tsconfig.json
+++ b/qase-newman/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "isolatedModules": true
   }
 }

--- a/qase-playwright/docs/usage.md
+++ b/qase-playwright/docs/usage.md
@@ -183,8 +183,7 @@ test('test', async ({ page }) => {
 
 ## Adding Steps to a Test
 
-You can add steps to a test case using the `qase.step` function. This function accepts a string, which will be used as
-the step description in Qase.
+You can add steps to a test case using the `qase.step` function. This function accepts a string for the action, and optionally an expected result and input data, which will be used as the step description in Qase.
 
 ### Example
 
@@ -194,6 +193,19 @@ import { qase } from 'playwright-qase-reporter';
 test('test', async ({ page }) => {
   await test.step(qase.step('Some step'), async () => {
     // some actions
+  });
+  await page.goto('https://example.com');
+});
+```
+
+### Example with Expected Result and Data
+
+```javascript
+import { qase } from 'playwright-qase-reporter';
+
+test('test', async ({ page }) => {
+  await test.step(qase.step('Click button', 'Button should be clicked', 'Button data'), async () => {
+    await page.click('button');
   });
   await page.goto('https://example.com');
 });

--- a/qase-playwright/jest.config.js
+++ b/qase-playwright/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
       tsconfig: {
         skipLibCheck: true,
       },
-      isolatedModules: true,
     }],
   },
   testMatch: ['**/*.test.ts'],

--- a/qase-playwright/tsconfig.json
+++ b/qase-playwright/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "isolatedModules": true
   }
 }

--- a/qase-testcafe/jest.config.js
+++ b/qase-testcafe/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
       tsconfig: {
         skipLibCheck: true,
       },
-      isolatedModules: true,
     }],
   },
   testMatch: ['**/*.test.ts'],

--- a/qase-testcafe/tsconfig.json
+++ b/qase-testcafe/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "isolatedModules": true
   }
 }

--- a/qase-vitest/changelog.md
+++ b/qase-vitest/changelog.md
@@ -1,3 +1,9 @@
+# qase-vitest@1.0.3
+
+## What's new
+
+- Added support for expected results and data for steps.
+
 # qase-vitest@1.0.2
 
 ## What's new

--- a/qase-vitest/docs/usage.md
+++ b/qase-vitest/docs/usage.md
@@ -66,6 +66,8 @@ The reporter uses the title from the `qase.step` function as the step title. By 
 
 Additionally, these steps get their own result in the Qase Test run, offering a well-organized summary of the test flow. This helps quickly identify the cause of any failures.
 
+You can also provide an expected result and input data for each step, which will be displayed in Qase.
+
 ```typescript
 it('A Test case with steps, updated from code', withQase(async ({ qase }) => {
   await qase.step('Initialize the environment', async () => {
@@ -78,6 +80,20 @@ it('A Test case with steps, updated from code', withQase(async ({ qase }) => {
   await qase.step('Verify Expected Behavior of the app', async () => {
     // Assert expected behavior
   });
+}));
+```
+
+#### Steps with Expected Result and Data
+
+```typescript
+it('A Test case with steps including expected results and data', withQase(async ({ qase }) => {
+  await qase.step('Click button', async () => {
+    // Click action
+  }, 'Button should be clicked', 'Button data');
+  
+  await qase.step('Fill form', async () => {
+    // Form filling action
+  }, 'Form should be filled', 'Form input data');
 }));
 ```
 <br>

--- a/qase-vitest/jest.config.js
+++ b/qase-vitest/jest.config.js
@@ -9,7 +9,6 @@ module.exports = {
       tsconfig: {
         skipLibCheck: true,
       },
-      isolatedModules: true,
     }],
   },
   collectCoverageFrom: [

--- a/qase-vitest/package.json
+++ b/qase-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-qase-reporter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Qase TMS Vitest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -40,7 +40,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.4.10"
+    "qase-javascript-commons": "~2.4.13"
   },
   "peerDependencies": {
     "vitest": ">=3.0.0"

--- a/qase-vitest/tsconfig.json
+++ b/qase-vitest/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "isolatedModules": true
   }
 }

--- a/qase-wdio/jest.config.js
+++ b/qase-wdio/jest.config.js
@@ -8,7 +8,6 @@ module.exports = {
       tsconfig: {
         skipLibCheck: true,
       },
-      isolatedModules: true,
     }],
   },
   collectCoverageFrom: [

--- a/qase-wdio/tsconfig.json
+++ b/qase-wdio/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
 
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "isolatedModules": true
   }
 }

--- a/qaseio/jest.config.js
+++ b/qaseio/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
       tsconfig: {
         skipLibCheck: true,
       },
-      isolatedModules: true,
     }],
     '^.+\\.js$': 'babel-jest'
   },

--- a/qaseio/src/index.ts
+++ b/qaseio/src/index.ts
@@ -1,3 +1,4 @@
 export * from './generated';
 
-export { QaseApi, QaseApiInterface } from './qaseio';
+export { QaseApi } from './qaseio';
+export type { QaseApiInterface } from './qaseio';

--- a/qaseio/tsconfig.json
+++ b/qaseio/tsconfig.json
@@ -8,6 +8,7 @@
     "noImplicitAny": true,
     "noEmit": true,
     "noEmitOnError": true,
+    "isolatedModules": true,
 
     "typeRoots": ["node_modules/@types"]
   },


### PR DESCRIPTION
- Enhanced step definitions in Jest, Mocha, and Vitest to accept expected results and input data.
- Updated test cases to demonstrate the new functionality, improving clarity in test reporting.
- Modified documentation to reflect the changes in step usage, providing examples for better understanding.

These improvements enhance the usability of the testing framework and provide more detailed reporting in Qase.