### PR TITLE
fix: correct package.json require path in api client configurations

### DIFF
--- a/qase-api-client/package.json
+++ b/qase-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-client",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Qase TMS Javascript API V1 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-api-client/src/configuration.ts
+++ b/qase-api-client/src/configuration.ts
@@ -13,7 +13,7 @@
  */
 
 // @ts-ignore
-const packageJson = require('../../package.json');
+const packageJson = require('../package.json');
 
 export interface ConfigurationParameters {
     apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);

--- a/qase-api-client/test/user-agent.test.ts
+++ b/qase-api-client/test/user-agent.test.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { Configuration, RunsApi } from '../src';
 
-const packageJson = require('../../package.json');
+const packageJson = require('../package.json');
 
 describe('User-Agent header', () => {
   describe('Configuration', () => {

--- a/qase-api-v2-client/package.json
+++ b/qase-api-v2-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-v2-client",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Qase TMS Javascript API V2 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-api-v2-client/src/configuration.ts
+++ b/qase-api-v2-client/src/configuration.ts
@@ -13,7 +13,7 @@
  */
 
 // @ts-ignore
-const packageJson = require('../../package.json');
+const packageJson = require('../package.json');
 
 export interface ConfigurationParameters {
     apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);

--- a/qase-api-v2-client/test/user-agent.test.ts
+++ b/qase-api-v2-client/test/user-agent.test.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { Configuration, ResultsApi } from '../src';
 
-const packageJson = require('../../package.json');
+const packageJson = require('../package.json');
 
 describe('User-Agent header', () => {
   describe('Configuration', () => {


### PR DESCRIPTION
## Summary
- Fix incorrect `require('../../package.json')` → `require('../package.json')` in `configuration.ts` for both `qase-api-client` and `qase-api-v2-client`
- The wrong path (introduced in 8ddb201) resolved two levels up from `dist/`, causing `Cannot find module` at runtime
- Bump `qase-api-client` 1.1.4 → 1.1.5, `qase-api-v2-client` 1.0.5 → 1.0.6

## Test plan
- [x] Both packages build successfully
- [x] All 12 User-Agent tests pass
- [x] Compiled `dist/configuration.js` contains correct `require('../package.json')`