### PR TITLE
chore: bump version to 2.1.8 and enhance QaseParameters support

### DIFF
--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,9 @@
+# qase-cucumberjs@2.1.8
+
+## What's new
+
+- Improved support for QaseParameters and QaseGroupParameters tags.
+
 # qase-cucumberjs@2.1.7
 
 ## What's new

--- a/qase-cucumberjs/docs/usage.md
+++ b/qase-cucumberjs/docs/usage.md
@@ -8,7 +8,7 @@ fields, suites, comments, and file attachments to your test cases.
 ## Adding QaseID to a Test
 
 To associate a QaseID with a test in Cucumber.js, use the `@QaseId` tag in your Gherkin feature files. This tag accepts
-a single integer or multiple integers separated by commas representing the test's ID(s) in Qase.
+a single integer or multiple integers separated by commas representing the test"s ID(s) in Qase.
 
 ### Example
 
@@ -33,7 +33,7 @@ Feature: User Authentication
 ## Adding a Title to a Test
 
 You can provide a custom title for your test using the `@Title` tag. The tag accepts a string, which will be used as
-the test's title in Qase. If no title is provided, the scenario name will be used by default.
+the test"s title in Qase. If no title is provided, the scenario name will be used by default.
 
 ### Example
 
@@ -70,7 +70,7 @@ enhance test case information in Qase.
 Feature: User Authentication
 
   @QaseId=1
-  @QaseFields={'severity':'high','priority':'medium','description':'Login functionality test'}
+  @QaseFields={"severity":"high","priority":"medium","description":"Login functionality test"}
   Scenario: Successful login
     Given I am on the login page
     When I enter valid credentials
@@ -136,7 +136,7 @@ parameter names and values.
 Feature: User Authentication
 
   @QaseId=1
-  @QaseParameters={'browser':'chrome','environment':'staging'}
+  @QaseParameters={"browser":"chrome","environment":"staging"}
   Scenario: Successful login
     Given I am on the login page
     When I enter valid credentials
@@ -156,8 +156,8 @@ group parameter names and values.
 Feature: User Authentication
 
   @QaseId=1
-  @QaseParameters={'browser':'chrome','environment':'staging'}
-  @QaseGroupParameters={'test_group':'authentication','test_type':'smoke'}
+  @QaseParameters={"browser":"chrome","environment":"staging"}
+  @QaseGroupParameters={"test_group":"authentication","test_type":"smoke"}
   Scenario: Successful login
     Given I am on the login page
     When I enter valid credentials
@@ -185,23 +185,23 @@ Feature: User Authentication
 
 ```javascript
 // step_definitions/login_steps.js
-const { Given, When, Then } = require('@cucumber/cucumber');
+const { Given, When, Then } = require("@cucumber/cucumber");
 
-Given('I am on the login page', async function() {
+Given("I am on the login page", async function() {
   // Step implementation
-  await this.page.goto('https://example.com/login');
+  await this.page.goto("https://example.com/login");
 });
 
-When('I enter valid credentials', async function() {
+When("I enter valid credentials", async function() {
   // Step implementation
-  await this.page.fill('#username', 'testuser');
-  await this.page.fill('#password', 'password');
-  await this.page.click('#login-button');
+  await this.page.fill("#username", "testuser");
+  await this.page.fill("#password", "password");
+  await this.page.click("#login-button");
 });
 
-Then('I should be logged in', async function() {
+Then("I should be logged in", async function() {
   // Step implementation
-  await this.page.waitForSelector('.dashboard');
+  await this.page.waitForSelector(".dashboard");
 });
 ```
 
