### PR TITLE
feat: add Network Profiler and bump patch versions for all reporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ tmp
 
 CLAUDE.md
 .planning/
+
+# Example package locks (managed by root workspace)
+examples/**/package-lock.json

--- a/examples/single/mocha/test/profiler-test.spec.js
+++ b/examples/single/mocha/test/profiler-test.spec.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+
+describe('Network Profiler Test', function() {
+  it('GET request should be intercepted by profiler', async function() {
+    const response = await fetch('https://jsonplaceholder.typicode.com/users/1');
+    assert.strictEqual(response.status, 200);
+    const user = await response.json();
+    assert.strictEqual(user.id, 1);
+  });
+
+  it('POST request should be intercepted by profiler', async function() {
+    const response = await fetch('https://jsonplaceholder.typicode.com/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'test', body: 'test body', userId: 1 })
+    });
+    assert.strictEqual(response.status, 201);
+  });
+
+  it('Multiple requests in one test', async function() {
+    const r1 = await fetch('https://jsonplaceholder.typicode.com/posts/1');
+    assert.strictEqual(r1.status, 200);
+
+    const r2 = await fetch('https://jsonplaceholder.typicode.com/comments?postId=1');
+    assert.strictEqual(r2.status, 200);
+  });
+});

--- a/examples/single/playwright/package.json
+++ b/examples/single/playwright/package.json
@@ -7,5 +7,8 @@
   "devDependencies": {
     "@playwright/test": "^1.56.1",
     "playwright-qase-reporter": "^2.1.6"
+  },
+  "dependencies": {
+    "qase-javascript-commons": "^2.0.0"
   }
 }

--- a/examples/single/playwright/test/profiler-api.spec.js
+++ b/examples/single/playwright/test/profiler-api.spec.js
@@ -1,0 +1,27 @@
+const { test } = require('playwright-qase-reporter/fixture');
+const { expect } = require('@playwright/test');
+
+test.describe('Network Profiler API Tests', () => {
+  test('GET request captured by profiler', async ({}) => {
+    const response = await fetch('https://jsonplaceholder.typicode.com/users/1');
+    expect(response.status).toBe(200);
+    const user = await response.json();
+    expect(user.id).toBe(1);
+  });
+
+  test('POST request captured by profiler', async ({}) => {
+    const response = await fetch('https://jsonplaceholder.typicode.com/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'test', body: 'test body', userId: 1 }),
+    });
+    expect(response.status).toBe(201);
+  });
+
+  test('Multiple requests in one test', async ({}) => {
+    const r1 = await fetch('https://jsonplaceholder.typicode.com/posts/1');
+    expect(r1.status).toBe(200);
+    const r2 = await fetch('https://jsonplaceholder.typicode.com/comments?postId=1');
+    expect(r2.status).toBe(200);
+  });
+});

--- a/examples/single/testcafe/package.json
+++ b/examples/single/testcafe/package.json
@@ -8,5 +8,8 @@
     "eslint-plugin-testcafe": "^0.2.1",
     "testcafe": "^3.7.2",
     "testcafe-reporter-qase": "^2.1.3"
+  },
+  "dependencies": {
+    "qase-javascript-commons": "^2.0.0"
   }
 }

--- a/examples/single/testcafe/tests/profiler-api.test.js
+++ b/examples/single/testcafe/tests/profiler-api.test.js
@@ -1,0 +1,25 @@
+fixture`Network Profiler API Tests`
+  .page`about:blank`;
+
+test('GET request captured by profiler', async t => {
+  const response = await fetch('https://jsonplaceholder.typicode.com/users/1');
+  await t.expect(response.status).eql(200);
+  const user = await response.json();
+  await t.expect(user.id).eql(1);
+});
+
+test('POST request captured by profiler', async t => {
+  const response = await fetch('https://jsonplaceholder.typicode.com/posts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'test', body: 'test body', userId: 1 }),
+  });
+  await t.expect(response.status).eql(201);
+});
+
+test('Multiple requests in one test', async t => {
+  const r1 = await fetch('https://jsonplaceholder.typicode.com/posts/1');
+  await t.expect(r1.status).eql(200);
+  const r2 = await fetch('https://jsonplaceholder.typicode.com/comments?postId=1');
+  await t.expect(r2.status).eql(200);
+});

--- a/examples/single/vitest/package.json
+++ b/examples/single/vitest/package.json
@@ -10,5 +10,8 @@
     "vitest": "^3.2.4",
     "typescript": "^5.9.3",
     "vitest-qase-reporter": "1.0.2"
+  },
+  "dependencies": {
+    "qase-javascript-commons": "^2.0.0"
   }
 }

--- a/examples/single/vitest/profiler-setup.ts
+++ b/examples/single/vitest/profiler-setup.ts
@@ -1,0 +1,40 @@
+import { beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { ConfigLoader, composeOptions, NetworkProfiler } from 'qase-javascript-commons';
+
+let profiler: NetworkProfiler | null = null;
+let stepSnapshot = 0;
+
+const configLoader = new ConfigLoader();
+const config = configLoader.load();
+const options = composeOptions({}, config);
+
+if (options.profilers?.includes('network')) {
+  profiler = new NetworkProfiler({
+    skipDomains: options.networkProfiler?.skip_domains,
+    trackOnFail: options.networkProfiler?.track_on_fail,
+  });
+
+  beforeAll(() => {
+    profiler!.enable();
+  });
+
+  afterAll(() => {
+    profiler!.restore();
+  });
+
+  beforeEach(() => {
+    stepSnapshot = profiler!.getAllSteps().length;
+  });
+
+  afterEach((context) => {
+    if (!profiler) return;
+    const allSteps = profiler.getAllSteps();
+    const newSteps = allSteps.slice(stepSnapshot);
+    if (newSteps.length > 0) {
+      // Use task.meta for cross-worker communication (serialized automatically).
+      // context.annotate() cannot be used in afterEach — Vitest considers the
+      // test complete before hooks run for annotation purposes.
+      (context.task.meta as Record<string, unknown>)._qaseProfilerSteps = JSON.stringify(newSteps);
+    }
+  });
+}

--- a/examples/single/vitest/vitest.config.ts
+++ b/examples/single/vitest/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     watch: false,
     testTimeout: 10000,
+    setupFiles: ['./profiler-setup.ts'],
     reporters: [
       'default',
       ['vitest-qase-reporter',

--- a/examples/single/wdio/package.json
+++ b/examples/single/wdio/package.json
@@ -10,5 +10,8 @@
     "@wdio/mocha-framework": "^8.40.0",
     "wdio-chromedriver-service": "^8.0.0",
     "wdio-qase-reporter": "^1.1.4"
+  },
+  "dependencies": {
+    "qase-javascript-commons": "^2.0.0"
   }
 }

--- a/examples/single/wdio/test/specs/profiler-api.spec.js
+++ b/examples/single/wdio/test/specs/profiler-api.spec.js
@@ -1,0 +1,24 @@
+describe('Network Profiler API Tests', () => {
+  it('GET request captured by profiler', async () => {
+    const response = await fetch('https://jsonplaceholder.typicode.com/users/1');
+    expect(response.status).toBe(200);
+    const user = await response.json();
+    expect(user.id).toBe(1);
+  });
+
+  it('POST request captured by profiler', async () => {
+    const response = await fetch('https://jsonplaceholder.typicode.com/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'test', body: 'test body', userId: 1 }),
+    });
+    expect(response.status).toBe(201);
+  });
+
+  it('Multiple requests in one test', async () => {
+    const r1 = await fetch('https://jsonplaceholder.typicode.com/posts/1');
+    expect(r1.status).toBe(200);
+    const r2 = await fetch('https://jsonplaceholder.typicode.com/comments?postId=1');
+    expect(r2.status).toBe(200);
+  });
+});

--- a/examples/single/wdio/wdio.conf.js
+++ b/examples/single/wdio/wdio.conf.js
@@ -1,5 +1,5 @@
 const WDIOQaseReporter = require('wdio-qase-reporter').default;
-const { afterRunHook, beforeRunHook } = require('wdio-qase-reporter');
+const { afterRunHook, beforeRunHook, QaseWdioService } = require('wdio-qase-reporter');
 
 exports.config = {
   runner: 'local',
@@ -27,6 +27,7 @@ exports.config = {
       },
     ],
   ],
+  services: [[QaseWdioService, {}]],
   framework: 'mocha',
   mochaOpts: {
     ui: 'bdd',

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "qase-mocha",
     "qase-wdio",
     "qase-vitest",
-    "./examples/*"
+    "./examples/single/*",
+    "./examples/multiProject/*"
   ],
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/qase-cucumberjs/README.md
+++ b/qase-cucumberjs/README.md
@@ -13,6 +13,7 @@ Qase CucumberJS Reporter enables seamless integration between your CucumberJS te
 - Native Gherkin step reporting (Given/When/Then automatically mapped)
 - Multi-project reporting support
 - Flexible configuration (file, environment variables, CucumberJS formatter)
+- Network Profiler for automatic HTTP request capture
 
 ## Installation
 
@@ -231,6 +232,30 @@ npx cucumber-js --profile default
 ```
 
 > **Note:** The reporter formatter should be specified with `-f cucumberjs-qase-reporter` flag or in your cucumber.js configuration.
+
+## Network Profiler
+
+The Network Profiler automatically captures outgoing HTTP requests made during test execution and reports them as REQUEST-type steps in Qase TestOps.
+
+**Enable in `qase.config.json`:**
+
+```json
+{
+  "profilers": ["network"],
+  "networkProfiler": {
+    "skip_domains": ["analytics.example.com"],
+    "track_on_fail": true
+  }
+}
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `profilers` | Array of profilers to enable. Use `["network"]` for HTTP capture | `[]` |
+| `networkProfiler.skip_domains` | Domains to exclude from profiling | `[]` |
+| `networkProfiler.track_on_fail` | Capture response body for failed requests (status >= 400) | `true` |
+
+> Requests to `qase.io` are always excluded automatically.
 
 ## Requirements
 

