### PR TITLE
chore: bump version to 2.4.16 and fix disabled status issue

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.4.16
+
+## What's new
+
+Fixed issue with incorrect 'disabled' status.
+
 # qase-javascript-commons@2.4.13
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Updated package version from 2.4.15 to 2.4.16 in package.json.
- Added changelog entry for the fix addressing the incorrect 'disabled' status.

These changes ensure the library reflects the latest version and resolves a critical issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `qase-javascript-commons` to `2.4.16` and adds changelog entry for fixing incorrect `disabled` status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebaa87e9b8d56af9b5cef3b7b069005263ff5bb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->