@@ -216,32 +216,32 @@ attaching files with content, paths, or media types.
 
 ```javascript
 // step_definitions/login_steps.js
-const { Given, When, Then } = require('@cucumber/cucumber');
+const { Given, When, Then } = require("@cucumber/cucumber");
 
-Given('I am on the login page', async function() {
-  await this.page.goto('https://example.com/login');
+Given("I am on the login page", async function() {
+  await this.page.goto("https://example.com/login");
   
   // Attach screenshot
   const screenshot = await this.page.screenshot();
-  await this.attach(screenshot, 'image/png');
+  await this.attach(screenshot, "image/png");
 });
 
-When('I enter valid credentials', async function() {
-  await this.page.fill('#username', 'testuser');
-  await this.page.fill('#password', 'password');
+When("I enter valid credentials", async function() {
+  await this.page.fill("#username", "testuser");
+  await this.page.fill("#password", "password");
   
   // Attach text content
-  await this.attach('Credentials entered successfully', 'text/plain');
+  await this.attach("Credentials entered successfully", "text/plain");
   
-  await this.page.click('#login-button');
+  await this.page.click("#login-button");
 });
 
-Then('I should be logged in', async function() {
-  await this.page.waitForSelector('.dashboard');
+Then("I should be logged in", async function() {
+  await this.page.waitForSelector(".dashboard");
   
   // Attach JSON data
-  const userData = { username: 'testuser', status: 'logged_in' };
-  await this.attach(JSON.stringify(userData, null, 2), 'application/json');
+  const userData = { username: "testuser", status: "logged_in" };
+  await this.attach(JSON.stringify(userData, null, 2), "application/json");
 });
 ```
 

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -416,7 +416,7 @@ export class Storage {
         const value = tag.name.replace(/^@[Qq]ase[Ff]ields=/, '');
         try {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const record: Record<string, string> = JSON.parse(value);
+          const record: Record<string, string> = JSON.parse(this.normalizeJsonString(value));
           metadata.fields = { ...metadata.fields, ...record };
         } catch (e) {
           // do nothing
@@ -427,7 +427,7 @@ export class Storage {
         const value = tag.name.replace(/^@[Qq]ase[Pp]arameters=/, '');
         try {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const record: Record<string, string> = JSON.parse(value);
+          const record: Record<string, string> = JSON.parse(this.normalizeJsonString(value));
           metadata.parameters = { ...metadata.parameters, ...record };
         } catch (e) {
           // do nothing
@@ -438,7 +438,7 @@ export class Storage {
         const value = tag.name.replace(/^@[Qq]ase[Gg]roup[Pp]arameters=/, '');
         try {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const record: Record<string, string> = JSON.parse(value);
+          const record: Record<string, string> = JSON.parse(this.normalizeJsonString(value));
           metadata.group_params = { ...metadata.group_params, ...record };
         } catch (e) {
           // do nothing
@@ -477,6 +477,23 @@ export class Storage {
     });
 
     return error;
+  }
+
+  /**
+   * Normalize JSON string by converting single quotes to double quotes
+   * This allows parsing JSON-like strings with single quotes
+   * @param {string} jsonString
+   * @returns {string}
+   * @private
+   */
+  private normalizeJsonString(jsonString: string): string {
+    // If the string contains single quotes, convert them to double quotes
+    // This handles cases like {'key':'value'} which should be {"key":"value"}
+    if (jsonString.includes("'")) {
+      return jsonString.replace(/'/g, '"');
+    }
+    // If no single quotes, return as-is (already valid JSON or will fail with proper error)
+    return jsonString;
   }
 
   private getFileNameFromMediaType(mediaType: string): string {

--- a/qase-cucumberjs/test/storage.test.ts
+++ b/qase-cucumberjs/test/storage.test.ts
@@ -581,6 +581,26 @@ describe('Storage', () => {
       expect(result.group_params).toEqual({ test_group: 'authentication', test_type: 'smoke' });
     });
 
+    it('should parse QaseParameters tag with single quotes', () => {
+      const tags = [
+        { name: "@QaseParameters={'browser':'chrome','environment':'staging'}" },
+      ];
+
+      const result = (storage as any).parseTags(tags);
+
+      expect(result.parameters).toEqual({ browser: 'chrome', environment: 'staging' });
+    });
+
+    it('should parse QaseGroupParameters tag with single quotes', () => {
+      const tags = [
+        { name: "@QaseGroupParameters={'group':'regression'}" },
+      ];
+
+      const result = (storage as any).parseTags(tags);
+
+      expect(result.group_params).toEqual({ group: 'regression' });
+    });
+
     it('should parse both QaseParameters and QaseGroupParameters', () => {
       const tags = [
         { name: '@QaseParameters={"browser":"chrome"}' },


### PR DESCRIPTION
- Updated package version from 2.1.7 to 2.1.8 in package.json.
- Improved support for QaseParameters and QaseGroupParameters tags in the storage logic.
- Added normalization for JSON strings to handle single quotes in parameters.
- Updated changelog to reflect the new version and features.

These changes enhance the functionality of the reporter by allowing more flexible parameter definitions in test tags.