--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,10 @@
+# qase-cucumberjs@2.2.1
+
+## What's new
+
+- Added Network Profiler integration for automatic HTTP request capture during test execution.
+- Updated `qase-javascript-commons` dependency to `~2.5.6`.
+
 # qase-cucumberjs@2.2.0
 
 ## What's new

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/messages": "^22.0.0",
-    "qase-javascript-commons": "~2.5.0"
+    "qase-javascript-commons": "~2.5.6"
   },
   "peerDependencies": {
     "@cucumber/cucumber": ">=7.0.0"

--- a/qase-cucumberjs/src/reporter.ts
+++ b/qase-cucumberjs/src/reporter.ts
@@ -8,6 +8,7 @@ import {
   composeOptions,
   ConfigLoader,
   ConfigType,
+  NetworkProfiler,
   QaseReporter,
   ReporterInterface,
 } from 'qase-javascript-commons';
@@ -34,6 +35,12 @@ export class CucumberQaseReporter extends Formatter {
    * @private
    */
   private reporter: ReporterInterface;
+
+  /**
+   * @type {NetworkProfiler | null}
+   * @private
+   */
+  private profiler: NetworkProfiler | null = null;
   /**
    * @type {EventEmitter}
    * @private
@@ -53,15 +60,24 @@ export class CucumberQaseReporter extends Formatter {
 
     super(formatterOptions);
 
+    const composedOptions = composeOptions(qase, config);
     this.reporter = QaseReporter.getInstance({
-      ...composeOptions(qase, config),
+      ...composedOptions,
       frameworkPackage: '@cucumber/cucumber',
       frameworkName: 'cucumberjs',
       reporterName: 'cucumberjs-qase-reporter',
     });
 
+    if (composedOptions.profilers?.includes('network')) {
+      this.profiler = new NetworkProfiler({
+        skipDomains: composedOptions.networkProfiler?.skip_domains,
+        trackOnFail: composedOptions.networkProfiler?.track_on_fail,
+      });
+      this.profiler.enable();
+    }
+
     this.eventBroadcaster = formatterOptions.eventBroadcaster;
-    this.storage = new Storage();
+    this.storage = new Storage(this.profiler);
     this.bindEventListeners();
   }
 
@@ -104,6 +120,7 @@ export class CucumberQaseReporter extends Formatter {
    * @private
    */
   private async publishResults(): Promise<void> {
+    this.profiler?.restore();
     await this.reporter.publish();
   }
 

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -12,6 +12,7 @@ import {
   Attachment,
   CompoundError,
   generateSignature,
+  NetworkProfiler,
   Relation,
   StepStatusEnum,
   StepType,
@@ -38,6 +39,22 @@ const qaseSuiteRegExp = /^@[Qq]ase[Ss]uite=(.+)$/;
 const qaseIgnoreRegExp = /^@[Qq]ase[Ii][Gg][Nn][Oo][Rr][Ee]$/;
 
 export class Storage {
+  /**
+   * @type {NetworkProfiler | null}
+   * @private
+   */
+  private profiler: NetworkProfiler | null;
+
+  /**
+   * @type {Record<string, number>}
+   * @private
+   */
+  private profilerStepSnapshots: Record<string, number> = {};
+
+  constructor(profiler: NetworkProfiler | null = null) {
+    this.profiler = profiler;
+  }
+
   /**
    * @type {Record<string, Pickle>}
    * @private
@@ -187,6 +204,9 @@ export class Storage {
       testCaseStarted;
     this.testCaseStartedResult[testCaseStarted.id] =
       TestStatusEnum.passed;
+    if (this.profiler) {
+      this.profilerStepSnapshots[testCaseStarted.id] = this.profiler.getAllSteps().length;
+    }
   }
 
   /**
@@ -304,6 +324,15 @@ export class Storage {
 
     const steps = this.convertSteps(pickle.steps, tc);
 
+    // Collect profiler steps since this test case started
+    let profilerSteps: TestStepType[] = [];
+    if (this.profiler) {
+      const snapshot = this.profilerStepSnapshots[testCase.testCaseStartedId] ?? 0;
+      const allSteps = this.profiler.getAllSteps();
+      profilerSteps = allSteps.slice(snapshot);
+      delete this.profilerStepSnapshots[testCase.testCaseStartedId];
+    }
+
     const hasProjectMapping = Object.keys(metadata.projectMapping).length > 0;
     const result = {
       attachments: this.attachments[testCase.testCaseStartedId] ?? [],
@@ -324,7 +353,7 @@ export class Storage {
       relations: relations,
       run_id: null,
       signature: this.getSignature(pickle, metadata.ids, params),
-      steps: steps,
+      steps: [...steps, ...profilerSteps],
       testops_id: metadata.ids.length > 0 ? metadata.ids : null,
       testops_project_mapping: hasProjectMapping ? metadata.projectMapping : null,
       id: tcs.id,

--- a/qase-cypress/README.md
+++ b/qase-cypress/README.md
@@ -15,6 +15,7 @@ Qase Cypress Reporter enables seamless integration between your Cypress tests an
 - Flexible configuration (file, environment variables, Cypress config)
 - Cucumber/Gherkin integration support
 - Automatic screenshot and video attachments
+- Network Profiler for automatic HTTP request capture
 
 ## Installation
 
@@ -267,6 +268,39 @@ npx cypress open
 # Run with environment variables
 QASE_MODE=testops QASE_TESTOPS_PROJECT=DEMO npx cypress run
 ```
+
+## Network Profiler
+
+The Network Profiler automatically captures browser-originated HTTP requests made during test execution and reports them as REQUEST-type steps in Qase TestOps.
+
+**Additional setup:** Import the support file in your `cypress/support/e2e.ts` (or `e2e.js`):
+
+```typescript
+// cypress/support/e2e.ts
+import 'cypress-qase-reporter/support';
+```
+
+The support file registers a `beforeEach` hook that installs `cy.intercept('**')` to capture all application HTTP requests. No changes to spec files are needed.
+
+**Enable in `qase.config.json`:**
+
+```json
+{
+  "profilers": ["network"],
+  "networkProfiler": {
+    "skip_domains": ["analytics.example.com"],
+    "track_on_fail": true
+  }
+}
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `profilers` | Array of profilers to enable. Use `["network"]` for HTTP capture | `[]` |
+| `networkProfiler.skip_domains` | Domains to exclude from profiling | `[]` |
+| `networkProfiler.track_on_fail` | Capture response body for failed requests (status >= 400) | `true` |
+
+> Requests to `qase.io` and Cypress internal requests (`/__cypress/`) are always excluded automatically.
 
 ## Requirements
 

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,10 @@
+# cypress-qase-reporter@3.2.1
+
+## What's new
+
+- Added Network Profiler integration for automatic HTTP request capture during test execution.
+- Updated `qase-javascript-commons` dependency to `~2.5.6`.
+
 # cypress-qase-reporter@3.2.0
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -51,7 +51,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.5.0",
+    "qase-javascript-commons": "~2.5.6",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-cypress/src/metadata.js
+++ b/qase-cypress/src/metadata.js
@@ -84,4 +84,11 @@ module.exports = function(on) {
       return null;
     },
   });
+
+  on('task', {
+    qaseNetworkRequest(data) {
+      MetadataManager.addNetworkRequest(data);
+      return null;
+    },
+  });
 };

--- a/qase-cypress/src/metadata/manager.ts
+++ b/qase-cypress/src/metadata/manager.ts
@@ -1,4 +1,4 @@
-import { Attach, Metadata, StepStart } from './models';
+import { Attach, Metadata, NetworkRequestData, StepStart } from './models';
 import { readFileSync, existsSync, unlinkSync, writeFileSync } from 'fs';
 import { v4 as uuidv4 } from 'uuid';
 import path from 'path';
@@ -126,6 +126,16 @@ export class MetadataManager {
 
     this.setMetadata(metadata);
   }
+
+  public static addNetworkRequest(data: NetworkRequestData): void {
+    const metadata = this.getMetadata() ?? {};
+    if (!metadata.networkRequests) {
+      metadata.networkRequests = [];
+    }
+    metadata.networkRequests.push(data);
+    this.setMetadata(metadata);
+  }
+
 
   public static setSuite(suite: string): void {
     const metadata = this.getMetadata() ?? {};

--- a/qase-cypress/src/metadata/models.ts
+++ b/qase-cypress/src/metadata/models.ts
@@ -1,5 +1,15 @@
 import { Attachment } from 'qase-javascript-commons';
 
+export interface NetworkRequestData {
+  method: string;
+  url: string;
+  statusCode: number | null;
+  duration: number;
+  responseBody: string | null;
+  startTime: number;
+}
+
+
 export interface Metadata {
   title?: string | undefined;
   fields?: Record<string, string>;
@@ -14,6 +24,7 @@ export interface Metadata {
   firstStepName?: string | undefined;
   attachments?: Attachment[];
   stepAttachments?: Record<string, Attachment[]>;
+  networkRequests?: NetworkRequestData[];
 }
 
 export interface StepStart {

--- a/qase-cypress/src/plugin.js
+++ b/qase-cypress/src/plugin.js
@@ -1,6 +1,23 @@
 import { afterRunHook, beforeRunHook } from './hooks';
+import { ConfigLoader, composeOptions } from 'qase-javascript-commons';
+import { configSchema } from './configSchema';
 
 module.exports = function (on, config) {
+  try {
+    const configLoader = new ConfigLoader(configSchema);
+    const qaseConfig = configLoader.load();
+    const reporterOptions = config.reporterOptions?.['cypressQaseReporterReporterOptions'] ?? {};
+    const composed = composeOptions(reporterOptions, qaseConfig);
+    if (composed.profilers?.includes('network')) {
+      config.env['QASE_PROFILER_ENABLED'] = 'true';
+      config.env['QASE_PROFILER_SKIP_DOMAINS'] = JSON.stringify(
+        composed.networkProfiler?.skip_domains ?? []
+      );
+    }
+  } catch (e) {
+    // Silent — profiler config errors must not break test runs
+  }
+
   on('before:run', async () => {
     await beforeRunHook(config);
   });
@@ -8,4 +25,6 @@ module.exports = function (on, config) {
   on('after:run', async () => {
     await afterRunHook(config);
   });
+
+  return config;
 };

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -11,6 +11,7 @@ import {
   generateSignature,
   QaseReporter,
   ReporterInterface,
+  StepRequestData,
   StepStatusEnum,
   StepType,
   TestResultType,
@@ -431,6 +432,28 @@ export class CypressQaseReporter extends reporters.Base {
             projectMapping[code] = [...(projectMapping[code] ?? []), ...idsFromTag];
           }
         }
+      }
+    }
+
+    // Convert network profiler requests to REQUEST steps
+    if (metadata?.networkRequests && metadata.networkRequests.length > 0) {
+      for (const req of metadata.networkRequests) {
+        const step = new TestStepType(StepType.REQUEST);
+        step.id = uuidv4();
+        const data = step.data as StepRequestData;
+        data.request_method = req.method;
+        data.request_url = req.url;
+        data.request_headers = null;
+        data.request_body = null;
+        data.status_code = req.statusCode;
+        data.response_body = req.responseBody;
+        data.response_headers = null;
+        step.execution.status = req.statusCode !== null && req.statusCode >= 400
+          ? StepStatusEnum.failed
+          : StepStatusEnum.passed;
+        step.execution.start_time = req.startTime / 1000;
+        step.execution.duration = req.duration;
+        steps.push(step);
       }
     }
 

--- a/qase-cypress/src/support.ts
+++ b/qase-cypress/src/support.ts
@@ -1,0 +1,69 @@
+/// <reference types="cypress" />
+
+beforeEach(() => {
+  if (Cypress.env('QASE_PROFILER_ENABLED') !== 'true') {
+    return;
+  }
+
+  let skipDomains: string[] = [];
+  try {
+    const raw = Cypress.env('QASE_PROFILER_SKIP_DOMAINS') as string | undefined;
+    if (raw) {
+      skipDomains = JSON.parse(raw) as string[];
+    }
+  } catch {
+    skipDomains = [];
+  }
+
+  cy.intercept('**', (req) => {
+    const url: string = req.url;
+
+    if (url.includes('/__cypress/')) {
+      return;
+    }
+
+    if (url.includes('qase.io')) {
+      return;
+    }
+
+    for (const domain of skipDomains) {
+      if (url.includes(domain)) {
+        return;
+      }
+    }
+
+    const startTime = Date.now();
+
+    req.continue((res) => {
+      const duration = Date.now() - startTime;
+      const statusCode: number = res.statusCode;
+
+      let responseBody: string | null = null;
+      if (statusCode >= 400) {
+        const body = res.body as unknown;
+        if (typeof body === 'string') {
+          responseBody = body.slice(0, 10000);
+        } else if (body !== null && body !== undefined) {
+          try {
+            responseBody = JSON.stringify(body).slice(0, 10000);
+          } catch {
+            responseBody = null;
+          }
+        }
+      }
+
+      cy.task(
+        'qaseNetworkRequest',
+        {
+          method: req.method,
+          url,
+          statusCode,
+          duration,
+          responseBody,
+          startTime,
+        },
+        { log: false },
+      );
+    });
+  });
+});

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,11 @@
+# qase-javascript-commons@2.5.6
+
+## What's new
+
+- Added Network Profiler framework for automatic HTTP/HTTPS request interception during test execution.
+- Added `StepType.REQUEST` step type for network request data in test results.
+- Added configurable profiler options in `qase.config.json` (`profilers` and `networkProfiler` fields).
+
 # qase-javascript-commons@2.5.5
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/client/clientV2.ts
+++ b/qase-javascript-commons/src/client/clientV2.ts
@@ -209,8 +209,10 @@ export class ClientV2 extends ClientV1 {
 
         if (step.step_type === StepType.TEXT) {
             this.processTextStep(step, resultStep, testTitle);
-        } else {
+        } else if (step.step_type === StepType.GHERKIN) {
             this.processGherkinStep(step, resultStep);
+        } else if (step.step_type === StepType.REQUEST) {
+            this.processRequestStep(step, resultStep);
         }
 
         if (step.steps.length > 0) {
@@ -261,6 +263,15 @@ export class ClientV2 extends ClientV1 {
         const stepData = step.data;
         resultStep.data.action = stepData.keyword;
     }
+
+    private processRequestStep(step: TestStepType, resultStep: ResultStep): void {
+        if (!('request_method' in step.data) || !resultStep.data) {
+            return;
+        }
+        const stepData = step.data;
+        resultStep.data.action = `${stepData.request_method} ${stepData.request_url}`;
+    }
+
 
     private getExecution(exec: TestExecution): ResultExecution {
         return {

--- a/qase-javascript-commons/src/config/config-validation-schema.ts
+++ b/qase-javascript-commons/src/config/config-validation-schema.ts
@@ -308,5 +308,29 @@ export const configValidationSchema = {
         },
       },
     },
+
+    profilers: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      nullable: true,
+    },
+
+    networkProfiler: {
+      type: 'object',
+      nullable: true,
+      properties: {
+        skip_domains: {
+          type: 'array',
+          items: { type: 'string' },
+          nullable: true,
+        },
+        track_on_fail: {
+          type: 'boolean',
+          nullable: true,
+        },
+      },
+    },
   },
 };

--- a/qase-javascript-commons/src/index.ts
+++ b/qase-javascript-commons/src/index.ts
@@ -6,6 +6,7 @@ export * from './models';
 export * from './options';
 export * from './reporters';
 export * from './writer';
+export * from './profilers';
 
 export * from './utils/get-package-version';
 export * from './utils/mimeTypes';

--- a/qase-javascript-commons/src/models/index.ts
+++ b/qase-javascript-commons/src/models/index.ts
@@ -2,6 +2,7 @@ export { TestResultType } from './test-result';
 export type { Relation, Suite, SuiteData, TestopsProjectMapping } from './test-result';
 export { TestExecution, TestStatusEnum } from './test-execution';
 export { TestStepType, StepType } from './test-step';
+export type { StepRequestData, StepTextData, StepGherkinData } from './step-data';
 export { StepStatusEnum } from './step-execution';
 export type { Attachment } from './attachment';
 export type { Report } from './report';

--- a/qase-javascript-commons/src/models/step-data.ts
+++ b/qase-javascript-commons/src/models/step-data.ts
@@ -9,3 +9,13 @@ export interface StepGherkinData {
   name: string;
   line: number;
 }
+
+export interface StepRequestData {
+  request_method: string;
+  request_url: string;
+  request_headers: Record<string, string> | null;
+  request_body: string | null;
+  status_code: number | null;
+  response_body: string | null;
+  response_headers: Record<string, string> | null;
+}

--- a/qase-javascript-commons/src/models/test-step.ts
+++ b/qase-javascript-commons/src/models/test-step.ts
@@ -1,4 +1,4 @@
-import { StepGherkinData, StepTextData } from './step-data';
+import { StepGherkinData, StepRequestData, StepTextData } from './step-data';
 import { StepExecution } from './step-execution';
 
 import { Attachment } from './attachment';
@@ -7,12 +7,13 @@ import { Attachment } from './attachment';
 export enum StepType {
   TEXT = 'text',
   GHERKIN = 'gherkin',
+  REQUEST = 'request',
 }
 
 export class TestStepType {
   id: string;
   step_type: StepType;
-  data: StepTextData | StepGherkinData;
+  data: StepTextData | StepGherkinData | StepRequestData;
   parent_id: string | null;
   execution: StepExecution;
   attachments: Attachment[];
@@ -31,11 +32,21 @@ export class TestStepType {
         expected_result: null,
         data: null,
       };
-    } else {
+    } else if (type === StepType.GHERKIN) {
       this.data = {
         keyword: '',
         name: '',
         line: 0,
+      };
+    } else {
+      this.data = {
+        request_method: '',
+        request_url: '',
+        request_headers: null,
+        request_body: null,
+        status_code: null,
+        response_body: null,
+        response_headers: null,
       };
     }
   }

--- a/qase-javascript-commons/src/options/options-type.ts
+++ b/qase-javascript-commons/src/options/options-type.ts
@@ -43,6 +43,11 @@ export type OptionsType = {
   /** Multi-project configuration (used when mode is testops_multi). */
   testops_multi?: TestOpsMultiConfigType | undefined;
   report?: RecursivePartial<AdditionalReportOptionsType> | undefined;
+  profilers?: string[] | undefined;
+  networkProfiler?: {
+    skip_domains?: string[] | undefined;
+    track_on_fail?: boolean | undefined;
+  } | undefined;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/qase-javascript-commons/src/profilers/abstract-profiler.ts
+++ b/qase-javascript-commons/src/profilers/abstract-profiler.ts
@@ -1,0 +1,5 @@
+export abstract class AbstractProfiler {
+  abstract enable(): void;
+  abstract disable(): void;
+  abstract restore(): void;
+}

--- a/qase-javascript-commons/src/profilers/fetch-interceptor.ts
+++ b/qase-javascript-commons/src/profilers/fetch-interceptor.ts
@@ -1,0 +1,329 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import { TestStepType } from '../models/test-step';
+import { StepRequestData } from '../models/step-data';
+import { buildRequestStep } from './http-interceptor';
+
+// Forward-declare the profiler interface to avoid circular imports
+interface ProfilerRef {
+  shouldSkip(url: string): boolean;
+  trackOnFail: boolean;
+  fallbackSteps: TestStepType[];
+}
+
+// ─── Type for pending request info keyed on undici request object ─────────────
+
+interface PendingRequestInfo {
+  /** Method extracted from undici request object */
+  method: string;
+  /** Full URL: origin + path */
+  url: string;
+  /** Millisecond timestamp when undici:request:create fired */
+  startTime: number;
+  /** The ALS context captured at create time (critical: connection pooling breaks getStore() in headers event). Null when outside ALS context (fallback mode). */
+  alsContext: TestStepType[] | null;
+}
+
+// ─── FetchInterceptor ─────────────────────────────────────────────────────────
+
+/**
+ * FetchInterceptor subscribes to undici diagnostics_channel events to capture
+ * outgoing fetch() calls as REQUEST-type steps in the AsyncLocalStorage store.
+ *
+ * Works with Node.js 18+ global fetch (which uses undici internally).
+ * Gracefully skips subscription on Node < 18 (no global fetch).
+ *
+ * Key design decisions:
+ *  - WeakMap keyed on undici request objects (same reference across all events)
+ *  - ALS context captured at undici:request:create time, NOT at headers time.
+ *    This is critical because undici connection pooling can break AsyncLocalStorage
+ *    propagation between the create and headers events when connections are reused.
+ *  - globalThis.fetch wrapping intercepts error response bodies (undici:request:bodyChunkReceived
+ *    is not available in Node 22's built-in undici)
+ *  - All handlers wrapped in try/catch (INTC-06: silent failure)
+ *
+ * Event flow:
+ *  undici:request:create   → capture method, URL, start time, ALS context → WeakMap
+ *  undici:request:headers  → build step using WeakMap data, push to ALS accumulator
+ *  undici:request:trailers → cleanup WeakMap entry
+ *  fetch wrapper           → update response_body for error responses (>= 400)
+ */
+export class FetchInterceptor {
+  private readonly store: AsyncLocalStorage<TestStepType[]>;
+  private readonly profiler: ProfilerRef;
+
+  // WeakMap keyed on undici request objects (same reference across create/headers/trailers events)
+  private readonly pendingRequests = new WeakMap<object, PendingRequestInfo>();
+
+  // Map from step to body-update callback (for error response body capture)
+  private readonly bodyHandlers = new WeakMap<TestStepType, (body: string) => void>();
+
+  // Bound handler references (needed for subscribe/unsubscribe identity)
+  private readonly createHandler: (msg: unknown) => void;
+  private readonly headersHandler: (msg: unknown) => void;
+  private readonly trailersHandler: (msg: unknown) => void;
+
+  // Saved original fetch for wrapping/unwrapping
+  private origFetch: typeof globalThis.fetch | null = null;
+
+  constructor(store: AsyncLocalStorage<TestStepType[]>, profiler: ProfilerRef) {
+    this.store = store;
+    this.profiler = profiler;
+
+    // Bind handlers as arrow functions for subscribe/unsubscribe reference identity
+    this.createHandler = (msg: unknown) => {
+      try {
+        this.handleCreate(msg);
+      } catch {
+        // INTC-06: silent failure
+      }
+    };
+
+    this.headersHandler = (msg: unknown) => {
+      try {
+        this.handleHeaders(msg);
+      } catch {
+        // INTC-06: silent failure
+      }
+    };
+
+    this.trailersHandler = (msg: unknown) => {
+      try {
+        this.handleTrailers(msg);
+      } catch {
+        // INTC-06: silent failure
+      }
+    };
+  }
+
+  /**
+   * Subscribe to undici diagnostics_channel events and wrap global fetch for
+   * error response body capture.
+   *
+   * No-op on Node < 18 (no global fetch) or if diagnostics_channel unavailable.
+   */
+  subscribe(): void {
+    // Guard: require global fetch (Node 18+)
+    if (typeof globalThis.fetch !== 'function') {
+      return;
+    }
+
+    let dc: typeof import('node:diagnostics_channel') | undefined;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      dc = require('node:diagnostics_channel') as typeof import('node:diagnostics_channel');
+    } catch {
+      return; // diagnostics_channel unavailable — skip entirely
+    }
+
+    if (typeof dc.subscribe !== 'function') {
+      return;
+    }
+
+    dc.subscribe('undici:request:create', this.createHandler);
+    dc.subscribe('undici:request:headers', this.headersHandler);
+    dc.subscribe('undici:request:trailers', this.trailersHandler);
+
+    // Wrap global fetch to intercept error response bodies
+    // (undici:request:bodyChunkReceived not available in Node 22 built-in undici)
+    this.origFetch = globalThis.fetch;
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    (globalThis as any).fetch = async function wrappedFetch(
+      input: Parameters<typeof globalThis.fetch>[0],
+      init?: Parameters<typeof globalThis.fetch>[1],
+    ): Promise<Response> {
+      const origFetch = self.origFetch;
+      if (!origFetch) {
+        throw new Error('fetch not available');
+      }
+      const response = await origFetch.call(globalThis, input, init);
+
+      // Intercept error responses to capture body
+      if (response.status >= 400 && self.profiler.trackOnFail) {
+        try {
+          // Clone to read body without consuming the original response
+          const cloned = response.clone();
+          void cloned.text().then((bodyText) => {
+            try {
+              self.applyResponseBody(input, response.status, bodyText);
+            } catch {
+              // INTC-06: silent failure
+            }
+          });
+        } catch {
+          // INTC-06: silent failure
+        }
+      }
+
+      return response;
+    };
+  }
+
+  /**
+   * Unsubscribe from diagnostics_channel events and restore original global fetch.
+   */
+  unsubscribe(): void {
+    // Restore original fetch
+    if (this.origFetch !== null) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (globalThis as any).fetch = this.origFetch;
+      this.origFetch = null;
+    }
+
+    let dc: typeof import('node:diagnostics_channel') | undefined;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      dc = require('node:diagnostics_channel') as typeof import('node:diagnostics_channel');
+    } catch {
+      return;
+    }
+
+    // Feature-detect unsubscribe (Pitfall 5: not available in all Node versions)
+    if (typeof dc.unsubscribe !== 'function') {
+      return;
+    }
+
+    try {
+      dc.unsubscribe('undici:request:create', this.createHandler);
+    } catch {
+      // silent
+    }
+    try {
+      dc.unsubscribe('undici:request:headers', this.headersHandler);
+    } catch {
+      // silent
+    }
+    try {
+      dc.unsubscribe('undici:request:trailers', this.trailersHandler);
+    } catch {
+      // silent
+    }
+  }
+
+  // ─── Private event handlers ─────────────────────────────────────────────────
+
+  private handleCreate(msg: unknown): void {
+    const message = msg as { request?: Record<string, unknown> };
+    const req = message.request;
+    if (!req) return;
+
+    // CRITICAL: Capture ALS context HERE (at create time), not in headersHandler.
+    // Due to undici connection pooling, store.getStore() may return undefined in
+    // the headers event when connections are reused across test runs.
+    const acc = this.store.getStore();
+    // acc may be null/undefined when outside a run() context — use fallback accumulator in that case
+
+    const method = typeof req['method'] === 'string' ? req['method'] : 'GET';
+    const origin = typeof req['origin'] === 'string' ? req['origin'] : '';
+    const path = typeof req['path'] === 'string' ? req['path'] : '/';
+    const url = `${origin}${path}`;
+
+    // Check shouldSkip
+    if (this.profiler.shouldSkip(url)) {
+      return;
+    }
+
+    this.pendingRequests.set(req, {
+      method,
+      url,
+      startTime: Date.now(),
+      alsContext: acc ?? null,
+    });
+  }
+
+  private handleHeaders(msg: unknown): void {
+    const message = msg as {
+      request?: Record<string, unknown>;
+      response?: { statusCode?: number };
+    };
+    const req = message.request;
+    if (!req) return;
+
+    const pending = this.pendingRequests.get(req);
+    if (!pending) return;
+
+    // Use the ALS context captured at create time — do NOT call store.getStore() here.
+    // Connection pooling in undici can break ALS propagation between events.
+    const acc = pending.alsContext;
+
+    const endTime = Date.now();
+    const statusCode = message.response?.statusCode ?? 0;
+
+    const step = buildRequestStep({
+      method: pending.method,
+      url: pending.url,
+      statusCode,
+      responseBody: null, // filled in later for errors via fetch wrapper
+      responseHeaders: null,
+      startTime: pending.startTime,
+      endTime,
+    });
+
+    if (acc !== null) {
+      acc.push(step);
+    } else {
+      // No ALS context — push to fallback accumulator (for Jest/Vitest/WDIO workers)
+      this.profiler.fallbackSteps.push(step);
+    }
+
+    // Register body handler for error responses
+    if (statusCode >= 400 && this.profiler.trackOnFail) {
+      this.bodyHandlers.set(step, (bodyText: string) => {
+        (step.data as StepRequestData).response_body = bodyText;
+      });
+    }
+  }
+
+  private handleTrailers(msg: unknown): void {
+    const message = msg as { request?: Record<string, unknown> };
+    const req = message.request;
+    if (!req) return;
+
+    // Clean up pending state
+    this.pendingRequests.delete(req);
+  }
+
+  /**
+   * Called by the fetch wrapper when an error response body is available.
+   * Finds the most recently added step for this URL/status and updates its response_body.
+   */
+  private applyResponseBody(
+    input: Parameters<typeof globalThis.fetch>[0],
+    statusCode: number,
+    bodyText: string,
+  ): void {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+    // Get all accumulated steps — use ALS context if available, fallback accumulator otherwise
+    const searchArray = this.store.getStore() ?? this.profiler.fallbackSteps;
+    if (searchArray.length === 0) return;
+
+    // Find the last step that matches this response and has null body
+    for (let i = searchArray.length - 1; i >= 0; i--) {
+      const step = searchArray[i];
+      if (!step) continue;
+      const data = step.data as StepRequestData;
+      if (data.status_code !== statusCode) continue;
+      if (data.response_body !== null) continue;
+
+      // Check if URL matches (handle query strings, trailing slashes)
+      const stepUrl = data.request_url ?? '';
+      const inputUrlBase = url.split('?')[0] ?? url;
+      if (url.includes(stepUrl) || stepUrl.includes(inputUrlBase) || stepUrl === inputUrlBase) {
+        const handler = this.bodyHandlers.get(step);
+        if (handler) {
+          handler(bodyText);
+          this.bodyHandlers.delete(step);
+          return;
+        }
+      }
+    }
+  }
+}

--- a/qase-javascript-commons/src/profilers/http-interceptor.ts
+++ b/qase-javascript-commons/src/profilers/http-interceptor.ts
@@ -1,0 +1,312 @@
+import http from 'node:http';
+import https from 'node:https';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { v4 as uuidv4 } from 'uuid';
+
+import { TestStepType, StepType } from '../models/test-step';
+import { StepStatusEnum } from '../models/step-execution';
+import { StepRequestData } from '../models/step-data';
+
+// Forward-declare the profiler interface we need to avoid circular imports
+interface ProfilerRef {
+  shouldSkip(url: string): boolean;
+  trackOnFail: boolean;
+  fallbackSteps: TestStepType[];
+}
+
+// ─── Type aliases for wrapped function signatures ─────────────────────────────
+
+type HttpRequestFn = typeof http.request;
+type HttpGetFn = typeof http.get;
+type HttpsRequestFn = typeof https.request;
+type HttpsGetFn = typeof https.get;
+
+// ─── Utility: extractRequestInfo ─────────────────────────────────────────────
+
+export interface RequestInfo {
+  method: string;
+  url: string;
+}
+
+/**
+ * Handles the 3 `http.request()` call signatures:
+ *  - (url: string, options?, callback?)
+ *  - (url: URL, options?, callback?)
+ *  - (options: RequestOptions, callback?)
+ *
+ * Returns `{ method, url }`. Default method is 'GET'.
+ */
+export function extractRequestInfo(
+  args: [
+    string | URL | http.RequestOptions,
+    (http.RequestOptions | ((res: http.IncomingMessage) => void))?,
+    ((res: http.IncomingMessage) => void)?,
+  ],
+): RequestInfo {
+  const first = args[0];
+
+  if (typeof first === 'string') {
+    // Signature: (url: string, options?, callback?)
+    const options = args[1];
+    const method =
+      options && typeof options === 'object' && !('emit' in options) && 'method' in options && typeof options.method === 'string'
+        ? options.method
+        : 'GET';
+    return { method, url: first };
+  }
+
+  if (first instanceof URL) {
+    // Signature: (url: URL, options?, callback?)
+    const options = args[1];
+    const method =
+      options && typeof options === 'object' && !('emit' in options) && 'method' in options && typeof options.method === 'string'
+        ? options.method
+        : 'GET';
+    return { method, url: first.toString() };
+  }
+
+  // Signature: (options: RequestOptions, callback?)
+  const opts = first;
+  const method = opts.method ?? 'GET';
+  const protocol = opts.protocol ?? 'http:';
+  const hostname = opts.hostname ?? opts.host ?? 'localhost';
+  const port = opts.port !== undefined ? `:${String(opts.port)}` : '';
+  const path = opts.path ?? '/';
+  const url = `${protocol}//${hostname}${port}${path}`;
+
+  return { method, url };
+}
+
+// ─── Utility: headersToRecord ─────────────────────────────────────────────────
+
+/**
+ * Converts `http.IncomingHttpHeaders` (which has `string | string[] | undefined` values)
+ * to `Record<string, string>`. Multi-value headers joined with `', '`. Undefined values skipped.
+ */
+export function headersToRecord(
+  headers: http.IncomingHttpHeaders,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      result[key] = value.join(', ');
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+// ─── Utility: buildRequestStep ───────────────────────────────────────────────
+
+export function buildRequestStep(params: {
+  method: string;
+  url: string;
+  statusCode: number;
+  responseBody: string | null;
+  responseHeaders: Record<string, string> | null;
+  startTime: number;
+  endTime: number;
+}): TestStepType {
+  const step = new TestStepType(StepType.REQUEST);
+  step.id = uuidv4();
+
+  const data = step.data as StepRequestData;
+  data.request_method = params.method;
+  data.request_url = params.url;
+  data.request_headers = null;
+  data.request_body = null;
+  data.status_code = params.statusCode;
+  data.response_body = params.responseBody;
+  data.response_headers = params.responseHeaders;
+
+  step.execution.start_time = params.startTime;
+  step.execution.end_time = params.endTime;
+  step.execution.duration = params.endTime - params.startTime;
+  step.execution.status = params.statusCode >= 400 ? StepStatusEnum.failed : StepStatusEnum.passed;
+
+  return step;
+}
+
+// ─── HttpInterceptor ─────────────────────────────────────────────────────────
+
+/**
+ * HttpInterceptor monkey-patches Node.js http/https module functions to capture
+ * outgoing requests as REQUEST-type steps in the AsyncLocalStorage store.
+ *
+ * Pattern:
+ *  1. `install()` — saves originals, replaces with wrappers
+ *  2. `uninstall()` — restores originals
+ */
+export class HttpInterceptor {
+  private readonly store: AsyncLocalStorage<TestStepType[]>;
+  private readonly profiler: ProfilerRef;
+
+  private origHttpRequest: HttpRequestFn | null = null;
+  private origHttpGet: HttpGetFn | null = null;
+  private origHttpsRequest: HttpsRequestFn | null = null;
+  private origHttpsGet: HttpsGetFn | null = null;
+
+  constructor(store: AsyncLocalStorage<TestStepType[]>, profiler: ProfilerRef) {
+    this.store = store;
+    this.profiler = profiler;
+  }
+
+  install(): void {
+    this.origHttpRequest = http.request;
+    this.origHttpGet = http.get;
+    this.origHttpsRequest = https.request;
+    this.origHttpsGet = https.get;
+
+    const wrappedHttpRequest = this.wrapRequestFn(this.origHttpRequest);
+    const wrappedHttpGet = this.wrapRequestFn(this.origHttpGet) as HttpGetFn;
+    const wrappedHttpsRequest = this.wrapRequestFn(this.origHttpsRequest) as HttpsRequestFn;
+    const wrappedHttpsGet = this.wrapRequestFn(this.origHttpsGet) as HttpsGetFn;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    (http as any).request = wrappedHttpRequest;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    (http as any).get = wrappedHttpGet;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    (https as any).request = wrappedHttpsRequest;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    (https as any).get = wrappedHttpsGet;
+  }
+
+  uninstall(): void {
+    if (this.origHttpRequest !== null) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (http as any).request = this.origHttpRequest;
+      this.origHttpRequest = null;
+    }
+    if (this.origHttpGet !== null) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (http as any).get = this.origHttpGet;
+      this.origHttpGet = null;
+    }
+    if (this.origHttpsRequest !== null) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (https as any).request = this.origHttpsRequest;
+      this.origHttpsRequest = null;
+    }
+    if (this.origHttpsGet !== null) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (https as any).get = this.origHttpsGet;
+      this.origHttpsGet = null;
+    }
+  }
+
+  /**
+   * Creates a wrapper around a http.request-like function.
+   * The wrapper:
+   *  1. Calls the original function to get the ClientRequest
+   *  2. Checks if there's an active ALS context — if not, returns unchanged
+   *  3. Checks shouldSkip — if true, returns unchanged
+   *  4. Intercepts the 'response' event via req.emit override
+   *  5. Builds a TestStepType on response end and pushes to accumulator
+   */
+  private wrapRequestFn(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    origFn: (...args: any[]) => http.ClientRequest,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): (...args: any[]) => http.ClientRequest {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return function (this: unknown, ...args: any[]): http.ClientRequest {
+      // Call original first to get the ClientRequest
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      const req: http.ClientRequest = origFn.apply(this, args);
+
+      // Extract request info
+      let reqInfo: RequestInfo;
+      try {
+        reqInfo = extractRequestInfo(
+          args as [
+            string | URL | http.RequestOptions,
+            (http.RequestOptions | ((res: http.IncomingMessage) => void))?,
+            ((res: http.IncomingMessage) => void)?,
+          ],
+        );
+      } catch {
+        return req;
+      }
+
+      // Check if this domain should be skipped
+      if (self.profiler.shouldSkip(reqInfo.url)) {
+        return req;
+      }
+
+      const startTime = Date.now();
+      const origEmit = req.emit.bind(req);
+
+      // Override req.emit to intercept the 'response' event
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      req.emit = function (event: string, ...emitArgs: any[]): boolean {
+        if (event === 'response') {
+          const res = emitArgs[0] as http.IncomingMessage;
+          try {
+            const chunks: Buffer[] = [];
+            const isError = (res.statusCode ?? 0) >= 400;
+
+            // Register data listener BEFORE calling original emit (Pitfall 2: stream consumption race)
+            if (isError && self.profiler.trackOnFail) {
+              res.on('data', (chunk: Buffer | string) => {
+                try {
+                  chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+                } catch {
+                  // silent failure
+                }
+              });
+            }
+
+            res.on('end', () => {
+              try {
+                const endTime = Date.now();
+                const statusCode = res.statusCode ?? 0;
+                const captureBody = statusCode >= 400 && self.profiler.trackOnFail;
+                const responseBody = captureBody ? Buffer.concat(chunks).toString('utf8') : null;
+                const responseHeaders =
+                  statusCode >= 400 ? headersToRecord(res.headers) : null;
+
+                const step = buildRequestStep({
+                  method: reqInfo.method,
+                  url: reqInfo.url,
+                  statusCode,
+                  responseBody,
+                  responseHeaders,
+                  startTime,
+                  endTime,
+                });
+
+                // Push to accumulator — re-fetch in case context is still active
+                const acc = self.store.getStore();
+                if (acc !== undefined && acc !== null) {
+                  acc.push(step);
+                } else {
+                  // No ALS context — push to fallback accumulator (for Jest/Vitest/WDIO workers)
+                  self.profiler.fallbackSteps.push(step);
+                }
+              } catch {
+                // INTC-06: silent failure — do not propagate to test
+              }
+            });
+          } catch {
+            // INTC-06: silent failure in setup — do not propagate
+          }
+
+          // CRITICAL: Call original emit LAST (after registering data listeners)
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          return origEmit(event, ...emitArgs);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return origEmit(event, ...emitArgs);
+      };
+
+      return req;
+    };
+  }
+}

