### PR TITLE
chore: bump version to 2.1.7 and improve thread handling

### DIFF
--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,9 @@
+# playwright-qase-reporter@2.1.7
+
+## What's new
+
+- Improved handling thread id for parallel and shared workers tests.
+
 # playwright-qase-reporter@2.1.6
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.2",
-    "qase-javascript-commons": "~2.4.10",
+    "qase-javascript-commons": "~2.4.16",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -411,7 +411,7 @@ export class PlaywrightQaseReporter implements Reporter {
         stacktrace: error === null ?
           null : error.stacktrace === undefined ?
             null : error.stacktrace,
-        thread: result.parallelIndex.toString(),
+        thread: process.ppid.toString() + '-' + result.parallelIndex.toString(),
       },
       fields: testCaseMetadata.fields,
       id: uuidv4(),


### PR DESCRIPTION
- Updated package version from 2.1.6 to 2.1.7 in package.json.
- Enhanced thread handling in the reporter to better support parallel and shared workers tests.
- Added changelog entry for the new version and improvements.

These changes ensure the reporter functions more effectively in parallel test scenarios and reflects the latest version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release 2.1.7**
> 
> - Improve thread identifier in `src/reporter.ts` by setting `execution.thread` to `process.ppid + '-' + result.parallelIndex` for accurate parallel/shared workers reporting
> - Bump package to `2.1.7` and update dependency `qase-javascript-commons` to `~2.4.16`
> - Add changelog entry documenting the thread id handling improvement
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df28d436c8ebfeefa42df5e756375ea647759479. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->