### PR TITLE
chore: bump version to 3.1.2 and improve skipped test handling

### DIFF
--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,9 @@
+# cypress-qase-reporter@3.1.2
+
+## What's new
+
+- Improved handling of skipped tests due to failing beforeEach hooks.
+
 # cypress-qase-reporter@3.1.1
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -51,7 +51,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.4.13",
+    "qase-javascript-commons": "~2.4.14",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -211,12 +211,31 @@ export class CypressQaseReporter extends reporters.Base {
    * @param {Suite} suite
    * @private
    */
+  /**
+   * Recursively collect all tests from a suite and its nested suites
+   * @param {Suite} suite
+   * @param {Test[]} tests
+   * @private
+   */
+  private collectAllTestsFromSuite(suite: Suite, tests: Test[]): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const suiteTests = suite.tests ?? [];
+    tests.push(...suiteTests);
+
+    // Recursively process nested suites
+    const nestedSuites = suite.suites ?? [];
+    for (const nestedSuite of nestedSuites) {
+      this.collectAllTestsFromSuite(nestedSuite, tests);
+    }
+  }
+
   private handleSkippedTestsInSuite(suite: Suite): void {
-    // Get tests only from the current suite (not nested suites, they will be processed separately)
-    const tests = suite.tests ?? [];
+    // Collect all tests from this suite and nested suites recursively
+    const allTests: Test[] = [];
+    this.collectAllTestsFromSuite(suite, allTests);
 
     // Find tests that were not processed (skipped due to beforeEach failure)
-    for (const test of tests) {     
+    for (const test of allTests) {     
       // Skip if test was already processed (e.g., first test that got EVENT_TEST_FAIL)
       if (!this.isTestProcessed(test)) {
         // Test was skipped due to beforeEach failure, report it as skipped


### PR DESCRIPTION
- Updated version from 3.1.1 to 3.1.2 in package.json.
- Enhanced the reporter to recursively collect all tests from a suite, improving the handling of skipped tests due to failing beforeEach hooks.
- Updated changelog to reflect the new version and changes.

These updates enhance the functionality and accuracy of the Cypress Qase Reporter.