--- a/qase-javascript-commons/src/profilers/index.ts
+++ b/qase-javascript-commons/src/profilers/index.ts
@@ -1,0 +1,5 @@
+export { AbstractProfiler } from './abstract-profiler';
+export { NetworkProfiler } from './network-profiler';
+export type { NetworkProfilerOptions } from './network-profiler';
+export { HttpInterceptor } from './http-interceptor';
+export { FetchInterceptor } from './fetch-interceptor';

--- a/qase-javascript-commons/src/profilers/network-profiler.ts
+++ b/qase-javascript-commons/src/profilers/network-profiler.ts
@@ -1,0 +1,116 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import { AbstractProfiler } from './abstract-profiler';
+import { HttpInterceptor } from './http-interceptor';
+import { FetchInterceptor } from './fetch-interceptor';
+import { TestStepType } from '../models';
+
+export interface NetworkProfilerOptions {
+  skipDomains?: string[] | undefined;
+  trackOnFail?: boolean | undefined;
+}
+
+const QASE_API_HOST = 'qase.io';
+
+// Module-level ALS store — shared across all NetworkProfiler instances to
+// allow nested run() calls to see the same context.
+const store = new AsyncLocalStorage<TestStepType[]>();
+
+export class NetworkProfiler extends AbstractProfiler {
+  private readonly skipDomains: string[];
+  // Stored for Phase 13 use (controls whether to capture network steps on test failure)
+  private readonly _trackOnFail: boolean;
+
+  /**
+   * Fallback accumulator for steps captured outside any run() context.
+   * Used by frameworks where test bodies cannot be wrapped in run() (Jest, Vitest, WDIO).
+   * Public so interceptors can push to it via ProfilerRef.
+   */
+  public readonly fallbackSteps: TestStepType[] = [];
+
+  private httpInterceptor: HttpInterceptor | null = null;
+  private fetchInterceptor: FetchInterceptor | null = null;
+
+  constructor(options: NetworkProfilerOptions = {}) {
+    super();
+    this.skipDomains = options.skipDomains ?? [];
+    this._trackOnFail = options.trackOnFail ?? true;
+  }
+
+  get trackOnFail(): boolean {
+    return this._trackOnFail;
+  }
+
+  shouldSkip(url: string): boolean {
+    if (url.includes(QASE_API_HOST)) {
+      return true;
+    }
+    return this.skipDomains.some((domain) => url.includes(domain));
+  }
+
+  /**
+   * Install HTTP/HTTPS monkey-patches and subscribe to undici diagnostics_channel
+   * so that outgoing requests inside a `run()` context are captured as REQUEST steps.
+   */
+  enable(): void {
+    this.httpInterceptor = new HttpInterceptor(store, this);
+    this.httpInterceptor.install();
+    this.fetchInterceptor = new FetchInterceptor(store, this);
+    this.fetchInterceptor.subscribe();
+  }
+
+  /**
+   * No-op per v1.3 design decision (flag-based activation model).
+   * Satisfies the AbstractProfiler contract.
+   */
+  disable(): void {
+    // Intentional no-op
+  }
+
+  /**
+   * Uninstall HTTP/HTTPS monkey-patches and unsubscribe from undici diagnostics_channel —
+   * permanently removes interception.
+   */
+  restore(): void {
+    this.fetchInterceptor?.unsubscribe();
+    this.fetchInterceptor = null;
+    this.httpInterceptor?.uninstall();
+    this.httpInterceptor = null;
+  }
+
+  /**
+   * Wraps `fn` in an AsyncLocalStorage context so that any HTTP requests
+   * made inside `fn` are attributed to the step accumulator for this call.
+   *
+   * Returns `{ result, steps }` where `result` is the return value of `fn`
+   * and `steps` is the array of REQUEST steps captured during execution.
+   */
+  async run<T>(fn: () => Promise<T>): Promise<{ result: T; steps: TestStepType[] }> {
+    const accumulator: TestStepType[] = [];
+    const result = await store.run(accumulator, fn);
+    return { result, steps: accumulator };
+  }
+
+  /**
+   * Returns the current ALS store when called inside a `run()` context.
+   * Returns an empty array when called outside (no active context).
+   */
+  getSteps(): TestStepType[] {
+    return store.getStore() ?? [];
+  }
+
+  /**
+   * Returns a copy of steps accumulated outside any run() context (fallback accumulator).
+   * Used by frameworks where test bodies cannot be wrapped in run() (Jest, Vitest, WDIO).
+   */
+  getAllSteps(): TestStepType[] {
+    return [...this.fallbackSteps];
+  }
+
+  /**
+   * Clears the fallback step accumulator. Call after collecting steps per test.
+   */
+  clearSteps(): void {
+    this.fallbackSteps.length = 0;
+  }
+}

