### PR TITLE
chore: bump version to 2.4.14 and refactor QaseReporter and ClientV2

### DIFF
--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.13",
+  "version": "2.4.14",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -26,6 +26,7 @@ import { getHostInfo } from './utils/hostData';
 import { ClientV2 } from './client/clientV2';
 import { TestOpsOptionsType } from './models/config/TestOpsOptionsType';
 import { applyStatusMapping } from './utils/status-mapping-utils';
+import { HostData } from './models/host-data';
 
 /**
  * @type {Record<TestStatusEnum, (test: TestResultType) => string>}
@@ -104,6 +105,8 @@ export class QaseReporter implements ReporterInterface {
 
   private withState: boolean;
 
+  private readonly hostData: HostData;
+
   /**
    * @param {OptionsType} options
    */
@@ -147,8 +150,8 @@ export class QaseReporter implements ReporterInterface {
     this.logger = new Logger(loggerOptions);
     this.logger.logDebug(`Config: ${JSON.stringify(this.sanitizeOptions(composedOptions))}`);
 
-    const hostData = getHostInfo(options.frameworkPackage, options.reporterName);
-    this.logger.logDebug(`Host data: ${JSON.stringify(hostData)}`);
+    this.hostData = getHostInfo(options.frameworkPackage, options.reporterName);
+    this.logger.logDebug(`Host data: ${JSON.stringify(this.hostData)}`);
 
     this.captureLogs = composedOptions.captureLogs;
 
@@ -570,6 +573,9 @@ export class QaseReporter implements ReporterInterface {
           options.testops as TestOpsOptionsType,
           options.environment,
           options.rootSuite,
+          this.hostData,
+          options.reporterName,
+          options.frameworkPackage
         );
 
         return new TestOpsReporter(


### PR DESCRIPTION
- Updated package version from 2.4.13 to 2.4.14 in package.json.
- Refactored QaseReporter to store host data as a class property and log it during initialization.
- Enhanced ClientV2 to accept host data, reporter name, and framework name in the constructor, improving API configuration.
- Added methods to build headers for client and platform information based on host data.

These changes improve the structure and functionality of the Qase reporting library.