### PR TITLE
chore: bump version to 2.4.18 and fix console output link

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.4.18
+
+## What's new
+
+Fixed issue with incorrect link to failed test in the console output.
+
 # qase-javascript-commons@2.4.17
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.4.17",
+  "version": "2.4.18",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -218,7 +218,7 @@ export class TestOpsReporter extends AbstractReporter {
     if (!this.runId) {
       throw new Error('Run ID is not set');
     }
-    const baseLink = `${this.baseUrl}/run/${this.projectCode}/dashboard/${this.runId}?source=logs&status=%5B2%5D&search=`;
+    const baseLink = `${this.baseUrl}/run/${this.projectCode}/dashboard/${this.runId}?source=logs&search=`;
     if (id) {
       return `${baseLink}${this.projectCode}-${id}`;
     }


### PR DESCRIPTION
- Updated package version from 2.4.17 to 2.4.18 in package.json.
- Fixed the incorrect link to failed tests in the console output.
- Updated changelog to reflect the new version and changes.

These updates improve the accuracy of test reporting in the console.