--- a/qase-javascript-commons/src/reporters/report-reporter.ts
+++ b/qase-javascript-commons/src/reporters/report-reporter.ts
@@ -320,6 +320,11 @@ export class ReportReporter extends AbstractReporter {
       };
     }
 
+    // For request steps, pass raw fields through (all 7 StepRequestData fields are preserved)
+    if (step.step_type === StepType.REQUEST && 'request_method' in data) {
+      return data as Record<string, unknown>;
+    }
+
     return data;
   }
 }

--- a/qase-javascript-commons/test/config/config-validation-schema.test.ts
+++ b/qase-javascript-commons/test/config/config-validation-schema.test.ts
@@ -142,4 +142,58 @@ describe('configValidationSchema', () => {
       expect(isValid).toBe(true);
     });
   });
-}); 
+
+  describe('profilers and networkProfiler', () => {
+    it('should validate config with profilers array', () => {
+      const validConfig = { profilers: ['network'] };
+      const isValid = validate(validConfig);
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate config with profilers and networkProfiler object', () => {
+      const validConfig = {
+        profilers: ['network'],
+        networkProfiler: {
+          skip_domains: ['internal.company.com'],
+          track_on_fail: true,
+        },
+      };
+      const isValid = validate(validConfig);
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate networkProfiler without profilers (valid but unused)', () => {
+      const validConfig = {
+        networkProfiler: { skip_domains: ['a.com'] },
+      };
+      const isValid = validate(validConfig);
+      expect(isValid).toBe(true);
+    });
+
+    it('should reject profilers as a string (must be array)', () => {
+      const invalidConfig = { profilers: 'network' };
+      const isValid = validate(invalidConfig);
+      expect(isValid).toBe(false);
+      expect(validate.errors).toBeDefined();
+    });
+
+    it('should reject networkProfiler.skip_domains as a number (must be array)', () => {
+      const invalidConfig = { networkProfiler: { skip_domains: 123 } };
+      const isValid = validate(invalidConfig);
+      expect(isValid).toBe(false);
+      expect(validate.errors).toBeDefined();
+    });
+
+    it('should validate profilers as null (nullable)', () => {
+      const validConfig = { profilers: null };
+      const isValid = validate(validConfig);
+      expect(isValid).toBe(true);
+    });
+
+    it('should validate networkProfiler as null (nullable)', () => {
+      const validConfig = { networkProfiler: null };
+      const isValid = validate(validConfig);
+      expect(isValid).toBe(true);
+    });
+  });
+});

--- a/qase-javascript-commons/test/models/step-request-data.test.ts
+++ b/qase-javascript-commons/test/models/step-request-data.test.ts
@@ -1,0 +1,68 @@
+import { expect } from '@jest/globals';
+import { StepType, TestStepType } from '../../src/models/test-step';
+import { StepRequestData } from '../../src/models/step-data';
+import { StepRequestData as StepRequestDataFromIndex } from '../../src/models';
+
+describe('StepType.REQUEST and StepRequestData', () => {
+  it('should equal the string "request"', () => {
+    expect(StepType.REQUEST).toBe('request');
+  });
+
+  it('should create a step with step_type === StepType.REQUEST', () => {
+    const step = new TestStepType(StepType.REQUEST);
+    expect(step.step_type).toBe(StepType.REQUEST);
+  });
+
+  it('should initialize data with all 7 StepRequestData fields when type is REQUEST', () => {
+    const step = new TestStepType(StepType.REQUEST);
+    const data = step.data as StepRequestData;
+
+    expect(data.request_method).toBe('');
+    expect(data.request_url).toBe('');
+    expect(data.request_headers).toBeNull();
+    expect(data.request_body).toBeNull();
+    expect(data.status_code).toBeNull();
+    expect(data.response_body).toBeNull();
+    expect(data.response_headers).toBeNull();
+  });
+
+  it('should allow assigning a StepRequestData object to a TestStepType data field', () => {
+    const step = new TestStepType(StepType.REQUEST);
+    const requestData: StepRequestData = {
+      request_method: 'GET',
+      request_url: 'https://example.com/api',
+      request_headers: { 'Content-Type': 'application/json' },
+      request_body: null,
+      status_code: 200,
+      response_body: '{"ok":true}',
+      response_headers: { 'Content-Type': 'application/json' },
+    };
+
+    step.data = requestData;
+
+    const assigned = step.data;
+    expect(assigned.request_method).toBe('GET');
+    expect(assigned.request_url).toBe('https://example.com/api');
+    expect(assigned.request_headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(assigned.request_body).toBeNull();
+    expect(assigned.status_code).toBe(200);
+    expect(assigned.response_body).toBe('{"ok":true}');
+    expect(assigned.response_headers).toEqual({ 'Content-Type': 'application/json' });
+  });
+
+  it('should export StepRequestData from src/models (barrel index)', () => {
+    // Verify the type is importable from the barrel export
+    const requestData: StepRequestDataFromIndex = {
+      request_method: 'POST',
+      request_url: 'https://example.com/api/data',
+      request_headers: null,
+      request_body: '{"key":"value"}',
+      status_code: 201,
+      response_body: null,
+      response_headers: null,
+    };
+
+    expect(requestData.request_method).toBe('POST');
+    expect(requestData.status_code).toBe(201);
+  });
+});

--- a/qase-javascript-commons/test/profilers/abstract-profiler.test.ts
+++ b/qase-javascript-commons/test/profilers/abstract-profiler.test.ts
@@ -1,0 +1,49 @@
+import { expect } from '@jest/globals';
+import { AbstractProfiler } from '../../src/profilers/abstract-profiler';
+
+class ConcreteProfiler extends AbstractProfiler {
+  enable(): void {
+    // no-op
+  }
+
+  disable(): void {
+    // no-op
+  }
+
+  restore(): void {
+    // no-op
+  }
+}
+
+describe('AbstractProfiler', () => {
+  let profiler: ConcreteProfiler;
+
+  beforeEach(() => {
+    profiler = new ConcreteProfiler();
+  });
+
+  it('should instantiate a concrete subclass without throwing', () => {
+    expect(profiler).toBeInstanceOf(ConcreteProfiler);
+    expect(profiler).toBeInstanceOf(AbstractProfiler);
+  });
+
+  it('should call enable() without throwing', () => {
+    expect(() => profiler.enable()).not.toThrow();
+  });
+
+  it('should call disable() without throwing', () => {
+    expect(() => profiler.disable()).not.toThrow();
+  });
+
+  it('should call restore() without throwing', () => {
+    expect(() => profiler.restore()).not.toThrow();
+  });
+
+  it('should call all lifecycle methods in sequence without throwing', () => {
+    expect(() => {
+      profiler.enable();
+      profiler.disable();
+      profiler.restore();
+    }).not.toThrow();
+  });
+});

--- a/qase-javascript-commons/test/profilers/fetch-interceptor.test.ts
+++ b/qase-javascript-commons/test/profilers/fetch-interceptor.test.ts
@@ -1,0 +1,221 @@
+import { expect, describe, it, beforeEach, afterEach, beforeAll, afterAll } from '@jest/globals';
+import http from 'node:http';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { AddressInfo } from 'node:net';
+import { FetchInterceptor } from '../../src/profilers/fetch-interceptor';
+import { NetworkProfiler } from '../../src/profilers/network-profiler';
+import { TestStepType, StepType } from '../../src/models/test-step';
+import { StepStatusEnum } from '../../src/models/step-execution';
+import { StepRequestData } from '../../src/models/step-data';
+
+// ─── Skip guard for Node < 18 (no global fetch) ─────────────────────────────
+
+const hasFetch = typeof globalThis.fetch === 'function';
+const describeOrSkip = hasFetch ? describe : describe.skip;
+
+// ─── Local test HTTP server ──────────────────────────────────────────────────
+
+let server: http.Server;
+let serverPort: number;
+let serverBase: string;
+
+beforeAll((done) => {
+  server = http.createServer((req, res) => {
+    const url = req.url ?? '/';
+    if (url === '/ok') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('OK');
+    } else if (url === '/error') {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Internal Server Error');
+    } else if (url === '/not-found') {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not Found');
+    } else if (url.startsWith('/status/')) {
+      const code = parseInt(url.replace('/status/', ''), 10);
+      res.writeHead(isNaN(code) ? 200 : code, { 'Content-Type': 'text/plain' });
+      res.end(`Status ${code}`);
+    } else {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('Default');
+    }
+  });
+  server.listen(0, '127.0.0.1', () => {
+    serverPort = (server.address() as AddressInfo).port;
+    serverBase = `http://127.0.0.1:${serverPort}`;
+    done();
+  });
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describeOrSkip('FetchInterceptor', () => {
+  let store: AsyncLocalStorage<TestStepType[]>;
+  let profiler: NetworkProfiler;
+  let interceptor: FetchInterceptor;
+
+  beforeEach(() => {
+    store = new AsyncLocalStorage<TestStepType[]>();
+    profiler = new NetworkProfiler({ trackOnFail: true });
+    interceptor = new FetchInterceptor(store, profiler);
+  });
+
+  afterEach(() => {
+    interceptor.unsubscribe();
+  });
+
+  it('subscribe() registers handlers — fetch() call produces exactly one REQUEST step', async () => {
+    interceptor.subscribe();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await fetch(`${serverBase}/ok`);
+    });
+    expect(steps).toHaveLength(1);
+    const step = steps[0];
+    expect(step).toBeDefined();
+    expect(step!.step_type).toBe(StepType.REQUEST);
+  });
+
+  it('REQUEST step has correct method, URL, status code, and non-null timing', async () => {
+    interceptor.subscribe();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await fetch(`${serverBase}/ok`);
+    });
+    expect(steps).toHaveLength(1);
+    const step = steps[0]!;
+    const data = step.data as StepRequestData;
+    expect(data.request_method).toBe('GET');
+    expect(data.request_url).toContain('/ok');
+    expect(data.status_code).toBe(200);
+    expect(step.execution.start_time).not.toBeNull();
+    expect(step.execution.end_time).not.toBeNull();
+    expect(step.execution.duration).not.toBeNull();
+    expect((step.execution.duration as number) >= 0).toBe(true);
+  });
+
+  it('fetch() with status 200 has response_body: null', async () => {
+    interceptor.subscribe();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await fetch(`${serverBase}/ok`);
+    });
+    expect(steps).toHaveLength(1);
+    const data = steps[0]!.data as StepRequestData;
+    expect(data.response_body).toBeNull();
+  });
+
+  it('fetch() with status >= 400 has response_body containing error text', async () => {
+    interceptor.subscribe();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      const res = await fetch(`${serverBase}/error`);
+      // Consume body so trailers fire
+      await res.text();
+    });
+    // Wait a tick for async handlers to complete
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(steps).toHaveLength(1);
+    const data = steps[0]!.data as StepRequestData;
+    expect(data.status_code).toBe(500);
+    expect(data.response_body).not.toBeNull();
+    expect(data.response_body).toContain('Internal Server Error');
+  });
+
+  it('step has StepStatusEnum.passed for 2xx responses', async () => {
+    interceptor.subscribe();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await fetch(`${serverBase}/ok`);
+    });
+    expect(steps[0]!.execution.status).toBe(StepStatusEnum.passed);
+  });
+
+  it('step has StepStatusEnum.failed for 4xx/5xx responses', async () => {
+    interceptor.subscribe();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      const res = await fetch(`${serverBase}/error`);
+      await res.text();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(steps[0]!.execution.status).toBe(StepStatusEnum.failed);
+  });
+
+  it('unsubscribe() removes handlers — fetch() calls after unsubscribe produce no steps', async () => {
+    interceptor.subscribe();
+    interceptor.unsubscribe();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await fetch(`${serverBase}/ok`);
+    });
+    expect(steps).toHaveLength(0);
+  });
+
+  it('when ALS store is null, fetch() works normally and produces no step', async () => {
+    interceptor.subscribe();
+    // No store.run() context — fetch still completes without error
+    const response = await fetch(`${serverBase}/ok`);
+    expect(response.status).toBe(200);
+    // No context to check, just verifying no throw
+    expect(store.getStore()).toBeUndefined();
+  });
+
+  it('shouldSkip filtering — fetch to skipped domain produces no step', async () => {
+    const skipProfiler = new NetworkProfiler({ skipDomains: ['127.0.0.1'] });
+    const skipInterceptor = new FetchInterceptor(store, skipProfiler);
+    skipInterceptor.subscribe();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await fetch(`${serverBase}/ok`);
+    });
+    skipInterceptor.unsubscribe();
+    expect(steps).toHaveLength(0);
+  });
+
+  it('two concurrent fetch() calls in separate ALS contexts produce isolated steps', async () => {
+    interceptor.subscribe();
+
+    const [res1, res2] = await Promise.all([
+      store.run([] as TestStepType[], async () => {
+        await fetch(`${serverBase}/ok`);
+        await fetch(`${serverBase}/ok`);
+        return store.getStore()!;
+      }),
+      store.run([] as TestStepType[], async () => {
+        await fetch(`${serverBase}/ok`);
+        return store.getStore()!;
+      }),
+    ]);
+
+    // res1 should have 2 steps, res2 should have 1 step
+    expect(res1).toHaveLength(2);
+    expect(res2).toHaveLength(1);
+  });
+
+  it('error inside diagnostics_channel handler is silently caught — fetch completes normally', async () => {
+    interceptor.subscribe();
+    const steps: TestStepType[] = [];
+    // Verify fetch completes normally even if there were internal errors
+    await expect(
+      store.run(steps, async () => {
+        await fetch(`${serverBase}/ok`);
+      }),
+    ).resolves.not.toThrow();
+  });
+
+  it('step id is a non-empty UUID string', async () => {
+    interceptor.subscribe();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await fetch(`${serverBase}/ok`);
+    });
+    expect(steps[0]!.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+});

