### PR TITLE
chore: bump version to 2.1.9 and add QaseSuite support

### DIFF
--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,9 @@
+# qase-cucumberjs@2.1.9
+
+## What's new
+
+- Added support for QaseSuite tag.
+
 # qase-cucumberjs@2.1.8
 
 ## What's new

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",

--- a/qase-cucumberjs/src/models.ts
+++ b/qase-cucumberjs/src/models.ts
@@ -5,6 +5,7 @@ export interface TestMetadata {
   isIgnore: boolean;
   parameters: Record<string, string>;
   group_params: Record<string, string>;
+  suite: string | null;
 }
 
 export interface ScenarioData {


### PR DESCRIPTION
- Updated package version from 2.1.8 to 2.1.9 in package.json.
- Introduced support for the QaseSuite tag, allowing for suite categorization in test results.
- Enhanced storage logic to handle suite metadata and prioritize QaseSuite over feature names.
- Updated changelog to reflect the new version and features.

These changes improve the organization of test results by enabling suite-level categorization.