### PR TITLE
fix: send disabled status as skipped

### DIFF
--- a/qase-javascript-commons/src/client/clientV2.ts
+++ b/qase-javascript-commons/src/client/clientV2.ts
@@ -18,7 +18,7 @@ export class ClientV2 extends ClientV1 {
         [TestStatusEnum.passed]: 'passed',
         [TestStatusEnum.failed]: 'failed',
         [TestStatusEnum.skipped]: 'skipped',
-        [TestStatusEnum.disabled]: 'disabled',
+        [TestStatusEnum.disabled]: 'skipped',
         [TestStatusEnum.blocked]: 'blocked',
         [TestStatusEnum.invalid]: 'invalid',
     };
@@ -75,7 +75,7 @@ export class ClientV2 extends ClientV1 {
 
         // Build X-Client header
         const clientParts: string[] = [];
-        
+
         if (reporterName && reporterName.trim()) {
             clientParts.push(`reporter=${reporterName}`);
         }
@@ -104,7 +104,7 @@ export class ClientV2 extends ClientV1 {
 
         // Build X-Platform header
         const platformParts: string[] = [];
-        
+
         if (hostData.system && hostData.system.trim()) {
             platformParts.push(`os=${hostData.system}`);
         }
@@ -151,7 +151,7 @@ export class ClientV2 extends ClientV1 {
         const model: ResultCreate = {
             title: result.title,
             execution: this.getExecution(result.execution),
-            testops_ids: Array.isArray(result.testops_id) 
+            testops_ids: Array.isArray(result.testops_id)
                 ? result.testops_id
                 : result.testops_id !== null ? [result.testops_id] : null,
             attachments: attachments,


### PR DESCRIPTION
Apparently `disabled` is an invalid status for test runs:

```
[ERROR] qase: Unable to add the result to the upstream reporter:
 Error: Error on uploading results: Bad request
{"message":"The selected execution.status is invalid.","errors":{"execution.status":["The selected execution.status is invalid."]}}
Body: [{"attachments":[],"author":null,"execution":{"status":"disabled","start_time":null,"end_time":null,"duration":0,"stacktrace":null,"thread":null},"fields":{},"message":null,"muted":false,"params":{},"group_params":{},"relations":{"suite":{"data":[{"title":"tests","public_id":null},{"title":"end-to-end","public_id":null}]}},"run_id":null,"signature":"...","steps":[],"testops_id":null,"id":"...","title":"should send disabled"}]
    at ClientV2.processError (/.../node_modules/qase-javascript-commons/dist/client/clientV1.js:570:24)
    at ClientV2.uploadResults (/.../node_modules/qase-javascript-commons/dist/client/clientV2.js:115:24)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async TestOpsReporter.publishResults (/.../node_modules/qase-javascript-commons/dist/reporters/testops-reporter.js:101:9)
    at async TestOpsReporter.addTestResult (/.../node_modules/qase-javascript-commons/dist/reporters/testops-reporter.js:73:17)
    at async QaseReporter.addTestResult (/.../node_modules/qase-javascript-commons/dist/qase.js:325:17)
```

I found this mapping but I also find another ones, so I'm not sure if I need to change something else as well.

Not sure if QASE API documentation is not updated, but it seems this is the API used to submit results but it doesn't mention the `execution.status` payload: https://developers.qase.io/v2.0/reference/create-result-v2

On API V1 though they have it: https://developers.qase.io/reference/create-result
> Can have the following values passed, failed, blocked, skipped, invalid + custom statuses



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Map `TestStatusEnum.disabled` to `skipped` in `ClientV2` status mapping to avoid invalid execution status.
> 
> - **ClientV2 status mapping**:
>   - Map `TestStatusEnum.disabled` -> `skipped` in `statusMap` to ensure valid `execution.status` when uploading results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c3d90e689a72269a054ef505fe4a8c0ab8f8a1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->