### PR TITLE
chore: bump version to 2.4.17 and eliminate startup delay

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.4.17
+
+## What's new
+
+Eliminated startup delay when reporter mode is `off`.
+
 # qase-javascript-commons@2.4.16
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.16",
+  "version": "2.4.17",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/utils/hostData.ts
+++ b/qase-javascript-commons/src/utils/hostData.ts
@@ -151,6 +151,28 @@ function getPackageVersion(packageName: string): string | null {
 }
 
 /**
+ * Returns minimal host data without slow operations (no npm list, no execSync for node/npm).
+ * Use when reporter mode is "off" to avoid startup delay.
+ * @returns {HostData} Minimal host information object
+ */
+export function getMinimalHostData(): HostData {
+  return {
+    system: os.platform(),
+    machineName: os.hostname(),
+    release: os.release(),
+    version: '',
+    arch: os.arch(),
+    node: '',
+    npm: '',
+    framework: '',
+    reporter: '',
+    commons: '',
+    apiClientV1: '',
+    apiClientV2: '',
+  };
+}
+
+/**
  * Gets information about the current host environment
  * @param {string} framework The framework name to check version for
  * @param {string} reporterName The reporter name to check version for


### PR DESCRIPTION
- Updated package version from 2.4.16 to 2.4.17 in package.json.
- Added a new function to return minimal host data, reducing startup delay when reporter mode is off.
- Updated changelog to reflect the new version and improvements.

These changes enhance the performance of the reporter by minimizing startup time in specific modes.
#883 