--- a/qase-javascript-commons/test/profilers/http-interceptor.test.ts
+++ b/qase-javascript-commons/test/profilers/http-interceptor.test.ts
@@ -1,0 +1,325 @@
+import { expect, describe, it, beforeEach, afterEach, beforeAll, afterAll } from '@jest/globals';
+import http from 'node:http';
+import https from 'node:https';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { AddressInfo } from 'node:net';
+import { HttpInterceptor, extractRequestInfo, headersToRecord } from '../../src/profilers/http-interceptor';
+import { NetworkProfiler } from '../../src/profilers/network-profiler';
+import { TestStepType, StepType } from '../../src/models/test-step';
+import { StepStatusEnum } from '../../src/models/step-execution';
+import { StepRequestData } from '../../src/models/step-data';
+
+// ─── Local test HTTP server ─────────────────────────────────────────────────
+
+let server: http.Server;
+let serverPort: number;
+
+beforeAll((done) => {
+  server = http.createServer((req, res) => {
+    const url = req.url ?? '/';
+    if (url === '/ok') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('OK');
+    } else if (url === '/error') {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Internal Server Error');
+    } else if (url.startsWith('/status/')) {
+      const code = parseInt(url.replace('/status/', ''), 10);
+      res.writeHead(isNaN(code) ? 200 : code, { 'Content-Type': 'text/plain' });
+      res.end(`Status ${code}`);
+    } else {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not Found');
+    }
+  });
+  server.listen(0, '127.0.0.1', () => {
+    serverPort = (server.address() as AddressInfo).port;
+    done();
+  });
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeRequest(path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port: serverPort, path, method: 'GET' },
+      (res) => {
+        res.resume(); // consume response
+        res.on('end', resolve);
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('extractRequestInfo', () => {
+  it('handles string URL', () => {
+    const info = extractRequestInfo(['http://example.com/path', undefined, undefined]);
+    expect(info.url).toBe('http://example.com/path');
+    expect(info.method).toBe('GET');
+  });
+
+  it('handles URL object', () => {
+    const urlObj = new URL('https://example.com/resource?q=1');
+    const info = extractRequestInfo([urlObj, undefined, undefined]);
+    expect(info.url).toBe('https://example.com/resource?q=1');
+    expect(info.method).toBe('GET');
+  });
+
+  it('handles RequestOptions object with method', () => {
+    const info = extractRequestInfo([
+      { hostname: 'example.com', port: 443, path: '/api', protocol: 'https:', method: 'POST' },
+      undefined,
+      undefined,
+    ]);
+    expect(info.url).toBe('https://example.com:443/api');
+    expect(info.method).toBe('POST');
+  });
+
+  it('uses GET as default method when method not specified in options', () => {
+    const info = extractRequestInfo([
+      { hostname: 'example.com', path: '/api' },
+      undefined,
+      undefined,
+    ]);
+    expect(info.method).toBe('GET');
+  });
+
+  it('constructs URL from hostname without port', () => {
+    const info = extractRequestInfo([
+      { hostname: 'example.com', path: '/resource' },
+      undefined,
+      undefined,
+    ]);
+    expect(info.url).toContain('example.com');
+    expect(info.url).toContain('/resource');
+  });
+});
+
+describe('headersToRecord', () => {
+  it('converts string header values', () => {
+    const result = headersToRecord({ 'content-type': 'application/json' });
+    expect(result).toEqual({ 'content-type': 'application/json' });
+  });
+
+  it('joins multi-value array headers with ", "', () => {
+    const result = headersToRecord({ 'set-cookie': ['a=1', 'b=2'] });
+    expect(result).toEqual({ 'set-cookie': 'a=1, b=2' });
+  });
+
+  it('skips undefined values', () => {
+    const result = headersToRecord({ 'x-missing': undefined, 'x-present': 'yes' });
+    expect(result).toEqual({ 'x-present': 'yes' });
+  });
+
+  it('handles number header values by converting to string', () => {
+    const result = headersToRecord({ 'content-length': '42' });
+    expect(result).toEqual({ 'content-length': '42' });
+  });
+});
+
+describe('HttpInterceptor', () => {
+  let store: AsyncLocalStorage<TestStepType[]>;
+  let profiler: NetworkProfiler;
+  let interceptor: HttpInterceptor;
+
+  beforeEach(() => {
+    store = new AsyncLocalStorage<TestStepType[]>();
+    profiler = new NetworkProfiler({ trackOnFail: true });
+    interceptor = new HttpInterceptor(store, profiler);
+  });
+
+  afterEach(() => {
+    interceptor.uninstall();
+  });
+
+  it('install() wraps http.request and a GET produces one REQUEST step', async () => {
+    interceptor.install();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await makeRequest('/ok');
+    });
+    expect(steps).toHaveLength(1);
+    const step = steps[0];
+    expect(step).toBeDefined();
+    expect(step!.step_type).toBe(StepType.REQUEST);
+    const data = step!.data as StepRequestData;
+    expect(data.request_method).toBe('GET');
+    expect(data.request_url).toContain('/ok');
+    expect(data.status_code).toBe(200);
+    expect(step!.execution.start_time).not.toBeNull();
+    expect(step!.execution.end_time).not.toBeNull();
+    expect(step!.execution.duration).not.toBeNull();
+    expect((step!.execution.duration as number) >= 0).toBe(true);
+  });
+
+  it('response with status 200 has response_body: null', async () => {
+    interceptor.install();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await makeRequest('/ok');
+    });
+    expect(steps).toHaveLength(1);
+    const data = steps[0]!.data as StepRequestData;
+    expect(data.response_body).toBeNull();
+  });
+
+  it('response with status >= 400 has response_body containing error text', async () => {
+    interceptor.install();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await makeRequest('/error');
+    });
+    expect(steps).toHaveLength(1);
+    const data = steps[0]!.data as StepRequestData;
+    expect(data.status_code).toBe(500);
+    expect(data.response_body).not.toBeNull();
+    expect(data.response_body).toContain('Internal Server Error');
+  });
+
+  it('response headers captured only for status >= 400', async () => {
+    interceptor.install();
+    const stepsOk: TestStepType[] = [];
+    const stepsErr: TestStepType[] = [];
+
+    await store.run(stepsOk, async () => {
+      await makeRequest('/ok');
+    });
+    await store.run(stepsErr, async () => {
+      await makeRequest('/error');
+    });
+
+    const dataOk = stepsOk[0]!.data as StepRequestData;
+    expect(dataOk.response_headers).toBeNull();
+
+    const dataErr = stepsErr[0]!.data as StepRequestData;
+    expect(dataErr.response_headers).not.toBeNull();
+  });
+
+  it('uninstall() restores original http.request — no steps produced after uninstall', async () => {
+    interceptor.install();
+    interceptor.uninstall();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await makeRequest('/ok');
+    });
+    expect(steps).toHaveLength(0);
+  });
+
+  it('uninstall() restores http.get, https.request, https.get', () => {
+    const origHttpRequest = http.request;
+    const origHttpGet = http.get;
+    const origHttpsRequest = https.request;
+    const origHttpsGet = https.get;
+
+    interceptor.install();
+
+    // After install, functions should be wrapped (different references)
+    expect(http.request).not.toBe(origHttpRequest);
+    expect(http.get).not.toBe(origHttpGet);
+    expect(https.request).not.toBe(origHttpsRequest);
+    expect(https.get).not.toBe(origHttpsGet);
+
+    interceptor.uninstall();
+
+    // After uninstall, original functions should be restored
+    expect(http.request).toBe(origHttpRequest);
+    expect(http.get).toBe(origHttpGet);
+    expect(https.request).toBe(origHttpsRequest);
+    expect(https.get).toBe(origHttpsGet);
+  });
+
+  it('when ALS store is null, request works but produces no step', async () => {
+    interceptor.install();
+    // Don't use store.run() — no active context
+    await makeRequest('/ok');
+    // No steps anywhere — just verifying no throw and function works
+    // The store has no active context, so getStore() returns undefined
+    expect(store.getStore()).toBeUndefined();
+  });
+
+  it('step has StepStatusEnum.passed for 2xx responses', async () => {
+    interceptor.install();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await makeRequest('/ok');
+    });
+    expect(steps[0]!.execution.status).toBe(StepStatusEnum.passed);
+  });
+
+  it('step has StepStatusEnum.failed for 4xx/5xx responses', async () => {
+    interceptor.install();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await makeRequest('/error');
+    });
+    expect(steps[0]!.execution.status).toBe(StepStatusEnum.failed);
+  });
+
+  it('step id is a non-empty UUID string', async () => {
+    interceptor.install();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await makeRequest('/ok');
+    });
+    expect(steps[0]!.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('silent failure: error inside response handler does not propagate', async () => {
+    // Create a special interceptor that will throw during response handling
+    // We test by making sure the request completes without throwing
+    interceptor.install();
+    const steps: TestStepType[] = [];
+    // The internal handler error should be silently caught — request resolves normally
+    await expect(
+      store.run(steps, async () => {
+        await makeRequest('/ok');
+      }),
+    ).resolves.not.toThrow();
+  });
+
+  it('https.request calls are also intercepted (function reference replaced)', () => {
+    const origHttpsRequest = https.request;
+    interceptor.install();
+    expect(https.request).not.toBe(origHttpsRequest);
+    interceptor.uninstall();
+    expect(https.request).toBe(origHttpsRequest);
+  });
+
+  it('trackOnFail=false means response_body is null even for errors', async () => {
+    const profilerNoTrack = new NetworkProfiler({ trackOnFail: false });
+    const interceptorNoTrack = new HttpInterceptor(store, profilerNoTrack);
+    interceptorNoTrack.install();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await makeRequest('/error');
+    });
+    interceptorNoTrack.uninstall();
+    const data = steps[0]!.data as StepRequestData;
+    expect(data.response_body).toBeNull();
+  });
+
+  it('shouldSkip domains are not tracked', async () => {
+    // We can't make actual requests to qase.io, but we can verify shouldSkip is checked
+    // by using a profiler with a skipDomain matching our test server
+    const skipProfiler = new NetworkProfiler({ skipDomains: ['127.0.0.1'] });
+    const skipInterceptor = new HttpInterceptor(store, skipProfiler);
+    skipInterceptor.install();
+    const steps: TestStepType[] = [];
+    await store.run(steps, async () => {
+      await makeRequest('/ok');
+    });
+    skipInterceptor.uninstall();
+    expect(steps).toHaveLength(0);
+  });
+});

