### PR TITLE
chore: bump version to 2.1.7 and add support for QaseParameters and QaseGroupParameters

### DIFF
--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,9 @@
+# qase-cucumberjs@2.1.7
+
+## What's new
+
+- Added support for QaseParameters and QaseGroupParameters tags.
+
 # qase-cucumberjs@2.1.6
 
 ## Bug fixes

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/messages": "^22.0.0",
-    "qase-javascript-commons": "~2.4.10"
+    "qase-javascript-commons": "~2.4.16"
   },
   "peerDependencies": {
     "@cucumber/cucumber": ">=7.0.0"

--- a/qase-cucumberjs/src/models.ts
+++ b/qase-cucumberjs/src/models.ts
@@ -3,6 +3,8 @@ export interface TestMetadata {
   fields: Record<string, string>;
   title: string | null;
   isIgnore: boolean;
+  parameters: Record<string, string>;
+  group_params: Record<string, string>;
 }
 
 export interface ScenarioData {


### PR DESCRIPTION
- Updated package version from 2.1.6 to 2.1.7 in package.json.
- Added support for QaseParameters and QaseGroupParameters tags in the storage logic.
- Enhanced test cases to validate the inclusion of parameters from these tags in test results.
- Updated changelog to reflect the new version and features.

These changes improve the functionality of the reporter by allowing users to specify parameters directly in their test tags.