### PR TITLE
docs: add native Playwright annotations pattern to link tests

### DIFF
--- a/qase-playwright/README.md
+++ b/qase-playwright/README.md
@@ -39,7 +39,7 @@ npm install --save-dev playwright-qase-reporter
 
 **2. Add Qase ID to your test:**
 
-Playwright offers **two ways** to link tests with Qase test cases:
+Playwright offers **three ways** to link tests with Qase test cases:
 
 ```typescript
 import { test, expect } from '@playwright/test';
@@ -55,6 +55,14 @@ test(qase(1, 'User can login with valid credentials'), async ({ page }) => {
 test('User can login', async ({ page }) => {
   qase.id(1);
   qase.title('User can login with valid credentials');
+  await page.goto('https://example.com');
+  expect(await page.title()).toBe('Example Domain');
+});
+
+// Option 3: Native Playwright annotations
+test('User can login', {
+  annotation: { type: 'QaseID', description: '1' },
+}, async ({ page }) => {
   await page.goto('https://example.com');
   expect(await page.title()).toBe('Example Domain');
 });

--- a/qase-playwright/docs/usage.md
+++ b/qase-playwright/docs/usage.md
@@ -29,7 +29,7 @@ This guide provides comprehensive instructions for integrating Qase with Playwri
 
 ## Adding QaseID
 
-Playwright offers **three flexible patterns** for linking automated tests to existing test cases in Qase.
+Playwright offers **four flexible patterns** for linking automated tests to existing test cases in Qase.
 
 ### Pattern 1: Wrapper Function (Single ID)
 
@@ -68,6 +68,32 @@ test('User can login', async ({ page }) => {
   expect(await page.title()).toBe('Login');
 });
 ```
+
+### Pattern 4: Native Playwright Annotations
+
+Use Playwright's native annotation system to specify Qase test case IDs:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+// Single ID
+test('User can login', {
+  annotation: { type: 'QaseID', description: '1' },
+}, async ({ page }) => {
+  await page.goto('https://example.com/login');
+  expect(await page.title()).toBe('Login');
+});
+
+// Multiple IDs (comma-separated)
+test('Test covering multiple scenarios', {
+  annotation: { type: 'QaseID', description: '1,2,3' },
+}, async ({ page }) => {
+  await page.goto('https://example.com');
+  expect(await page.title()).toBe('Example Domain');
+});
+```
+
+**Note:** The annotation pattern is useful when you want to avoid importing the Qase reporter in your test files, or when integrating with existing Playwright test metadata.
 
 ### Multi-Project Support
 


### PR DESCRIPTION
## Summary

Added documentation for the third way to link tests with Qase test cases using native Playwright annotations.

## Changes

### README.md
- Updated "two ways" → "three ways"
- Added Option 3: Native Playwright annotations example

### docs/usage.md
- Updated "three patterns" → "four patterns"  
- Added Pattern 4: Native Playwright Annotations with detailed examples
- Added note about when this pattern is useful

## New Pattern Example

```typescript
test('User can login', {
  annotation: { type: 'QaseID', description: '1' },
}, async ({ page }) => {
  await page.goto('https://example.com');
  expect(await page.title()).toBe('Example Domain');
});
```

## Benefits

This pattern is useful when:
- You want to avoid importing the Qase reporter in test files
- Integrating with existing Playwright test metadata
- Using Playwright's native annotation system for consistency

## Impact

- 📚 Documentation completeness improved
- 🎯 All three supported patterns now documented
- ✅ Examples provided for both single and multiple IDs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or API behavior changes.
> 
> **Overview**
> Documents an additional way to link Playwright tests to Qase cases using native Playwright `annotation` metadata (`type: 'QaseID'`).
> 
> Updates `README.md` and `docs/usage.md` to reflect the new option/pattern and adds examples for single and comma-separated multiple IDs, plus guidance on when to use annotations (e.g., avoiding importing the reporter in test files).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 046af648af9f97ffe7edbe6f42512fe101f4e285. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->