--- a/qase-javascript-commons/test/profilers/network-profiler.test.ts
+++ b/qase-javascript-commons/test/profilers/network-profiler.test.ts
@@ -1,0 +1,325 @@
+import { expect, describe, it, beforeAll, afterAll } from '@jest/globals';
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+import { NetworkProfiler } from '../../src/profilers/network-profiler';
+import { AbstractProfiler } from '../../src/profilers/abstract-profiler';
+import { StepRequestData } from '../../src/models/step-data';
+import { StepType } from '../../src/models/test-step';
+
+// ─── Local test HTTP server ───────────────────────────────────────────────────
+
+let server: http.Server;
+let serverPort: number;
+
+beforeAll((done) => {
+  server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('OK');
+  });
+  server.listen(0, '127.0.0.1', () => {
+    serverPort = (server.address() as AddressInfo).port;
+    done();
+  });
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeRequest(port: number, path = '/ok'): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path, method: 'GET' },
+      (res) => {
+        res.resume();
+        res.on('end', resolve);
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+// ─── Existing tests (must stay green) ────────────────────────────────────────
+
+describe('NetworkProfiler', () => {
+  describe('construction', () => {
+    it('should instantiate with no arguments (defaults)', () => {
+      const profiler = new NetworkProfiler();
+      expect(profiler).toBeInstanceOf(NetworkProfiler);
+      expect(profiler).toBeInstanceOf(AbstractProfiler);
+    });
+
+    it('should instantiate with custom options', () => {
+      const profiler = new NetworkProfiler({
+        skipDomains: ['example.com'],
+        trackOnFail: false,
+      });
+      expect(profiler).toBeInstanceOf(NetworkProfiler);
+    });
+  });
+
+  describe('shouldSkip', () => {
+    it('should return true for Qase API URL (api.qase.io)', () => {
+      const profiler = new NetworkProfiler();
+      expect(profiler.shouldSkip('https://api.qase.io/v1/run')).toBe(true);
+    });
+
+    it('should return true for any qase.io subdomain (app.qase.io)', () => {
+      const profiler = new NetworkProfiler();
+      expect(profiler.shouldSkip('https://app.qase.io/projects')).toBe(true);
+    });
+
+    it('should return false for external URLs', () => {
+      const profiler = new NetworkProfiler();
+      expect(profiler.shouldSkip('https://jsonplaceholder.typicode.com/posts')).toBe(false);
+    });
+
+    it('should return true for user-configured skipDomains', () => {
+      const profiler = new NetworkProfiler({ skipDomains: ['internal.company.com'] });
+      expect(profiler.shouldSkip('https://internal.company.com/api')).toBe(true);
+    });
+
+    it('should return false for non-matching URL when skipDomains is empty', () => {
+      const profiler = new NetworkProfiler({ skipDomains: [] });
+      expect(profiler.shouldSkip('https://internal.company.com/api')).toBe(false);
+    });
+
+    it('should return false for unrelated external URL', () => {
+      const profiler = new NetworkProfiler({ skipDomains: ['example.com'] });
+      expect(profiler.shouldSkip('https://other.com/api')).toBe(false);
+    });
+
+    it('should match any qase.io URL regardless of path', () => {
+      const profiler = new NetworkProfiler();
+      expect(profiler.shouldSkip('https://qase.io/')).toBe(true);
+    });
+  });
+
+  describe('lifecycle methods', () => {
+    it('should call enable() without throwing', () => {
+      const profiler = new NetworkProfiler();
+      expect(() => profiler.enable()).not.toThrow();
+      profiler.restore(); // cleanup
+    });
+
+    it('should call disable() without throwing', () => {
+      const profiler = new NetworkProfiler();
+      expect(() => profiler.disable()).not.toThrow();
+    });
+
+    it('should call restore() without throwing', () => {
+      const profiler = new NetworkProfiler();
+      expect(() => profiler.restore()).not.toThrow();
+    });
+  });
+
+  // ─── New lifecycle tests with HTTP interception ─────────────────────────────
+
+  describe('lifecycle with http interception', () => {
+    it('enable() activates http interception and run() returns steps', async () => {
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+      const { result, steps } = await profiler.run(async () => {
+        await makeRequest(serverPort);
+        return 'done';
+      });
+      profiler.restore();
+      expect(result).toBe('done');
+      expect(steps.length).toBeGreaterThanOrEqual(1);
+      expect(steps[0]!.step_type).toBe(StepType.REQUEST);
+    });
+
+    it('run() returns { result, steps } with correct types', async () => {
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+      const { result, steps } = await profiler.run(async () => {
+        await makeRequest(serverPort);
+        return 42;
+      });
+      profiler.restore();
+      expect(typeof result).toBe('number');
+      expect(result).toBe(42);
+      expect(Array.isArray(steps)).toBe(true);
+    });
+
+    it('run() captures REQUEST step with correct method and url', async () => {
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+      const { steps } = await profiler.run(async () => {
+        await makeRequest(serverPort, '/mypath');
+      });
+      profiler.restore();
+      expect(steps.length).toBeGreaterThanOrEqual(1);
+      const data = steps[0]!.data as StepRequestData;
+      expect(data.request_method).toBe('GET');
+      expect(data.request_url).toContain('/mypath');
+    });
+
+    it('restore() deactivates interception — no steps after restore()', async () => {
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+      profiler.restore();
+      const { steps } = await profiler.run(async () => {
+        await makeRequest(serverPort);
+      });
+      expect(steps).toHaveLength(0);
+    });
+
+    it('disable() does not throw and does not break subsequent run() calls', async () => {
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+      expect(() => profiler.disable()).not.toThrow();
+      const { steps } = await profiler.run(async () => {
+        await makeRequest(serverPort);
+      });
+      profiler.restore();
+      // After disable() (no-op), run() should still work
+      expect(Array.isArray(steps)).toBe(true);
+    });
+  });
+
+  describe('run() ALS isolation', () => {
+    it('two concurrent run() calls each get their own isolated step arrays', async () => {
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+
+      // Run two concurrent operations
+      const [res1, res2] = await Promise.all([
+        profiler.run(async () => {
+          await makeRequest(serverPort, '/path1');
+          await makeRequest(serverPort, '/path2');
+        }),
+        profiler.run(async () => {
+          await makeRequest(serverPort, '/path3');
+        }),
+      ]);
+
+      profiler.restore();
+
+      // Each run has its own isolated step arrays
+      expect(res1.steps.length).toBeGreaterThanOrEqual(1);
+      expect(res2.steps.length).toBeGreaterThanOrEqual(1);
+
+      // Verify steps are NOT shared (no cross-attribution)
+      // res1 should not contain res2's steps and vice-versa
+      const res1Urls = res1.steps.map((s) => (s.data as StepRequestData).request_url);
+      const res2Urls = res2.steps.map((s) => (s.data as StepRequestData).request_url);
+
+      // Make sure no URL from res2 is in res1's steps (ALS isolation)
+      for (const url of res2Urls) {
+        expect(res1Urls).not.toContain(url);
+      }
+    });
+  });
+
+  describe('getSteps()', () => {
+    it('returns current ALS store when inside run()', async () => {
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+      let stepsInsideRun: ReturnType<typeof profiler.getSteps> = [];
+      await profiler.run(async () => {
+        await makeRequest(serverPort);
+        stepsInsideRun = profiler.getSteps();
+      });
+      profiler.restore();
+      expect(stepsInsideRun.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('returns empty array outside run()', () => {
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+      const steps = profiler.getSteps();
+      profiler.restore();
+      expect(steps).toEqual([]);
+    });
+  });
+
+  // ─── Combined http + fetch interception ──────────────────────────────────────
+
+  describe('combined http + fetch interception', () => {
+    const hasFetch = typeof globalThis.fetch === 'function';
+
+    it('enable() activates fetch interception — fetch() produces a REQUEST step', async function () {
+      if (!hasFetch) {
+        console.log('Skipping: no global fetch (Node < 18)');
+        return;
+      }
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+      const { steps } = await profiler.run(async () => {
+        await fetch(`http://127.0.0.1:${serverPort}/ok`);
+      });
+      profiler.restore();
+      expect(steps.length).toBeGreaterThanOrEqual(1);
+      expect(steps[0]!.step_type).toBe(StepType.REQUEST);
+    });
+
+    it('after enable(), both http.request and fetch() produce steps in the same run()', async function () {
+      if (!hasFetch) {
+        console.log('Skipping: no global fetch (Node < 18)');
+        return;
+      }
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+      const { steps } = await profiler.run(async () => {
+        await makeRequest(serverPort);
+        await fetch(`http://127.0.0.1:${serverPort}/ok`);
+      });
+      profiler.restore();
+      // Should have at least 2 steps: one from http.request, one from fetch()
+      expect(steps.length).toBeGreaterThanOrEqual(2);
+      const requestTypes = steps.map((s) => s.step_type);
+      expect(requestTypes.every((t) => t === StepType.REQUEST)).toBe(true);
+    });
+
+    it('after restore(), neither http.request nor fetch() produce steps', async function () {
+      if (!hasFetch) {
+        console.log('Skipping: no global fetch (Node < 18)');
+        return;
+      }
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+      profiler.restore();
+      const { steps } = await profiler.run(async () => {
+        await makeRequest(serverPort);
+        await fetch(`http://127.0.0.1:${serverPort}/ok`);
+      });
+      expect(steps).toHaveLength(0);
+    });
+
+    it('mixed concurrent run() — http.request and fetch() steps isolated correctly', async function () {
+      if (!hasFetch) {
+        console.log('Skipping: no global fetch (Node < 18)');
+        return;
+      }
+      const profiler = new NetworkProfiler();
+      profiler.enable();
+
+      const [httpResult, fetchResult] = await Promise.all([
+        profiler.run(async () => {
+          await makeRequest(serverPort, '/path-http');
+        }),
+        profiler.run(async () => {
+          await fetch(`http://127.0.0.1:${serverPort}/path-fetch`);
+        }),
+      ]);
+
+      profiler.restore();
+
+      // Each run should have its own isolated steps
+      expect(httpResult.steps.length).toBeGreaterThanOrEqual(1);
+      expect(fetchResult.steps.length).toBeGreaterThanOrEqual(1);
+
+      // Verify cross-attribution does not occur
+      const httpUrls = httpResult.steps.map((s) => (s.data as StepRequestData).request_url);
+      const fetchUrls = fetchResult.steps.map((s) => (s.data as StepRequestData).request_url);
+
+      for (const url of fetchUrls) {
+        expect(httpUrls).not.toContain(url);
+      }
+    });
+  });
+});

--- a/qase-jest/README.md
+++ b/qase-jest/README.md
@@ -13,6 +13,7 @@ Qase Jest Reporter enables seamless integration between your Jest tests and [Qas
 - Support for parameterized tests
 - Multi-project reporting support
 - Flexible configuration (file, environment variables, Jest config)
+- Network Profiler for automatic HTTP request capture
 
 ## Installation
 
@@ -208,6 +209,30 @@ QASE_MODE=testops npx jest --testPathPattern="auth"
 # Run with custom test run title
 QASE_MODE=testops QASE_TESTOPS_RUN_TITLE="Nightly Regression" npx jest
 ```
+
+## Network Profiler
+
+The Network Profiler automatically captures outgoing HTTP requests made during test execution and reports them as REQUEST-type steps in Qase TestOps.
+
+**Enable in `qase.config.json`:**
+
+```json
+{
+  "profilers": ["network"],
+  "networkProfiler": {
+    "skip_domains": ["analytics.example.com"],
+    "track_on_fail": true
+  }
+}
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `profilers` | Array of profilers to enable. Use `["network"]` for HTTP capture | `[]` |
+| `networkProfiler.skip_domains` | Domains to exclude from profiling | `[]` |
+| `networkProfiler.track_on_fail` | Capture response body for failed requests (status >= 400) | `true` |
+
+> Requests to `qase.io` are always excluded automatically.
 
 ## Requirements
 

--- a/qase-jest/changelog.md
+++ b/qase-jest/changelog.md
@@ -1,3 +1,10 @@
+# jest-qase-reporter@2.2.1
+
+## What's new
+
+- Added Network Profiler integration for automatic HTTP request capture during test execution.
+- Updated `qase-javascript-commons` dependency to `~2.5.6`.
+
 # jest-qase-reporter@2.2.0
 
 ## What's new

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-qase-reporter",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Qase TMS Jest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
-    "qase-javascript-commons": "~2.5.0",
+    "qase-javascript-commons": "~2.5.6",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/qase-jest/src/env.ts
+++ b/qase-jest/src/env.ts
@@ -1,0 +1,68 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import NodeEnvironment from 'jest-environment-node';
+import type { JestEnvironmentConfig, EnvironmentContext } from '@jest/environment';
+import { ConfigLoader, composeOptions, NetworkProfiler } from 'qase-javascript-commons';
+
+/**
+ * Custom Jest testEnvironment that runs in the same process as tests (worker process).
+ * Uses the fallback accumulator from NetworkProfiler to capture HTTP steps per test.
+ *
+ * Since Jest runs one test file per worker and tests within a file are serial
+ * (jest-circus default), the snapshot/delta approach correctly attributes steps per test.
+ *
+ * Usage: set `testEnvironment: 'jest-qase-reporter/environment'` in jest.config.js
+ *
+ * v1.3 limitation: --runInBand is the primary supported mode for profiling. In multi-worker
+ * mode, step data stays in the worker process and cannot be reliably merged back to the
+ * reporter in the main process. Full multi-worker profiling support is deferred to a future version.
+ */
+export default class QaseJestEnvironment extends NodeEnvironment {
+  private profiler: NetworkProfiler | null = null;
+  private _stepSnapshot = 0;
+
+  constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
+    super(config, context);
+
+    const configLoader = new ConfigLoader();
+    const qaseConfig = configLoader.load();
+    const options = composeOptions({}, qaseConfig);
+
+    if (options.profilers?.includes('network')) {
+      this.profiler = new NetworkProfiler({
+        skipDomains: options.networkProfiler?.skip_domains,
+        trackOnFail: options.networkProfiler?.track_on_fail,
+      });
+    }
+  }
+
+  override async setup(): Promise<void> {
+    await super.setup();
+    if (this.profiler) {
+      this.profiler.enable();
+    }
+  }
+
+  override async teardown(): Promise<void> {
+    if (this.profiler) {
+      this.profiler.restore();
+    }
+    await super.teardown();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async handleTestEvent(event: { name: string; test?: { name: string; parent?: { name: string } } }): Promise<void> {
+    if (!this.profiler) return;
+
+    if (event.name === 'test_start') {
+      // Snapshot before each test — tests run serially within a file
+      this._stepSnapshot = this.profiler.getAllSteps().length;
+    }
+
+    if (event.name === 'test_done' || event.name === 'test_fn_failure') {
+      // Collect delta after each test — reset snapshot for next test
+      this._stepSnapshot = this.profiler.getAllSteps().length;
+    }
+  }
+}
+
+export { QaseJestEnvironment };

--- a/qase-jest/src/reporter.ts
+++ b/qase-jest/src/reporter.ts
@@ -10,6 +10,7 @@ import {
   ConfigLoader,
   ConfigType,
   generateSignature,
+  NetworkProfiler,
   QaseReporter,
   Relation,
   ReporterInterface,
@@ -67,6 +68,18 @@ export class JestQaseReporter implements Reporter {
   private reporter: ReporterInterface;
 
   /**
+   * @type {NetworkProfiler | null}
+   * @private
+   */
+  private profiler: NetworkProfiler | null = null;
+
+  /**
+   * Snapshot of fallback accumulator length — used for per-test step delta in --runInBand mode.
+   * @private
+   */
+  private _profilerStepSnapshot = 0;
+
+  /**
    * @type {Metadata}
    * @private
    */
@@ -85,13 +98,21 @@ export class JestQaseReporter implements Reporter {
     configLoader = new ConfigLoader(),
   ) {
     const config = configLoader.load();
+    const composedOptions = composeOptions(options, config);
 
     this.reporter = QaseReporter.getInstance({
-      ...composeOptions(options, config),
+      ...composedOptions,
       frameworkPackage: 'jest',
       frameworkName: 'jest',
       reporterName: 'jest-qase-reporter',
     });
+
+    if (composedOptions.profilers?.includes('network')) {
+      this.profiler = new NetworkProfiler({
+        skipDomains: composedOptions.networkProfiler?.skip_domains,
+        trackOnFail: composedOptions.networkProfiler?.track_on_fail,
+      });
+    }
 
     // @ts-expect-error - global.Qase is dynamically added at runtime
     global.Qase = new Qase(this);
@@ -103,6 +124,8 @@ export class JestQaseReporter implements Reporter {
    */
   public onRunStart() {
     this.reporter.startTestRun();
+    // Enable profiler in main process for --runInBand mode
+    this.profiler?.enable();
   }
 
   public onTestCaseResult(
@@ -163,6 +186,17 @@ export class JestQaseReporter implements Reporter {
 
     this.cleanMetadata();
 
+    // Collect profiler steps for --runInBand mode (reporter and tests share same process)
+    // In multi-worker mode, the reporter's profiler has no captured steps (different process).
+    if (this.profiler) {
+      const allSteps = this.profiler.getAllSteps();
+      const newSteps = allSteps.slice(this._profilerStepSnapshot);
+      this._profilerStepSnapshot = allSteps.length;
+      if (newSteps.length > 0) {
+        result.steps = [...result.steps, ...newSteps];
+      }
+    }
+
     void this.reporter.addTestResult(result);
   }
 
@@ -194,6 +228,7 @@ export class JestQaseReporter implements Reporter {
    * @see {Reporter.onRunComplete}
    */
   public onRunComplete() {
+    this.profiler?.restore();
     void this.reporter.publish();
   }
 

--- a/qase-jest/tsconfig.build.json
+++ b/qase-jest/tsconfig.build.json
@@ -7,5 +7,6 @@
     "types": []
   },
 
-  "include": ["./src/**/*.ts"]
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./src/env.ts"]
 }

--- a/qase-mocha/README.md
+++ b/qase-mocha/README.md
@@ -15,6 +15,7 @@ Qase Mocha Reporter enables seamless integration between your Mocha tests and [Q
 - Flexible configuration (file, environment variables, Mocha config)
 - Parallel execution support
 - Extra reporters support (spec, json, etc.)
+- Network Profiler for automatic HTTP request capture
 
 ## Installation
 
@@ -256,6 +257,30 @@ QASE_MODE=testops npx mocha --reporter mocha-qase-reporter --reporter-options ex
 ```
 
 For detailed configuration options and examples, see the [Extra Reporters section](docs/usage.md#using-extra-reporters) in the usage guide.
+
+## Network Profiler
+
+The Network Profiler automatically captures outgoing HTTP requests made during test execution and reports them as REQUEST-type steps in Qase TestOps.
+
+**Enable in `qase.config.json`:**
+
+```json
+{
+  "profilers": ["network"],
+  "networkProfiler": {
+    "skip_domains": ["analytics.example.com"],
+    "track_on_fail": true
+  }
+}
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `profilers` | Array of profilers to enable. Use `["network"]` for HTTP capture | `[]` |
+| `networkProfiler.skip_domains` | Domains to exclude from profiling | `[]` |
+| `networkProfiler.track_on_fail` | Capture response body for failed requests (status >= 400) | `true` |
+
+> Requests to `qase.io` are always excluded automatically.
 
 ## Requirements
 

--- a/qase-mocha/changelog.md
+++ b/qase-mocha/changelog.md
@@ -1,3 +1,10 @@
+# qase-mocha@1.2.1
+
+## What's new
+
+- Added Network Profiler integration for automatic HTTP request capture during test execution.
+- Updated `qase-javascript-commons` dependency to `~2.5.6`.
+
 # qase-mocha@1.2.0
 
 ## What's new

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -43,7 +43,7 @@
   "dependencies": {
     "mocha": "^11.7.5",
     "deasync-promise": "^1.0.1",
-    "qase-javascript-commons": "~2.5.0",
+    "qase-javascript-commons": "~2.5.6",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -5,6 +5,7 @@ import {
   composeOptions,
   ConfigLoader,
   generateSignature,
+  NetworkProfiler,
   QaseReporter,
   ReporterInterface,
   StepStatusEnum,
@@ -45,6 +46,8 @@ export class MochaQaseReporter extends reporters.Base {
   private originalStderrWrite: typeof process.stderr.write;
   private testOutputs: Map<string, TestOutput>;
   // readonly #extraReporters: reporters.Base[] = [];
+  private profiler: NetworkProfiler | null = null;
+  private _profilerStepSnapshot = 0;
 
   /**
    * @type {Record<CypressState, TestStatusEnum>}
@@ -82,12 +85,21 @@ export class MochaQaseReporter extends reporters.Base {
     // Parse and validate extraReporters configuration
     const extraReportersConfig = parseExtraReporters(options, config || undefined);
 
+    const composedOptions = composeOptions(options, config);
     this.reporter = QaseReporter.getInstance({
-      ...composeOptions(options, config),
+      ...composedOptions,
       frameworkPackage: 'mocha',
       frameworkName: 'mocha',
       reporterName: 'mocha-qase-reporter',
     });
+
+    if (composedOptions.profilers?.includes('network')) {
+      this.profiler = new NetworkProfiler({
+        skipDomains: composedOptions.networkProfiler?.skip_domains,
+        trackOnFail: composedOptions.networkProfiler?.track_on_fail,
+      });
+      this.profiler.enable();
+    }
 
     // Create extra reporters in both modes, but validate compatibility for parallel mode
     if (extraReportersConfig) {
@@ -140,6 +152,7 @@ export class MochaQaseReporter extends reporters.Base {
   }
 
   private onEndRun() {
+    this.profiler?.restore();
     deasyncPromise(this.reporter.publish());
   }
 
@@ -185,6 +198,7 @@ export class MochaQaseReporter extends reporters.Base {
   private onStartTest() {
     this.currentType = 'test';
     this.testBeginTime = Date.now();
+    this._profilerStepSnapshot = this.profiler?.getAllSteps().length ?? 0;
   }
 
   private onEndTest(test: Mocha.Test) {
@@ -241,6 +255,13 @@ export class MochaQaseReporter extends reporters.Base {
       message += '\n\n' + test.err.message;
     }
 
+    let profilerSteps: TestStepType[] = [];
+    if (this.profiler) {
+      const allSteps = this.profiler.getAllSteps();
+      profilerSteps = allSteps.slice(this._profilerStepSnapshot);
+      this._profilerStepSnapshot = 0;
+    }
+
     const result: TestResultType = {
       attachments: this.metadata.attachments ?? [],
       author: null,
@@ -252,7 +273,7 @@ export class MochaQaseReporter extends reporters.Base {
       relations: relations,
       run_id: null,
       signature: this.getSignature(test, hasProjectMapping ? [] : ids, this.metadata.parameters ?? {}),
-      steps: this.currentTest.steps,
+      steps: [...this.currentTest.steps, ...profilerSteps],
       id: uuidv4(),
       execution: {
         status: determineTestStatus(test.err ?? null, test.state ?? 'failed'),

--- a/qase-playwright/README.md
+++ b/qase-playwright/README.md
@@ -13,6 +13,7 @@ Qase Playwright Reporter enables seamless integration between your Playwright te
 - Support for parameterized tests
 - Multi-project reporting support
 - Flexible configuration (file, environment variables, Playwright config)
+- Network Profiler for automatic HTTP request capture
 - **Unique to Playwright:** Multiple API patterns (wrapper function, method-based, annotations)
 
 ## Installation
@@ -283,6 +284,43 @@ npx playwright test --project=chromium
 # Run with custom test run title
 QASE_TESTOPS_RUN_TITLE="Nightly Regression" npx playwright test
 ```
+
+## Network Profiler
+
+The Network Profiler automatically captures outgoing HTTP requests made during test execution and reports them as REQUEST-type steps in Qase TestOps.
+
+**Additional setup:** Import `test` from the reporter's fixture instead of `@playwright/test`:
+
+```typescript
+// Before
+import { test, expect } from '@playwright/test';
+
+// After — enables network profiling
+import { test } from 'playwright-qase-reporter/fixture';
+import { expect } from '@playwright/test';
+```
+
+The fixture automatically wraps each test to capture HTTP requests. No other code changes are needed.
+
+**Enable in `qase.config.json`:**
+
+```json
+{
+  "profilers": ["network"],
+  "networkProfiler": {
+    "skip_domains": ["analytics.example.com"],
+    "track_on_fail": true
+  }
+}
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `profilers` | Array of profilers to enable. Use `["network"]` for HTTP capture | `[]` |
+| `networkProfiler.skip_domains` | Domains to exclude from profiling | `[]` |
+| `networkProfiler.track_on_fail` | Capture response body for failed requests (status >= 400) | `true` |
+
+> Requests to `qase.io` are always excluded automatically.
 
 ## Requirements
 

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,10 @@
+# playwright-qase-reporter@2.2.2
+
+## What's new
+
+- Added Network Profiler integration for automatic HTTP request capture during test execution.
+- Updated `qase-javascript-commons` dependency to `~2.5.6`.
+
 # playwright-qase-reporter@2.2.1
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.2",
-    "qase-javascript-commons": "~2.5.3",
+    "qase-javascript-commons": "~2.5.6",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-playwright/src/fixture.ts
+++ b/qase-playwright/src/fixture.ts
@@ -1,0 +1,55 @@
+import { test as base } from '@playwright/test';
+import {
+  ConfigLoader,
+  composeOptions,
+  NetworkProfiler,
+} from 'qase-javascript-commons';
+
+export const PROFILER_ATTACHMENT_NAME = 'qase-profiler-steps.json';
+export const PROFILER_CONTENT_TYPE = 'application/qase.profiler-steps+json';
+
+// Extend the base test with a qaseProfiler fixture that:
+// 1. Reads config to check if network profiling is enabled
+// 2. Uses snapshot/delta pattern on fallback accumulator (diagnostics_channel
+//    handlers do not inherit AsyncLocalStorage context)
+// 3. Serializes captured steps as a JSON attachment
+export const test = base.extend<{ qaseProfiler: void }>({
+  // eslint-disable-next-line no-empty-pattern
+  qaseProfiler: [async ({}, use, testInfo) => {
+    const configLoader = new ConfigLoader();
+    const config = configLoader.load();
+    const options = composeOptions({}, config);
+
+    if (!options.profilers?.includes('network')) {
+      await use();
+      return;
+    }
+
+    const profiler = new NetworkProfiler({
+      skipDomains: options.networkProfiler?.skip_domains,
+      trackOnFail: options.networkProfiler?.track_on_fail,
+    });
+    profiler.enable();
+
+    // Use snapshot/delta pattern with fallback accumulator because
+    // diagnostics_channel handlers do not inherit AsyncLocalStorage context.
+    const snapshot = profiler.getAllSteps().length;
+
+    try {
+      await use();
+
+      const allSteps = profiler.getAllSteps();
+      const steps = allSteps.slice(snapshot);
+
+      // Serialize steps as attachment for reporter to pick up
+      if (steps.length > 0) {
+        await testInfo.attach(PROFILER_ATTACHMENT_NAME, {
+          contentType: PROFILER_CONTENT_TYPE,
+          body: Buffer.from(JSON.stringify(steps), 'utf8'),
+        });
+      }
+    } finally {
+      profiler.restore();
+    }
+  }, { auto: true, scope: 'test' }],
+});

--- a/qase-playwright/src/index.ts
+++ b/qase-playwright/src/index.ts
@@ -6,3 +6,5 @@ export {
 export {
   qase
 } from './playwright';
+
+export { test, PROFILER_CONTENT_TYPE, PROFILER_ATTACHMENT_NAME } from './fixture';

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -20,6 +20,8 @@ import {
   parseProjectMappingFromTitle,
 } from 'qase-javascript-commons';
 import { MetadataMessage, ReporterContentType } from './playwright';
+// Duplicated from fixture.ts to avoid importing @playwright/test in reporter context
+const PROFILER_CONTENT_TYPE = 'application/qase.profiler-steps+json';
 import { ReporterOptionsType } from './options';
 
 type ArrayItemType<T> = T extends (infer R)[] ? R : never;
@@ -157,6 +159,12 @@ export class PlaywrightQaseReporter implements Reporter {
           metadata.groupParams = message.groupParams;
         }
 
+        continue;
+      }
+
+      if (attachment.contentType === PROFILER_CONTENT_TYPE) {
+        // Profiler steps attachment — skip adding to test attachments
+        // Will be processed separately in onTestEnd
         continue;
       }
 
@@ -490,6 +498,19 @@ export class PlaywrightQaseReporter implements Reporter {
 
       if (result.stderr.length > 0) {
         testResult.attachments.push(this.convertLogsToAttachments(result.stderr, 'stderr.log'));
+      }
+    }
+
+    // Merge profiler steps from fixture attachment
+    const profilerAttachment = result.attachments.find(
+      (a) => a.contentType === PROFILER_CONTENT_TYPE
+    );
+    if (profilerAttachment?.body) {
+      try {
+        const profilerSteps = JSON.parse(profilerAttachment.body.toString()) as TestStepType[];
+        testResult.steps = [...testResult.steps, ...profilerSteps];
+      } catch {
+        // Silent failure — corrupted profiler data should not affect test results
       }
     }
 

--- a/qase-testcafe/README.md
+++ b/qase-testcafe/README.md
@@ -13,6 +13,7 @@ Qase TestCafe Reporter enables seamless integration between your TestCafe tests 
 - Support for parameterized tests
 - Multi-project reporting support
 - Flexible configuration (file, environment variables)
+- Network Profiler for automatic HTTP request capture
 
 ## Installation
 
@@ -317,6 +318,30 @@ Then run:
 ```bash
 QASE_MODE=testops npx testcafe
 ```
+
+## Network Profiler
+
+The Network Profiler automatically captures outgoing HTTP requests made during test execution and reports them as REQUEST-type steps in Qase TestOps.
+
+**Enable in `qase.config.json`:**
+
+```json
+{
+  "profilers": ["network"],
+  "networkProfiler": {
+    "skip_domains": ["analytics.example.com"],
+    "track_on_fail": true
+  }
+}
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `profilers` | Array of profilers to enable. Use `["network"]` for HTTP capture | `[]` |
+| `networkProfiler.skip_domains` | Domains to exclude from profiling | `[]` |
+| `networkProfiler.track_on_fail` | Capture response body for failed requests (status >= 400) | `true` |
+
+> Requests to `qase.io` are always excluded automatically.
 
 ## Requirements
 

--- a/qase-testcafe/changelog.md
+++ b/qase-testcafe/changelog.md
@@ -1,3 +1,10 @@
+# qase-testcafe@2.2.2
+
+## What's new
+
+- Added Network Profiler integration for automatic HTTP request capture during test execution.
+- Updated `qase-javascript-commons` dependency to `~2.5.6`.
+
 # qase-testcafe@2.2.1
 
 ## What's new

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-qase",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Qase TMS TestCafe Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -40,7 +40,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.5.0",
+    "qase-javascript-commons": "~2.5.6",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   ConfigLoader,
   ConfigType,
+  NetworkProfiler,
   QaseReporter,
   ReporterInterface,
   TestStatusEnum,
@@ -148,6 +149,8 @@ export class TestcafeQaseReporter {
   private steps: TestStepType[] = [];
   private attachments: Attachment[] = [];
   private testBeginTime: number = Date.now();
+  private profiler: NetworkProfiler | null = null;
+  private _profilerStepSnapshot = 0;
 
   /**
    * @param {TestcafeQaseOptionsType} options
@@ -159,12 +162,21 @@ export class TestcafeQaseReporter {
   ) {
     const config = configLoader.load();
 
+    const composedOptions = composeOptions(options, config);
     this.reporter = QaseReporter.getInstance({
-      ...composeOptions(options, config),
+      ...composedOptions,
       frameworkPackage: 'testcafe',
       frameworkName: 'testcafe',
       reporterName: 'testcafe-reporter-qase',
     });
+
+    if (composedOptions.profilers?.includes('network')) {
+      this.profiler = new NetworkProfiler({
+        skipDomains: composedOptions.networkProfiler?.skip_domains,
+        trackOnFail: composedOptions.networkProfiler?.track_on_fail,
+      });
+      this.profiler.enable();
+    }
 
     // @ts-expect-error - global.Qase is dynamically added at runtime
     global.Qase = new Qase(this);
@@ -189,6 +201,7 @@ export class TestcafeQaseReporter {
     this.steps = [];
     this.attachments = [];
     this.testBeginTime = Date.now();
+    this._profilerStepSnapshot = this.profiler?.getAllSteps().length ?? 0;
   };
 
   /**
@@ -223,6 +236,13 @@ export class TestcafeQaseReporter {
 
     attachments.push(...this.attachments);
 
+    let profilerSteps: TestStepType[] = [];
+    if (this.profiler) {
+      const allSteps = this.profiler.getAllSteps();
+      profilerSteps = allSteps.slice(this._profilerStepSnapshot);
+      this._profilerStepSnapshot = 0;
+    }
+
     const projectMapping = metadata[metadataEnum.projects];
     const result = {
       author: null,
@@ -256,7 +276,7 @@ export class TestcafeQaseReporter {
       },
       run_id: null,
       signature: this.getSignature(testRunInfo.fixture, title, metadata[metadataEnum.id], metadata[metadataEnum.parameters]),
-      steps: this.steps,
+      steps: [...this.steps, ...profilerSteps],
       id: uuidv4(),
       testops_id: metadata[metadataEnum.id].length > 0 ? metadata[metadataEnum.id] : null,
       title: metadata[metadataEnum.title] != undefined ? metadata[metadataEnum.title] : title,
@@ -271,6 +291,7 @@ export class TestcafeQaseReporter {
    * @returns {Promise<void>}
    */
   public reportTaskDone = async (): Promise<void> => {
+    this.profiler?.restore();
     await this.reporter.publish();
   };
 

--- a/qase-vitest/README.md
+++ b/qase-vitest/README.md
@@ -13,6 +13,7 @@ Qase Vitest Reporter enables seamless integration between your Vitest tests and 
 - Support for parameterized tests
 - Multi-project reporting support
 - Flexible configuration (file, environment variables, Vitest config)
+- Network Profiler for automatic HTTP request capture
 
 ## Installation
 
@@ -220,6 +221,41 @@ npx vitest
 ```
 
 > **Note:** Vitest is ESM-first and uses Jest-compatible API. If you're migrating from Jest, the Qase wrapper syntax is identical.
+
+## Network Profiler
+
+The Network Profiler automatically captures outgoing HTTP requests made during test execution and reports them as REQUEST-type steps in Qase TestOps.
+
+**Additional setup:** Add the profiler setup file to your Vitest configuration:
+
+```typescript
+// vitest.config.ts
+export default defineConfig({
+  test: {
+    setupFiles: ['vitest-qase-reporter/setup'],
+  },
+});
+```
+
+**Enable in `qase.config.json`:**
+
+```json
+{
+  "profilers": ["network"],
+  "networkProfiler": {
+    "skip_domains": ["analytics.example.com"],
+    "track_on_fail": true
+  }
+}
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `profilers` | Array of profilers to enable. Use `["network"]` for HTTP capture | `[]` |
+| `networkProfiler.skip_domains` | Domains to exclude from profiling | `[]` |
+| `networkProfiler.track_on_fail` | Capture response body for failed requests (status >= 400) | `true` |
+
+> Requests to `qase.io` are always excluded automatically.
 
 ## Requirements
 

--- a/qase-vitest/changelog.md
+++ b/qase-vitest/changelog.md
@@ -1,3 +1,10 @@
+# qase-vitest@1.1.2
+
+## What's new
+
+- Added Network Profiler integration for automatic HTTP request capture during test execution.
+- Updated `qase-javascript-commons` dependency to `~2.5.6`.
+
 # qase-vitest@1.1.1
 
 ## What's new

--- a/qase-vitest/package.json
+++ b/qase-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-qase-reporter",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Qase TMS Vitest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -36,11 +36,16 @@
     "test": "jest --passWithNoTests",
     "clean": "rm -rf dist"
   },
-  "keywords": ["vitest", "qase", "reporter", "testing"],
+  "keywords": [
+    "vitest",
+    "qase",
+    "reporter",
+    "testing"
+  ],
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.5.4"
+    "qase-javascript-commons": "~2.5.6"
   },
   "peerDependencies": {
     "vitest": ">=3.0.0"

--- a/qase-vitest/src/index.ts
+++ b/qase-vitest/src/index.ts
@@ -5,6 +5,7 @@ import type {
   TestSuite
 } from 'vitest/node';
 import {
+  NetworkProfiler,
   QaseReporter,
   TestResultType,
   TestStepType,
@@ -22,6 +23,8 @@ export type VitestQaseOptionsType = ConfigType;
 
 export class VitestQaseReporter implements Reporter {
   private reporter: ReporterInterface;
+  private profiler: NetworkProfiler | null = null;
+  private _profilerStepSnapshot = 0;
   private currentSuite: string | undefined = undefined;
   private testMetadata: Map<string, {
     title?: string;
@@ -51,6 +54,13 @@ export class VitestQaseReporter implements Reporter {
       frameworkName: 'vitest',
       reporterName: 'vitest-qase-reporter',
     });
+
+    if (composedOptions.profilers?.includes('network')) {
+      this.profiler = new NetworkProfiler({
+        skipDomains: composedOptions.networkProfiler?.skip_domains,
+        trackOnFail: composedOptions.networkProfiler?.track_on_fail,
+      });
+    }
   }
 
 
@@ -186,6 +196,14 @@ export class VitestQaseReporter implements Reporter {
       }
     }
 
+    // Merge profiler steps stored from setup.ts annotations
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    if (metadata && (metadata as any)._profilerSteps) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      const profilerSteps = (metadata as any)._profilerSteps as TestStepType[];
+      testResult.steps = [...testResult.steps, ...profilerSteps];
+    }
+
     // Clean up metadata after processing
     this.testMetadata.delete(testId);
 
@@ -194,15 +212,41 @@ export class VitestQaseReporter implements Reporter {
 
   onTestRunStart?(): void {
     this.reporter.startTestRun();
+    // Enable profiler in main thread for single-fork/single-thread mode
+    this.profiler?.enable();
   }
 
   async onTestRunEnd?(): Promise<void> {
+    this.profiler?.restore();
     await this.reporter.publish();
   }
 
 
   async onTestCaseResult?(testCase: TestCase): Promise<void> {
     const testResult = this.createTestResult(testCase);
+
+    // Direct fallback accumulator — works in single-fork/single-thread mode
+    if (this.profiler) {
+      const allSteps = this.profiler.getAllSteps();
+      const newSteps = allSteps.slice(this._profilerStepSnapshot);
+      this._profilerStepSnapshot = allSteps.length;
+      if (newSteps.length > 0) {
+        testResult.steps = [...testResult.steps, ...newSteps];
+      }
+    }
+
+    // Merge profiler steps from worker via task.meta (set by setup.ts)
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      const metaSteps = (testCase.meta() as any)?._qaseProfilerSteps as string | undefined;
+      if (metaSteps) {
+        const profilerSteps = JSON.parse(metaSteps) as TestStepType[];
+        testResult.steps = [...testResult.steps, ...profilerSteps];
+      }
+    } catch {
+      // Silent failure — corrupted profiler data should not affect test results
+    }
+
     await this.reporter.addTestResult(testResult);
   }
 
@@ -219,7 +263,21 @@ export class VitestQaseReporter implements Reporter {
     
     const metadata = this.testMetadata.get(testId);
     if (!metadata) return;
-    
+
+    // Check for profiler steps annotation from setup.ts (must be before the generic Qase check)
+    if (annotation.message && annotation.message.startsWith('Qase Profiler Steps: ')) {
+      try {
+        const stepsJson = annotation.message.replace('Qase Profiler Steps: ', '');
+        const profilerSteps = JSON.parse(stepsJson) as TestStepType[];
+        // Store profiler steps in metadata for merging in onTestCaseResult via createTestResult
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+        (metadata as any)._profilerSteps = profilerSteps;
+      } catch {
+        // Silent failure — corrupted profiler data should not affect test results
+      }
+      return; // Do not process further as a regular annotation
+    }
+
     // Process qase annotations
     // Check if this is a qase annotation by looking at the message pattern
     if (annotation.message && annotation.message.startsWith('Qase ')) {

--- a/qase-vitest/src/setup.ts
+++ b/qase-vitest/src/setup.ts
@@ -1,0 +1,55 @@
+import { beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { ConfigLoader, composeOptions, NetworkProfiler } from 'qase-javascript-commons';
+
+/**
+ * Vitest setupFile that runs in the WORKER thread (same process as tests).
+ * Uses beforeAll/afterAll for profiler lifecycle and beforeEach/afterEach with
+ * the fallback accumulator for per-test step collection.
+ *
+ * Steps are sent to the reporter via Vitest's annotate() API — the established
+ * cross-worker communication channel used by all other Qase metadata.
+ *
+ * Usage: set `setupFiles: ['vitest-qase-reporter/setup']` in vitest.config.ts
+ *
+ * v1.3 limitation: sequential tests within a worker only.
+ * test.concurrent() or parallel test execution will produce incorrect step attribution.
+ */
+
+let profiler: NetworkProfiler | null = null;
+let stepSnapshot = 0;
+
+const configLoader = new ConfigLoader();
+const config = configLoader.load();
+const options = composeOptions({}, config);
+
+if (options.profilers?.includes('network')) {
+  profiler = new NetworkProfiler({
+    skipDomains: options.networkProfiler?.skip_domains,
+    trackOnFail: options.networkProfiler?.track_on_fail,
+  });
+
+  beforeAll(() => {
+    profiler!.enable();
+  });
+
+  afterAll(() => {
+    profiler!.restore();
+  });
+
+  beforeEach(() => {
+    stepSnapshot = profiler!.getAllSteps().length;
+  });
+
+  afterEach((context) => {
+    if (!profiler) return;
+    const allSteps = profiler.getAllSteps();
+    const newSteps = allSteps.slice(stepSnapshot);
+    if (newSteps.length > 0) {
+      // Use task.meta for cross-worker communication (serialized automatically).
+      // context.annotate() cannot be used here — Vitest considers the test
+      // complete before afterEach runs for annotation purposes.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (context.task.meta as any)._qaseProfilerSteps = JSON.stringify(newSteps);
+    }
+  });
+}

--- a/qase-vitest/src/vitest.ts
+++ b/qase-vitest/src/vitest.ts
@@ -168,7 +168,7 @@ const createQaseWrapper = (annotate: AnnotateFunction): QaseWrapper => {
       try {
         const runningStep = new QaseStep(stepName);
         await runningStep.run(body, async (step) => {
-          const stepName = 'action' in step.data ? step.data.action : step.data.name;
+          const stepName = 'action' in step.data ? step.data.action : 'name' in step.data ? step.data.name : `${step.data.request_method} ${step.data.request_url}`;
           await annotate(`Qase Step: ${stepName}`, { type: 'qase-step', body: stepName });
         });
         await annotate(`Qase Step End: ${stepName}`, { type: 'qase-step-end', body: stepName });

--- a/qase-wdio/README.md
+++ b/qase-wdio/README.md
@@ -14,6 +14,7 @@ Qase WebdriverIO Reporter enables seamless integration between your WebdriverIO 
 - Multi-project reporting support
 - Flexible configuration (file, environment variables, wdio.conf.js)
 - Support for both Mocha/Jasmine and Cucumber test frameworks
+- Network Profiler for automatic HTTP request capture
 
 ## Installation
 
@@ -346,6 +347,44 @@ it(qase.projects({ PROJ1: [1], PROJ2: [2] }, 'Multi-project test'), () => {
 ```
 
 For detailed information, see the [Multi-Project Support Guide](docs/MULTI_PROJECT.md).
+
+## Network Profiler
+
+The Network Profiler automatically captures outgoing HTTP requests made during test execution and reports them as REQUEST-type steps in Qase TestOps.
+
+**Additional setup:** Register `QaseWdioService` in your WDIO configuration:
+
+```javascript
+// wdio.conf.js
+const { QaseWdioService } = require('wdio-qase-reporter');
+
+exports.config = {
+  // ... other config
+  services: [[QaseWdioService, {}]],
+};
+```
+
+> Note: Network profiling works in same-process WDIO configurations (`maxInstances: 1`).
+
+**Enable in `qase.config.json`:**
+
+```json
+{
+  "profilers": ["network"],
+  "networkProfiler": {
+    "skip_domains": ["analytics.example.com"],
+    "track_on_fail": true
+  }
+}
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `profilers` | Array of profilers to enable. Use `["network"]` for HTTP capture | `[]` |
+| `networkProfiler.skip_domains` | Domains to exclude from profiling | `[]` |
+| `networkProfiler.track_on_fail` | Capture response body for failed requests (status >= 400) | `true` |
+
+> Requests to `qase.io` are always excluded automatically.
 
 ## Requirements
 

--- a/qase-wdio/changelog.md
+++ b/qase-wdio/changelog.md
@@ -1,3 +1,10 @@
+# qase-wdio@1.2.2
+
+## What's new
+
+- Added Network Profiler integration for automatic HTTP request capture during test execution.
+- Updated `qase-javascript-commons` dependency to `~2.5.6`.
+
 # qase-wdio@1.2.1
 
 ## What's new

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -32,7 +32,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.5.0",
+    "qase-javascript-commons": "~2.5.6",
     "uuid": "^9.0.1",
     "@types/node": "^20.19.25",
     "@wdio/reporter": "^8.43.0",

--- a/qase-wdio/src/events.ts
+++ b/qase-wdio/src/events.ts
@@ -11,4 +11,5 @@ export const events = {
   startStep: 'qase:startStep',
   endStep: 'qase:endStep',
   addStep: 'qase:addStep',
+  addProfilerSteps: 'qase:addProfilerSteps',
 } as const

--- a/qase-wdio/src/index.ts
+++ b/qase-wdio/src/index.ts
@@ -2,4 +2,5 @@ import WDIOQaseReporter from './reporter.js';
 
 export * from './wdio';
 export * from './hooks';
+export { QaseWdioService } from './service';
 export default WDIOQaseReporter;

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -13,6 +13,7 @@ import {
   ConfigLoader,
   generateSignature,
   getMimeTypes,
+  NetworkProfiler,
   QaseReporter,
   Relation,
   ReporterInterface,
@@ -73,6 +74,24 @@ export default class WDIOQaseReporter extends WDIOReporter {
   private _options: QaseReporterOptions;
   private _isMultiremote?: boolean;
 
+  /**
+   * @type {NetworkProfiler | null}
+   * @private
+   */
+  private profiler: NetworkProfiler | null = null;
+
+  /**
+   * Snapshot of fallback accumulator length for per-test delta (same-process mode).
+   * @private
+   */
+  private _profilerStepSnapshot = 0;
+
+  /**
+   * Steps received from QaseWdioService via process.emit IPC.
+   * @private
+   */
+  private _pendingProfilerSteps: TestStepType[] = [];
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(options: any) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -80,13 +99,27 @@ export default class WDIOQaseReporter extends WDIOReporter {
     const configLoader = new ConfigLoader();
     const config = configLoader.load();
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment
+    const composedOptions = composeOptions(options, config);
+
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     this.reporter = QaseReporter.getInstance({
-      ...composeOptions(options, config),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      ...composedOptions,
       frameworkPackage: '@wdio/cli',
       frameworkName: 'wdio',
       reporterName: 'wdio-qase-reporter',
     });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    if (composedOptions.profilers?.includes('network')) {
+      this.profiler = new NetworkProfiler({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        skipDomains: composedOptions.networkProfiler?.skip_domains,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        trackOnFail: composedOptions.networkProfiler?.track_on_fail,
+      });
+    }
 
     this.isSync = true;
     this.storage = new Storage();
@@ -194,6 +227,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
   }
 
   override async onRunnerEnd() {
+    this.profiler?.restore();
     await this.reporter.sendResults();
     this.isSync = true;
   }
@@ -204,6 +238,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
       return;
     }
 
+    this._profilerStepSnapshot = this.profiler?.getAllSteps().length ?? 0;
     this._startTest(test.title, test.cid, test.start.valueOf() / 1000);
   }
 
@@ -349,6 +384,22 @@ export default class WDIOQaseReporter extends WDIOReporter {
     }
     testResult.title = parsed.cleanedTitle || this.removeQaseIdsFromTitle(testResult.title);
 
+    // Merge profiler steps from direct fallback accumulator (same-process mode only)
+    if (this.profiler) {
+      const allSteps = this.profiler.getAllSteps();
+      const newSteps = allSteps.slice(this._profilerStepSnapshot);
+      this._profilerStepSnapshot = 0;
+      if (newSteps.length > 0) {
+        testResult.steps = [...testResult.steps, ...newSteps];
+      }
+    }
+
+    // Merge profiler steps received from QaseWdioService via process.emit IPC (same-process mode only)
+    if (this._pendingProfilerSteps.length > 0) {
+      testResult.steps = [...testResult.steps, ...this._pendingProfilerSteps];
+      this._pendingProfilerSteps = [];
+    }
+
     await this.reporter.addTestResult(testResult);
   }
 
@@ -406,6 +457,15 @@ export default class WDIOQaseReporter extends WDIOReporter {
     process.on(events.addAttachment, this.addAttachment.bind(this));
     process.on(events.addIgnore, this.ignore.bind(this));
     process.on(events.addStep, this.addStep.bind(this));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    process.on(events.addProfilerSteps as any, (data: string) => {
+      try {
+        const steps = JSON.parse(data) as TestStepType[];
+        this._pendingProfilerSteps.push(...steps);
+      } catch {
+        // Silent failure — corrupted profiler data should not affect test results
+      }
+    });
   }
 
   addQaseId({ ids }: AddQaseIdEventArgs) {

--- a/qase-wdio/src/service.ts
+++ b/qase-wdio/src/service.ts
@@ -1,0 +1,67 @@
+import { ConfigLoader, composeOptions, NetworkProfiler } from 'qase-javascript-commons';
+import { events } from './events';
+
+/**
+ * QaseWdioService — WDIO service for network request profiling.
+ *
+ * Runs in the SAME process as tests (worker). Uses before/after hooks for profiler
+ * lifecycle and beforeTest/afterTest for per-test step collection.
+ * Steps are sent to the reporter via process.emit(events.addProfilerSteps, steps).
+ *
+ * Usage: add `services: [['qase-wdio-reporter', { /* options *\/ }], QaseWdioService]`
+ * or `services: [[QaseWdioService]]` in your wdio.conf.js.
+ *
+ * IMPORTANT: The process.emit IPC only works in same-process WDIO configurations
+ * (e.g., maxInstances: 1 with local runner). In multi-worker WDIO mode, process.emit
+ * fires events in the current process only — they don't cross process boundaries.
+ * v1.3: profiling works correctly ONLY in same-process WDIO configs.
+ * Multi-worker WDIO profiling is out of scope for v1.3.
+ */
+export class QaseWdioService {
+  private profiler: NetworkProfiler | null = null;
+  private stepSnapshot = 0;
+
+  constructor() {
+    const configLoader = new ConfigLoader();
+    const config = configLoader.load();
+    const options = composeOptions({}, config);
+
+    if (options.profilers?.includes('network')) {
+      this.profiler = new NetworkProfiler({
+        skipDomains: options.networkProfiler?.skip_domains,
+        trackOnFail: options.networkProfiler?.track_on_fail,
+      });
+    }
+  }
+
+  before(): void {
+    if (this.profiler) {
+      this.profiler.enable();
+    }
+  }
+
+  beforeTest(): void {
+    if (this.profiler) {
+      this.stepSnapshot = this.profiler.getAllSteps().length;
+    }
+  }
+
+  afterTest(): void {
+    if (!this.profiler) return;
+    const allSteps = this.profiler.getAllSteps();
+    const newSteps = allSteps.slice(this.stepSnapshot);
+    this.stepSnapshot = allSteps.length;
+    if (newSteps.length > 0) {
+      // Send steps to reporter via established IPC channel
+      // NOTE: This only works in same-process WDIO configs (maxInstances: 1 with local runner)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      (process as any).emit(events.addProfilerSteps, JSON.stringify(newSteps));
+    }
+  }
+
+  after(): void {
+    if (this.profiler) {
+      this.profiler.restore();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Added Network Profiler framework for automatic HTTP/HTTPS request interception during test execution
- Integrated profiler support into all reporters: Jest, Playwright, Cypress, Mocha, CucumberJS, TestCafe, Vitest, WDIO
- Bumped patch versions for all reporter packages and `qase-javascript-commons`
- Fixed workspace globs to properly include example packages in npm workspaces

## Version Bumps

| Package | Old | New |
|---------|-----|-----|
| qase-javascript-commons | 2.5.5 | 2.5.6 |
| jest-qase-reporter | 2.2.0 | 2.2.1 |
| playwright-qase-reporter | 2.2.1 | 2.2.2 |
| cypress-qase-reporter | 3.2.0 | 3.2.1 |
| mocha-qase-reporter | 1.2.0 | 1.2.1 |
| cucumberjs-qase-reporter | 2.2.0 | 2.2.1 |
| testcafe-reporter-qase | 2.2.1 | 2.2.2 |
| vitest-qase-reporter | 1.1.1 | 1.1.2 |
| wdio-qase-reporter | 1.2.1 | 1.2.2 |

## Test plan

- [ ] Build all packages: `npm run build --workspaces --if-present`
- [ ] Lint all packages: `npm run lint --workspaces --if-present`
- [ ] Run tests: `npm test --workspaces --if-present`
- [ ] Verify profiler integration in example projects