### PR TITLE
chore: bump version to 2.5.1 and fix test status determination

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.5.1
+
+## What's new
+
+Fixed issue with incorrect test status determination.
+
 # qase-javascript-commons@2.5.0
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Updated package version from 2.5.0 to 2.5.1 in package.json.
- Enhanced the logic for determining test status, including handling assertion errors more accurately.
- Added new test cases to validate the updated status determination logic.
- Updated changelog to reflect the new version and changes.

These updates improve the accuracy of test status reporting in various scenarios.