### PR TITLE
chore: bump version to 2.4.15 and update reporter version formatting

### DIFF
--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.14",
+  "version": "2.4.15",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/client/clientV2.ts
+++ b/qase-javascript-commons/src/client/clientV2.ts
@@ -80,22 +80,22 @@ export class ClientV2 extends ClientV1 {
             clientParts.push(`reporter=${reporterName}`);
         }
         if (hostData.reporter && hostData.reporter.trim()) {
-            clientParts.push(`reporter_version=v${hostData.reporter}`);
+            clientParts.push(`reporter_version=${hostData.reporter}`);
         }
         if (frameworkName && frameworkName.trim()) {
             clientParts.push(`framework=${frameworkName}`);
         }
         if (hostData.framework && hostData.framework.trim()) {
-            clientParts.push(`framework_version=v${hostData.framework}`);
+            clientParts.push(`framework_version=${hostData.framework}`);
         }
         if (hostData.apiClientV1 && hostData.apiClientV1.trim()) {
-            clientParts.push(`client_version_v1=v${hostData.apiClientV1}`);
+            clientParts.push(`client_version_v1=${hostData.apiClientV1}`);
         }
         if (hostData.apiClientV2 && hostData.apiClientV2.trim()) {
-            clientParts.push(`client_version_v2=v${hostData.apiClientV2}`);
+            clientParts.push(`client_version_v2=${hostData.apiClientV2}`);
         }
         if (hostData.commons && hostData.commons.trim()) {
-            clientParts.push(`core_version=v${hostData.commons}`);
+            clientParts.push(`core_version=${hostData.commons}`);
         }
 
         if (clientParts.length > 0) {


### PR DESCRIPTION
- Updated package version from 2.4.14 to 2.4.15 in package.json.
- Modified ClientV2 to remove the 'v' prefix from reporter, framework, and client version strings for consistency in formatting.

These changes ensure a more uniform representation of version information in the reporting library.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the 'v' prefix from version values in `X-Client` header assembly and bumps package to 2.4.15.
> 
> - **Client (`src/client/clientV2.ts`)**:
>   - Normalize `X-Client` header version values by removing the `v` prefix for `reporter_version`, `framework_version`, `client_version_v1`, `client_version_v2`, and `core_version`.
> - **Release**:
>   - Bump `qase-javascript-commons/package.json` version from `2.4.14` to `2.4.15`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe5870c22e3d4ab8f91c72ee6c8dcbfa9724e860. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->