### PR TITLE
Add integration testing with reporters-validator

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -81,10 +81,10 @@ jobs:
 
     - name: Validate Vitest reporter
       run: |
+        cd ${{ github.workspace }}/examples/single/vitest
         QASE_MODE=report \
         QASE_REPORT_CONNECTION_PATH=${{ github.workspace }}/build/vitest-report \
-        npx vitest run --config examples/single/vitest/vitest.integration.config.ts \
-          --root examples/single/vitest || true
+        npx vitest run --config vitest.integration.config.ts || true
 
         # Handle report.json vs run.json naming difference
         if [ ! -f "${{ github.workspace }}/build/vitest-report/run.json" ] && \
@@ -93,11 +93,12 @@ jobs:
              "${{ github.workspace }}/build/vitest-report/run.json"
         fi
 
-        python3 scripts/normalize_report.py ${{ github.workspace }}/build/vitest-report
+        python3 ${{ github.workspace }}/scripts/normalize_report.py \
+          ${{ github.workspace }}/build/vitest-report
 
         reporters-validator validate \
           --report-dir ${{ github.workspace }}/build/vitest-report \
-          --expected expected/vitest-examples.yaml \
+          --expected ${{ github.workspace }}/expected/vitest-examples.yaml \
           --schema-dir /tmp/specs/report/schemas
 
     - name: Install Playwright browsers

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -30,6 +30,111 @@ jobs:
     - run: npm run lint -w ${{ matrix.prefix }}
     - run: npm run test -w ${{ matrix.prefix }}
 
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: test
+    name: Integration tests
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+    - run: npm install npm@latest
+    - run: npm ci
+    - run: npm run build -ws --if-present
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install reporters-validator
+      run: pip install git+https://github.com/qase-tms/reporters-validator.git
+
+    - name: Download report schemas
+      run: git clone --depth 1 https://github.com/qase-tms/specs.git /tmp/specs
+
+    - name: Validate Jest reporter
+      run: |
+        QASE_MODE=report \
+        QASE_REPORT_CONNECTION_PATH=${{ github.workspace }}/build/jest-report \
+        npm test -w examples-jest || true
+
+        python3 scripts/normalize_report.py ${{ github.workspace }}/build/jest-report
+
+        reporters-validator validate \
+          --report-dir ${{ github.workspace }}/build/jest-report \
+          --expected expected/jest-examples.yaml \
+          --schema-dir /tmp/specs/report/schemas
+
+    - name: Validate Mocha reporter
+      run: |
+        QASE_MODE=report \
+        QASE_REPORT_CONNECTION_PATH=${{ github.workspace }}/build/mocha-report \
+        npm test -w examples-mocha || true
+
+        python3 scripts/normalize_report.py ${{ github.workspace }}/build/mocha-report
+
+        reporters-validator validate \
+          --report-dir ${{ github.workspace }}/build/mocha-report \
+          --expected expected/mocha-examples.yaml \
+          --schema-dir /tmp/specs/report/schemas
+
+    - name: Validate Vitest reporter
+      run: |
+        QASE_MODE=report \
+        QASE_REPORT_CONNECTION_PATH=${{ github.workspace }}/build/vitest-report \
+        npx vitest run --config examples/single/vitest/vitest.integration.config.ts \
+          --root examples/single/vitest || true
+
+        # Handle report.json vs run.json naming difference
+        if [ ! -f "${{ github.workspace }}/build/vitest-report/run.json" ] && \
+           [ -f "${{ github.workspace }}/build/vitest-report/report.json" ]; then
+          cp "${{ github.workspace }}/build/vitest-report/report.json" \
+             "${{ github.workspace }}/build/vitest-report/run.json"
+        fi
+
+        python3 scripts/normalize_report.py ${{ github.workspace }}/build/vitest-report
+
+        reporters-validator validate \
+          --report-dir ${{ github.workspace }}/build/vitest-report \
+          --expected expected/vitest-examples.yaml \
+          --schema-dir /tmp/specs/report/schemas
+
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps chromium
+
+    - name: Validate Playwright reporter
+      run: |
+        cd ${{ github.workspace }}/examples/single/playwright
+        QASE_MODE=report \
+        QASE_REPORT_CONNECTION_PATH=${{ github.workspace }}/build/playwright-report \
+        npx playwright test \
+          test/login.spec.js test/inventory.spec.js \
+          test/cart.spec.js test/checkout.spec.js || true
+
+        python3 ${{ github.workspace }}/scripts/normalize_report.py \
+          ${{ github.workspace }}/build/playwright-report
+
+        reporters-validator validate \
+          --report-dir ${{ github.workspace }}/build/playwright-report \
+          --expected ${{ github.workspace }}/expected/playwright-examples.yaml \
+          --schema-dir /tmp/specs/report/schemas
+
+    - name: Validate Cypress reporter
+      run: |
+        cd ${{ github.workspace }}/examples/single/cypress
+        QASE_MODE=report \
+        QASE_REPORT_CONNECTION_PATH=${{ github.workspace }}/build/cypress-report \
+        npx cypress run || true
+
+        python3 ${{ github.workspace }}/scripts/normalize_report.py \
+          ${{ github.workspace }}/build/cypress-report
+
+        reporters-validator validate \
+          --report-dir ${{ github.workspace }}/build/cypress-report \
+          --expected ${{ github.workspace }}/expected/cypress-examples.yaml \
+          --schema-dir /tmp/specs/report/schemas
+
   build-n-publish:
     runs-on: ubuntu-latest
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,11 @@ tmp
 
 CLAUDE.md
 .planning/
+.mcp.json
 
 # Example package locks (managed by root workspace)
 examples/**/package-lock.json
+
+# Integration test report output
+build/
+**/build/report/

--- a/examples/single/vitest/package.json
+++ b/examples/single/vitest/package.json
@@ -7,8 +7,10 @@
     "test:run": "vitest run"
   },
   "devDependencies": {
-    "vitest": "^3.2.4",
+    "strip-literal": "^3.1.0",
+    "tinyspy": "^4.0.4",
     "typescript": "^5.9.3",
+    "vitest": "^3.2.4",
     "vitest-qase-reporter": "1.0.2"
   },
   "dependencies": {

--- a/examples/single/vitest/test/api-advanced.test.ts
+++ b/examples/single/vitest/test/api-advanced.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from 'vitest';
-import { withQase } from 'vitest-qase-reporter/vitest';
+import { withQase, addQaseId } from 'vitest-qase-reporter/vitest';
 
 describe("Advanced Qase Features", () => {
-  test("Complex nested steps - multi-step user and post retrieval", withQase(async ({ qase }) => {
+  test(addQaseId("Complex nested steps - multi-step user and post retrieval", [11]), withQase(async ({ qase }) => {
     await qase.title("Demonstrate nested step execution");
     await qase.fields({ layer: 'api', severity: 'normal', priority: 'medium' });
 
@@ -38,16 +38,16 @@ describe("Advanced Qase Features", () => {
 
     await qase.step("Step 3: Verify relationship consistency", async () => {
       await qase.parameters({
-        userId: userId,
+        userId: String(userId),
         userName: userName,
-        postCount: userPosts.length
+        postCount: String(userPosts.length)
       });
 
       expect(userPosts.length).toBe(10); // Each user has 10 posts
     });
   }));
 
-  test("Suite hierarchy - demonstrate nested suite structure", withQase(async ({ qase }) => {
+  test(addQaseId("Suite hierarchy - demonstrate nested suite structure", [12]), withQase(async ({ qase }) => {
     await qase.title("Demonstrate suite hierarchy with tab separators");
     await qase.suite('API Tests\tAdvanced\tRelationships');
     await qase.fields({ layer: 'api', severity: 'normal' });
@@ -73,7 +73,7 @@ describe("Advanced Qase Features", () => {
     });
   }));
 
-  test("Parameterized test pattern - demonstrate multiple test parameters", withQase(async ({ qase }) => {
+  test(addQaseId("Parameterized test pattern - demonstrate multiple test parameters", [13]), withQase(async ({ qase }) => {
     await qase.title("Verify multiple users with different parameters");
     await qase.fields({ layer: 'api', severity: 'normal' });
 
@@ -82,9 +82,9 @@ describe("Advanced Qase Features", () => {
     for (const userId of userIds) {
       await qase.step(`Test user ${userId}`, async () => {
         await qase.parameters({
-          userId: userId,
-          iteration: userIds.indexOf(userId) + 1,
-          totalIterations: userIds.length
+          userId: String(userId),
+          iteration: String(userIds.indexOf(userId) + 1),
+          totalIterations: String(userIds.length)
         });
 
         const response = await fetch(`https://jsonplaceholder.typicode.com/users/${userId}`);
@@ -101,7 +101,7 @@ describe("Advanced Qase Features", () => {
     });
   }));
 
-  test.skip("Authentication endpoint placeholder", () => {
+  test.skip(addQaseId("Authentication endpoint placeholder", [14]), () => {
     qase.ignore();
     // This test is intentionally skipped to demonstrate qase.ignore()
     // Future feature: test OAuth authentication flow

--- a/examples/single/vitest/test/api-crud.test.ts
+++ b/examples/single/vitest/test/api-crud.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from 'vitest';
-import { withQase } from 'vitest-qase-reporter/vitest';
+import { withQase, addQaseId } from 'vitest-qase-reporter/vitest';
 
 describe("User CRUD Operations", () => {
-  test("GET all users - verify 10 users returned", withQase(async ({ qase }) => {
+  test(addQaseId("GET all users - verify 10 users returned", [1]), withQase(async ({ qase }) => {
     await qase.title("Retrieve all users from JSONPlaceholder API");
     await qase.fields({ layer: 'api', severity: 'normal' });
 
@@ -26,10 +26,10 @@ describe("User CRUD Operations", () => {
     });
   }));
 
-  test("GET single user by ID - verify user 1 is Leanne Graham", withQase(async ({ qase }) => {
+  test(addQaseId("GET single user by ID - verify user 1 is Leanne Graham", [2]), withQase(async ({ qase }) => {
     await qase.title("Retrieve specific user by ID");
     await qase.fields({ layer: 'api', severity: 'normal' });
-    await qase.parameters({ userId: 1 });
+    await qase.parameters({ userId: '1' });
 
     await qase.step("Send GET request to /users/1", async () => {
       const response = await fetch('https://jsonplaceholder.typicode.com/users/1');
@@ -53,7 +53,7 @@ describe("User CRUD Operations", () => {
     });
   }));
 
-  test("POST create user - verify 201 response and returned ID", withQase(async ({ qase }) => {
+  test(addQaseId("POST create user - verify 201 response and returned ID", [3]), withQase(async ({ qase }) => {
     await qase.title("Create new user via POST request");
     await qase.fields({ layer: 'api', severity: 'critical', priority: 'high' });
 
@@ -88,10 +88,10 @@ describe("User CRUD Operations", () => {
     });
   }));
 
-  test("DELETE user - verify 200 response", withQase(async ({ qase }) => {
+  test(addQaseId("DELETE user - verify 200 response", [4]), withQase(async ({ qase }) => {
     await qase.title("Delete user by ID");
     await qase.fields({ layer: 'api', severity: 'normal' });
-    await qase.parameters({ userId: 1 });
+    await qase.parameters({ userId: '1' });
     await qase.comment("Note: JSONPlaceholder fakes DELETE requests - no actual data is removed");
 
     await qase.step("Send DELETE request to /users/1", async () => {

--- a/examples/single/vitest/test/api-errors.test.ts
+++ b/examples/single/vitest/test/api-errors.test.ts
@@ -1,11 +1,11 @@
 import { describe, test, expect } from 'vitest';
-import { withQase } from 'vitest-qase-reporter/vitest';
+import { withQase, addQaseId } from 'vitest-qase-reporter/vitest';
 
 describe("Error Handling", () => {
-  test("GET non-existent user (404) - verify error status", withQase(async ({ qase }) => {
+  test(addQaseId("GET non-existent user (404) - verify error status", [8]), withQase(async ({ qase }) => {
     await qase.title("Verify API returns 404 for non-existent user");
     await qase.fields({ layer: 'api', severity: 'normal', priority: 'medium' });
-    await qase.parameters({ userId: 999 });
+    await qase.parameters({ userId: '999' });
     await qase.comment("Expected failure: User ID 999 does not exist in JSONPlaceholder database");
 
     await qase.step("Send GET request to /users/999", async () => {
@@ -26,10 +26,10 @@ describe("Error Handling", () => {
     });
   }));
 
-  test("GET non-existent post (404) - attach error response", withQase(async ({ qase }) => {
+  test(addQaseId("GET non-existent post (404) - attach error response", [9]), withQase(async ({ qase }) => {
     await qase.title("Verify API returns 404 for non-existent post");
     await qase.fields({ layer: 'api', severity: 'normal' });
-    await qase.parameters({ postId: 9999 });
+    await qase.parameters({ postId: '9999' });
 
     let errorResponse: any;
 
@@ -54,7 +54,7 @@ describe("Error Handling", () => {
     });
   }));
 
-  test("GET invalid endpoint (404) - verify graceful handling", withQase(async ({ qase }) => {
+  test(addQaseId("GET invalid endpoint (404) - verify graceful handling", [10]), withQase(async ({ qase }) => {
     await qase.title("Verify API handles invalid endpoints gracefully");
     await qase.fields({ layer: 'api', severity: 'normal' });
 

--- a/examples/single/vitest/test/api-posts.test.ts
+++ b/examples/single/vitest/test/api-posts.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from 'vitest';
-import { withQase } from 'vitest-qase-reporter/vitest';
+import { withQase, addQaseId } from 'vitest-qase-reporter/vitest';
 
 describe("Post Validation", () => {
-  test("GET all posts - verify 100 posts returned", withQase(async ({ qase }) => {
+  test(addQaseId("GET all posts - verify 100 posts returned", [5]), withQase(async ({ qase }) => {
     await qase.title("Retrieve all posts from JSONPlaceholder API");
     await qase.fields({ layer: 'api', priority: 'high', severity: 'normal' });
 
@@ -27,10 +27,10 @@ describe("Post Validation", () => {
     });
   }));
 
-  test("GET posts by user ID - verify filtered results", withQase(async ({ qase }) => {
+  test(addQaseId("GET posts by user ID - verify filtered results", [6]), withQase(async ({ qase }) => {
     await qase.title("Retrieve posts for specific user");
     await qase.fields({ layer: 'api', severity: 'normal' });
-    await qase.parameters({ userId: 1, expectedPosts: 10 });
+    await qase.parameters({ userId: '1', expectedPosts: '10' });
 
     await qase.step("Send GET request with userId filter", async () => {
       const response = await fetch('https://jsonplaceholder.typicode.com/posts?userId=1');
@@ -63,10 +63,10 @@ describe("Post Validation", () => {
     });
   }));
 
-  test("GET post with comments - verify comment structure", withQase(async ({ qase }) => {
+  test(addQaseId("GET post with comments - verify comment structure", [7]), withQase(async ({ qase }) => {
     await qase.title("Retrieve post comments and validate structure");
     await qase.fields({ layer: 'api', severity: 'normal' });
-    await qase.parameters({ postId: 1 });
+    await qase.parameters({ postId: '1' });
 
     let comments: any[] = [];
 

--- a/examples/single/vitest/vitest.integration.config.ts
+++ b/examples/single/vitest/vitest.integration.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    watch: false,
+    testTimeout: 10000,
+    include: ['test/**/*.test.ts'],
+    reporters: [
+      'default',
+      ['vitest-qase-reporter',
+        {
+          debug: true,
+          testops: {
+            api: {
+              token: "<token>",
+            },
+            run: {
+              complete: true,
+            },
+            project: "<project_code>",
+            uploadAttachments: true,
+            showPublicReportLink: true,
+          },
+          captureLogs: true,
+        }
+      ],
+    ],
+  },
+});

--- a/examples/single/vitest/vitest.integration.config.ts
+++ b/examples/single/vitest/vitest.integration.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     watch: false,
     testTimeout: 10000,
+    fileParallelism: false,
     include: ['test/**/*.test.ts'],
     reporters: [
       'default',

--- a/expected/cypress-examples.yaml
+++ b/expected/cypress-examples.yaml
@@ -1,0 +1,101 @@
+run:
+  stats:
+    total: 3
+    passed: 3
+    failed: 0
+    skipped: 0
+    blocked: 0
+    invalid: 0
+    muted: 0
+results:
+- title: User can login with valid credentials
+  signature: 1::cypress::e2e::login.cy.js::login_scenarios::user_can_login_with_valid_credentials_(qase_id:_1)
+  testops_ids:
+  - 1
+  status: passed
+  fields:
+    severity: critical
+    priority: high
+    layer: e2e
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tAuthentication\tLogin"
+        public_id: null
+  steps:
+  - data:
+      action: Fill in username
+    execution:
+      status: passed
+  - data:
+      action: Fill in password
+    execution:
+      status: passed
+  - data:
+      action: Submit login form
+    execution:
+      status: passed
+  - data:
+      action: Verify successful login
+    execution:
+      status: passed
+- title: User cannot login with invalid password
+  signature: 2::cypress::e2e::login.cy.js::login_scenarios::user_cannot_login_with_invalid_password_(qase_id:_2)::{'username':'standard_user'}::{'password':'wrong_password'}
+  testops_ids:
+  - 2
+  status: passed
+  fields:
+    severity: critical
+    priority: high
+    layer: e2e
+  params:
+    username: standard_user
+    password: wrong_password
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tAuthentication\tLogin"
+        public_id: null
+  steps:
+  - data:
+      action: Attempt login with invalid credentials
+    execution:
+      status: passed
+  - data:
+      action: Verify error message is shown
+    execution:
+      status: passed
+  - data:
+      action: Verify still on login page
+    execution:
+      status: passed
+- title: Locked user cannot login
+  signature: 3::cypress::e2e::login.cy.js::login_scenarios::locked_user_cannot_login_(qase_id:_3)::{'username':'locked_out_user'}::{'password':'secret_sauce'}
+  testops_ids:
+  - 3
+  status: passed
+  fields:
+    severity: critical
+    priority: high
+    layer: e2e
+  params:
+    username: locked_out_user
+    password: secret_sauce
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tAuthentication\tLogin"
+        public_id: null
+  steps:
+  - data:
+      action: Attempt login with locked user
+    execution:
+      status: passed
+  - data:
+      action: Verify locked out error message
+    execution:
+      status: passed
+  - data:
+      action: Verify cannot access inventory
+    execution:
+      status: passed

--- a/expected/jest-examples.yaml
+++ b/expected/jest-examples.yaml
@@ -1,0 +1,429 @@
+run:
+  stats:
+    total: 16
+    passed: 12
+    failed: 3
+    skipped: 1
+    blocked: 0
+    invalid: 0
+    muted: 0
+results:
+- title: Suite hierarchy demonstration
+  signature: 13::test::api-advanced.test.js::jsonplaceholder_api_-_advanced_features_suite_hierarchy_demonstration_(qase_id:_13)
+  testops_ids:
+  - 13
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  relations:
+    suite:
+      data:
+      - title: "API Tests\tAdvanced\tData Validation"
+        public_id: null
+  steps:
+  - data:
+      action: Validate todos endpoint structure
+    execution:
+      status: passed
+- title: GET non-existent post returns empty object
+  signature: 9::test::api-errors.test.js::jsonplaceholder_api_-_error_handling_get_non-existent_post_returns_empty_object_(qase_id:_9)
+  testops_ids:
+  - 9
+  status: failed
+  fields:
+    layer: api
+    severity: normal
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-errors.test.js
+        public_id: null
+      - title: JSONPlaceholder API - Error Handling
+        public_id: null
+  steps:
+  - data:
+      action: Request post with ID 999
+    execution:
+      status: failed
+- title: GET post with comments returns nested data
+  signature: 7::test::api-posts.test.js::jsonplaceholder_api_-_post_validation_get_post_with_comments_returns_nested_data_(qase_id:_7)
+  testops_ids:
+  - 7
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+    priority: medium
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-posts.test.js
+        public_id: null
+      - title: JSONPlaceholder API - Post Validation
+        public_id: null
+  steps:
+  - data:
+      action: Fetch post by ID
+    execution:
+      status: passed
+  - data:
+      action: Fetch comments for the post
+    execution:
+      status: passed
+  - data:
+      action: Verify comment structure
+    execution:
+      status: passed
+  attachments:
+  - file_name: post-with-comments.json
+    mime_type: application/octet-stream
+- title: GET non-existent user returns empty object
+  signature: 8::test::api-errors.test.js::jsonplaceholder_api_-_error_handling_get_non-existent_user_returns_empty_object_(qase_id:_8)
+  testops_ids:
+  - 8
+  status: failed
+  fields:
+    layer: api
+    severity: normal
+    priority: medium
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-errors.test.js
+        public_id: null
+      - title: JSONPlaceholder API - Error Handling
+        public_id: null
+  steps:
+  - data:
+      action: Request user with ID 999
+    execution:
+      status: failed
+- title: GET single user by ID returns correct user
+  signature: 2::test::api-crud.test.js::jsonplaceholder_api_-_user_crud_operations_get_single_user_by_id_returns_correct_user_(qase_id:_2)::{'userid':'1'}
+  testops_ids:
+  - 2
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  params:
+    userId: '1'
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-crud.test.js
+        public_id: null
+      - title: JSONPlaceholder API - User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send GET request to /users/1
+    execution:
+      status: passed
+  - data:
+      action: Verify user address and company information
+    execution:
+      status: passed
+- title: GET all posts returns 100 posts
+  signature: 5::test::api-posts.test.js::jsonplaceholder_api_-_post_validation_get_all_posts_returns_100_posts_(qase_id:_5)
+  testops_ids:
+  - 5
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+    priority: high
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-posts.test.js
+        public_id: null
+      - title: JSONPlaceholder API - Post Validation
+        public_id: null
+  steps:
+  - data:
+      action: Send GET request to /posts endpoint
+    execution:
+      status: passed
+  - data:
+      action: Verify post structure
+    execution:
+      status: passed
+- title: Albums endpoint with nested photos
+  signature: 15::test::api-advanced.test.js::jsonplaceholder_api_-_advanced_features_albums_endpoint_with_nested_photos_(qase_id:_15)
+  testops_ids:
+  - 15
+  status: passed
+  fields:
+    layer: api
+    severity: low
+    priority: low
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-advanced.test.js
+        public_id: null
+      - title: JSONPlaceholder API - Advanced Features
+        public_id: null
+  steps:
+  - data:
+      action: Fetch album details
+    execution:
+      status: passed
+  - data:
+      action: Verify photo structure
+    execution:
+      status: passed
+  - data:
+      action: Fetch photos in album
+    execution:
+      status: passed
+- title: GET posts filtered by user ID returns correct results
+  signature: 6::test::api-posts.test.js::jsonplaceholder_api_-_post_validation_get_posts_filtered_by_user_id_returns_correct_results_(qase_id:_6)::{'userid':'1'}::{'filtertype':'query_parameter'}
+  testops_ids:
+  - 6
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  params:
+    userId: '1'
+    filterType: query_parameter
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-posts.test.js
+        public_id: null
+      - title: JSONPlaceholder API - Post Validation
+        public_id: null
+  steps:
+  - data:
+      action: Send GET request with userId filter
+    execution:
+      status: passed
+  - data:
+      action: Verify all posts belong to user 1
+    execution:
+      status: passed
+- title: Invalid endpoint returns 404 with HTML
+  signature: 10::test::api-errors.test.js::jsonplaceholder_api_-_error_handling_invalid_endpoint_returns_404_with_html_(qase_id:_10)
+  testops_ids:
+  - 10
+  status: failed
+  fields:
+    layer: api
+    severity: low
+    priority: low
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-errors.test.js
+        public_id: null
+      - title: JSONPlaceholder API - Error Handling
+        public_id: null
+  steps:
+  - data:
+      action: Request invalid endpoint
+    execution:
+      status: failed
+- title: DELETE user returns 200 status
+  signature: 4::test::api-crud.test.js::jsonplaceholder_api_-_user_crud_operations_delete_user_returns_200_status_(qase_id:_4)
+  testops_ids:
+  - 4
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-crud.test.js
+        public_id: null
+      - title: JSONPlaceholder API - User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send DELETE request to /users/1
+    execution:
+      status: passed
+  - data:
+      action: Verify response is empty object
+    execution:
+      status: passed
+- title: POST with invalid JSON is gracefully handled
+  signature: 11::test::api-errors.test.js::jsonplaceholder_api_-_error_handling_post_with_invalid_json_is_gracefully_handled_(qase_id:_11)
+  testops_ids:
+  - 11
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-errors.test.js
+        public_id: null
+      - title: JSONPlaceholder API - Error Handling
+        public_id: null
+  steps:
+  - data:
+      action: Send POST with minimal data
+    execution:
+      status: passed
+- title: POST create new user returns 201 with ID
+  signature: 3::test::api-crud.test.js::jsonplaceholder_api_-_user_crud_operations_post_create_new_user_returns_201_with_id_(qase_id:_3)
+  testops_ids:
+  - 3
+  status: passed
+  fields:
+    layer: api
+    severity: critical
+    priority: high
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-crud.test.js
+        public_id: null
+      - title: JSONPlaceholder API - User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send POST request to create user
+    execution:
+      status: passed
+  attachments:
+  - file_name: request-body.json
+    mime_type: application/octet-stream
+- title: Parameterized test pattern - multiple user IDs
+  signature: 14::test::api-advanced.test.js::jsonplaceholder_api_-_advanced_features_parameterized_test_pattern_-_multiple_user_ids_(qase_id:_14)::{'testscope':'multiple_users'}::{'userids':'1,2,3'}::{'validationtype':'existence'}
+  testops_ids:
+  - 14
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  params:
+    testScope: multiple_users
+    userIds: 1,2,3
+    validationType: existence
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-advanced.test.js
+        public_id: null
+      - title: JSONPlaceholder API - Advanced Features
+        public_id: null
+  steps:
+  - data:
+      action: Verify user 1 exists
+    execution:
+      status: passed
+  - data:
+      action: Verify user 2 exists
+    execution:
+      status: passed
+  - data:
+      action: Verify user 3 exists
+    execution:
+      status: passed
+- title: GET all users returns 10 users
+  signature: 1::test::api-crud.test.js::jsonplaceholder_api_-_user_crud_operations_get_all_users_returns_10_users_(qase_id:_1)
+  testops_ids:
+  - 1
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+    priority: high
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-crud.test.js
+        public_id: null
+      - title: JSONPlaceholder API - User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send GET request to /users endpoint
+    execution:
+      status: passed
+  - data:
+      action: Verify response contains valid user structure
+    execution:
+      status: passed
+- title: Authentication feature (not yet implemented)
+  signature: 16::test::api-advanced.test.js::jsonplaceholder_api_-_advanced_features_authentication_feature_(not_yet_implemented)_(qase_id:_16)
+  testops_ids:
+  - 16
+  status: skipped
+  relations:
+    suite:
+      data:
+      - title: test
+        public_id: null
+      - title: api-advanced.test.js
+        public_id: null
+      - title: JSONPlaceholder API - Advanced Features
+        public_id: null
+- title: Complex nested steps - fetch user and their posts
+  signature: 12::test::api-advanced.test.js::jsonplaceholder_api_-_advanced_features_complex_nested_steps_-_fetch_user_and_their_posts_(qase_id:_12)
+  testops_ids:
+  - 12
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+    priority: medium
+  relations:
+    suite:
+      data:
+      - title: "API Tests\tAdvanced\tRelationships"
+        public_id: null
+  steps:
+  - data:
+      action: Validate user has company information
+    execution:
+      status: passed
+  - data:
+      action: Fetch user details
+    execution:
+      status: passed
+  - data:
+      action: Verify first post belongs to user
+    execution:
+      status: passed
+  - data:
+      action: Verify post titles are non-empty
+    execution:
+      status: passed
+  - data:
+      action: Fetch all posts by user
+    execution:
+      status: passed

--- a/expected/mocha-examples.yaml
+++ b/expected/mocha-examples.yaml
@@ -1,0 +1,174 @@
+run:
+  stats:
+    total: 17
+    passed: 3
+    failed: 0
+    skipped: 1
+    blocked: 0
+    invalid: 13
+    muted: 0
+results:
+- title: POST request should be intercepted by profiler
+  signature: test::profiler-test.spec.js::network_profiler_test::post_request_should_be_intercepted_by_profiler
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: Network Profiler Test
+        public_id: null
+- title: GET request should be intercepted by profiler
+  signature: test::profiler-test.spec.js::network_profiler_test::get_request_should_be_intercepted_by_profiler
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: Network Profiler Test
+        public_id: null
+- title: Multiple requests in one test
+  signature: test::profiler-test.spec.js::network_profiler_test::multiple_requests_in_one_test
+  status: passed
+  relations:
+    suite:
+      data:
+      - title: Network Profiler Test
+        public_id: null
+- title: GET all users - verify 10 users returned
+  signature: 1::test::api-crud.spec.js::jsonplaceholder_user_crud_operations::get_all_users_-_verify_10_users_returned_(qase_id:_1)
+  testops_ids:
+  - 1
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder User CRUD Operations
+        public_id: null
+- title: GET post with comments - verify comment structure
+  signature: 7::test::api-posts.spec.js::jsonplaceholder_post_validation::get_post_with_comments_-_verify_comment_structure_(qase_id:_7)
+  testops_ids:
+  - 7
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder Post Validation
+        public_id: null
+- title: GET non-existent user - verify 404 response
+  signature: 8::test::api-errors.spec.js::jsonplaceholder_error_handling::get_non-existent_user_-_verify_404_response_(qase_id:_8)
+  testops_ids:
+  - 8
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder Error Handling
+        public_id: null
+- title: Complex nested steps - multi-resource retrieval
+  signature: 11::test::api-advanced.spec.js::jsonplaceholder_advanced_qase_features::complex_nested_steps_-_multi-resource_retrieval_(qase_id:_11)
+  testops_ids:
+  - 11
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder Advanced Qase Features
+        public_id: null
+- title: GET all posts - verify 100 posts returned
+  signature: 5::test::api-posts.spec.js::jsonplaceholder_post_validation::get_all_posts_-_verify_100_posts_returned_(qase_id:_5)
+  testops_ids:
+  - 5
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder Post Validation
+        public_id: null
+- title: GET posts by user ID - verify filtered results
+  signature: 6::test::api-posts.spec.js::jsonplaceholder_post_validation::get_posts_by_user_id_-_verify_filtered_results_(qase_id:_6)
+  testops_ids:
+  - 6
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder Post Validation
+        public_id: null
+- title: Future feature - API authentication
+  signature: 14::test::api-advanced.spec.js::jsonplaceholder_advanced_qase_features::future_feature_-_api_authentication_(qase_id:_14)
+  testops_ids:
+  - 14
+  status: skipped
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder Advanced Qase Features
+        public_id: null
+- title: GET non-existent post - attach error response
+  signature: 9::test::api-errors.spec.js::jsonplaceholder_error_handling::get_non-existent_post_-_attach_error_response_(qase_id:_9)
+  testops_ids:
+  - 9
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder Error Handling
+        public_id: null
+- title: Parameterized test pattern - multiple user IDs
+  signature: 13::test::api-advanced.spec.js::jsonplaceholder_advanced_qase_features::parameterized_test_pattern_-_multiple_user_ids_(qase_id:_13)
+  testops_ids:
+  - 13
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder Advanced Qase Features
+        public_id: null
+- title: Suite hierarchy demonstration
+  signature: 12::test::api-advanced.spec.js::jsonplaceholder_advanced_qase_features::suite_hierarchy_demonstration_(qase_id:_12)
+  testops_ids:
+  - 12
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder Advanced Qase Features
+        public_id: null
+- title: GET single user by ID - verify user details
+  signature: 2::test::api-crud.spec.js::jsonplaceholder_user_crud_operations::get_single_user_by_id_-_verify_user_details_(qase_id:_2)
+  testops_ids:
+  - 2
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder User CRUD Operations
+        public_id: null
+- title: DELETE user - verify 200 response
+  signature: 4::test::api-crud.spec.js::jsonplaceholder_user_crud_operations::delete_user_-_verify_200_response_(qase_id:_4)
+  testops_ids:
+  - 4
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder User CRUD Operations
+        public_id: null
+- title: POST create user - verify 201 response and returned ID
+  signature: 3::test::api-crud.spec.js::jsonplaceholder_user_crud_operations::post_create_user_-_verify_201_response_and_returned_id_(qase_id:_3)
+  testops_ids:
+  - 3
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder User CRUD Operations
+        public_id: null
+- title: Invalid endpoint - verify graceful 404 handling
+  signature: 10::test::api-errors.spec.js::jsonplaceholder_error_handling::invalid_endpoint_-_verify_graceful_404_handling_(qase_id:_10)
+  testops_ids:
+  - 10
+  status: invalid
+  relations:
+    suite:
+      data:
+      - title: JSONPlaceholder Error Handling
+        public_id: null

--- a/expected/playwright-examples.yaml
+++ b/expected/playwright-examples.yaml
@@ -1,0 +1,458 @@
+run:
+  stats:
+    total: 12
+    passed: 12
+    failed: 0
+    skipped: 0
+    blocked: 0
+    invalid: 0
+    muted: 0
+results:
+- title: User can sort products by price
+  signature: 5::e-commerce::inventory::sorting::{'sortoption':'lohi'}
+  testops_ids:
+  - 5
+  status: passed
+  fields:
+    severity: minor
+    priority: medium
+    layer: e2e
+  params:
+    sortOption: lohi
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tInventory\tSorting"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Select sort by price (low to high)
+    execution:
+      status: passed
+  - data:
+      action: Verify products are sorted correctly
+    execution:
+      status: passed
+- title: User can cancel checkout
+  signature: 12::e-commerce::checkout::navigation
+  testops_ids:
+  - 12
+  status: passed
+  fields:
+    severity: major
+    priority: medium
+    layer: e2e
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tCheckout\tNavigation"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Click cancel button
+    execution:
+      status: passed
+  - data:
+      action: Verify return to cart page
+    execution:
+      status: passed
+- title: User can browse all products
+  signature: 4::e-commerce::inventory::browsing
+  testops_ids:
+  - 4
+  status: passed
+  fields:
+    severity: normal
+    priority: high
+    layer: e2e
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tInventory\tBrowsing"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Verify inventory page title
+    execution:
+      status: passed
+  - data:
+      action: Count available products
+    execution:
+      status: passed
+  - data:
+      action: Verify product details are visible
+    execution:
+      status: passed
+      attachments:
+      - file_name: product-count.json
+        mime_type: application/json
+- title: User can view product details
+  signature: 6::e-commerce::inventory::product_details
+  testops_ids:
+  - 6
+  status: passed
+  fields:
+    severity: major
+    priority: low
+    layer: e2e
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tInventory\tProduct Details"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Click on first product
+    execution:
+      status: passed
+  - data:
+      action: Verify product detail page is displayed
+    execution:
+      status: passed
+- title: User can remove product from cart
+  signature: 8::e-commerce::shopping_cart::remove_items
+  testops_ids:
+  - 8
+  status: passed
+  fields:
+    severity: normal
+    priority: medium
+    layer: e2e
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tShopping Cart\tRemove Items"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Add product to cart
+    execution:
+      status: passed
+  - data:
+      action: Navigate to cart
+    execution:
+      status: passed
+  - data:
+      action: Remove product from cart
+    execution:
+      status: passed
+  - data:
+      action: Verify cart is empty
+    execution:
+      status: passed
+- title: User can add multiple products to cart
+  signature: 9::e-commerce::shopping_cart::multiple_items
+  testops_ids:
+  - 9
+  status: passed
+  fields:
+    severity: major
+    priority: high
+    layer: e2e
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tShopping Cart\tMultiple Items"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Add first product
+    execution:
+      status: passed
+  - data:
+      action: Add second product
+    execution:
+      status: passed
+  - data:
+      action: Verify cart badge shows 2 items
+    execution:
+      status: passed
+- title: User can complete checkout with valid information
+  signature: 10::e-commerce::checkout::complete_flow::{'firstname':'john'}::{'lastname':'doe'}::{'postalcode':'12345'}
+  testops_ids:
+  - 10
+  status: passed
+  fields:
+    severity: critical
+    priority: low
+    layer: e2e
+  params:
+    firstName: John
+    lastName: Doe
+    postalCode: '12345'
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tCheckout\tComplete Flow"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Fill checkout information
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: Enter customer details
+      execution:
+        status: passed
+    - data:
+        action: Continue to overview
+      execution:
+        status: passed
+  - data:
+      action: Complete the order
+    execution:
+      status: passed
+  - data:
+      action: Verify order completion
+    execution:
+      status: passed
+      attachments:
+      - file_name: order-complete.txt
+        mime_type: text/plain
+- title: User cannot login with invalid password
+  signature: 2::e-commerce::authentication::login::{'username':'standard_user'}::{'password':'wrong_password'}
+  testops_ids:
+  - 2
+  status: passed
+  fields:
+    severity: minor
+    priority: high
+    layer: e2e
+  params:
+    username: standard_user
+    password: wrong_password
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tAuthentication\tLogin"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Attempt login with invalid password
+    execution:
+      status: passed
+  - data:
+      action: Verify error message is displayed
+    execution:
+      status: passed
+- title: User can login with valid credentials
+  signature: 1::e-commerce::authentication::login
+  testops_ids:
+  - 1
+  status: passed
+  fields:
+    severity: critical
+    priority: high
+    layer: e2e
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tAuthentication\tLogin"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Navigate to login page
+    execution:
+      status: passed
+  - data:
+      action: Fill in credentials and submit
+    execution:
+      status: passed
+  - data:
+      action: Verify successful login
+    execution:
+      status: passed
+      attachments:
+      - file_name: login-success.png
+        mime_type: image/png
+- title: Checkout fails without required information
+  signature: 11::e-commerce::checkout::validation::{'scenario':'missing_first_name'}
+  testops_ids:
+  - 11
+  status: passed
+  fields:
+    severity: normal
+    priority: high
+    layer: e2e
+  params:
+    scenario: missing_first_name
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tCheckout\tValidation"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Attempt to continue without filling first name
+    execution:
+      status: passed
+  - data:
+      action: Verify error message is displayed
+    execution:
+      status: passed
+- title: User can add product to cart
+  signature: 7::e-commerce::shopping_cart::add_items::{'product':'sauce labs backpack'}
+  testops_ids:
+  - 7
+  status: passed
+  fields:
+    severity: critical
+    priority: high
+    layer: e2e
+  params:
+    product: Sauce Labs Backpack
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tShopping Cart\tAdd Items"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Add product to cart
+    execution:
+      status: passed
+  - data:
+      action: Verify cart badge shows 1 item
+    execution:
+      status: passed
+  - data:
+      action: Navigate to cart and verify product
+    execution:
+      status: passed
+      attachments:
+      - file_name: cart-state.json
+        mime_type: application/json
+- title: Locked user cannot login
+  signature: 3::e-commerce::authentication::login::{'username':'locked_out_user'}
+  testops_ids:
+  - 3
+  status: passed
+  fields:
+    severity: major
+    priority: medium
+    layer: e2e
+  params:
+    username: locked_out_user
+  relations:
+    suite:
+      data:
+      - title: "E-commerce\tAuthentication\tLogin"
+        public_id: null
+  steps:
+  - data:
+      action: Before Hooks
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: beforeEach hook
+      execution:
+        status: passed
+  - data:
+      action: Attempt login with locked user
+    execution:
+      status: passed
+  - data:
+      action: Verify locked-out error message
+    execution:
+      status: passed

--- a/expected/vitest-examples.yaml
+++ b/expected/vitest-examples.yaml
@@ -109,7 +109,7 @@ results:
   relations:
     suite:
       data:
-      - title: User CRUD Operations
+      - title: Post Validation
         public_id: null
   steps:
   - data:
@@ -193,7 +193,7 @@ results:
   relations:
     suite:
       data:
-      - title: User CRUD Operations
+      - title: Advanced Qase Features
         public_id: null
   steps:
   - data:
@@ -284,7 +284,7 @@ results:
   relations:
     suite:
       data:
-      - title: User CRUD Operations
+      - title: Error Handling
         public_id: null
   steps:
   - data:
@@ -311,7 +311,7 @@ results:
   relations:
     suite:
       data:
-      - title: User CRUD Operations
+      - title: Error Handling
         public_id: null
   steps:
   - data:
@@ -339,7 +339,7 @@ results:
   relations:
     suite:
       data:
-      - title: User CRUD Operations
+      - title: Error Handling
         public_id: null
   steps:
   - data:

--- a/expected/vitest-examples.yaml
+++ b/expected/vitest-examples.yaml
@@ -1,0 +1,356 @@
+run:
+  stats:
+    total: 14
+    passed: 13
+    failed: 0
+    skipped: 1
+    broken: 0
+    muted: 0
+results:
+- title: Retrieve all users from JSONPlaceholder API
+  signature: 'User CRUD Operations > GET all users - verify 10 users returned (Qase
+    ID: 1)'
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  relations:
+    suite:
+      data:
+      - title: User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send GET request to /users endpoint
+    execution:
+      status: passed
+  - data:
+      action: Validate user data structure
+    execution:
+      status: passed
+- title: Retrieve specific user by ID
+  signature: 'User CRUD Operations > GET single user by ID - verify user 1 is Leanne
+    Graham (Qase ID: 2)'
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  params:
+    userId: '1'
+  relations:
+    suite:
+      data:
+      - title: User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send GET request to /users/1
+    execution:
+      status: passed
+  - data:
+      action: Validate user address structure
+    execution:
+      status: passed
+- title: Create new user via POST request
+  signature: 'User CRUD Operations > POST create user - verify 201 response and returned
+    ID (Qase ID: 3)'
+  status: passed
+  fields:
+    layer: api
+    severity: critical
+    priority: high
+  relations:
+    suite:
+      data:
+      - title: User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send POST request with new user data
+    execution:
+      status: passed
+  - data:
+      action: Attach request body for debugging
+    execution:
+      status: passed
+  attachments:
+  - file_name: new-user-payload.json
+    mime_type: application/octet-stream
+- title: Delete user by ID
+  signature: 'User CRUD Operations > DELETE user - verify 200 response (Qase ID: 4)'
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  params:
+    userId: '1'
+  relations:
+    suite:
+      data:
+      - title: User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send DELETE request to /users/1
+    execution:
+      status: passed
+  - data:
+      action: Verify delete operation succeeded
+    execution:
+      status: passed
+- title: Retrieve all posts from JSONPlaceholder API
+  signature: 'Post Validation > GET all posts - verify 100 posts returned (Qase ID:
+    5)'
+  status: passed
+  fields:
+    layer: api
+    priority: high
+    severity: normal
+  relations:
+    suite:
+      data:
+      - title: User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send GET request to /posts endpoint
+    execution:
+      status: passed
+  - data:
+      action: Validate post structure
+    execution:
+      status: passed
+- title: Retrieve posts for specific user
+  signature: 'Post Validation > GET posts by user ID - verify filtered results (Qase
+    ID: 6)'
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  params:
+    userId: '1'
+    expectedPosts: '10'
+  relations:
+    suite:
+      data:
+      - title: Post Validation
+        public_id: null
+  steps:
+  - data:
+      action: Send GET request with userId filter
+    execution:
+      status: passed
+  - data:
+      action: Verify all posts belong to user 1
+    execution:
+      status: passed
+  - data:
+      action: Validate post content is not empty
+    execution:
+      status: passed
+- title: Retrieve post comments and validate structure
+  signature: 'Post Validation > GET post with comments - verify comment structure
+    (Qase ID: 7)'
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  params:
+    postId: '1'
+  relations:
+    suite:
+      data:
+      - title: Post Validation
+        public_id: null
+  steps:
+  - data:
+      action: Fetch comments for post 1
+    execution:
+      status: passed
+  - data:
+      action: Validate comment structure
+    execution:
+      status: passed
+  - data:
+      action: Attach first comment for reference
+    execution:
+      status: passed
+  attachments:
+  - file_name: first-comment.json
+    mime_type: application/octet-stream
+- title: Demonstrate nested step execution
+  signature: 'Advanced Qase Features > Complex nested steps - multi-step user and
+    post retrieval (Qase ID: 11)'
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+    priority: medium
+  params:
+    userId: '1'
+    userName: Leanne Graham
+    postCount: '10'
+  relations:
+    suite:
+      data:
+      - title: User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: 'Nested: Validate user data completeness'
+    execution:
+      status: passed
+  - data:
+      action: 'Nested: Validate posts belong to user'
+    execution:
+      status: passed
+  - data:
+      action: 'Step 3: Verify relationship consistency'
+    execution:
+      status: passed
+- title: Demonstrate suite hierarchy with tab separators
+  signature: 'Advanced Qase Features > Suite hierarchy - demonstrate nested suite
+    structure (Qase ID: 12)'
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  relations:
+    suite:
+      data:
+      - title: "API Tests\tAdvanced\tRelationships"
+        public_id: null
+  steps:
+  - data:
+      action: Fetch user and their albums
+    execution:
+      status: passed
+  - data:
+      action: Verify album structure
+    execution:
+      status: passed
+- title: Verify multiple users with different parameters
+  signature: 'Advanced Qase Features > Parameterized test pattern - demonstrate multiple
+    test parameters (Qase ID: 13)'
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  params:
+    userId: '3'
+    iteration: '3'
+    totalIterations: '3'
+  relations:
+    suite:
+      data:
+      - title: Advanced Qase Features
+        public_id: null
+  steps:
+  - data:
+      action: Test user 1
+    execution:
+      status: passed
+  - data:
+      action: Test user 2
+    execution:
+      status: passed
+  - data:
+      action: Test user 3
+    execution:
+      status: passed
+  - data:
+      action: Verify all users processed
+    execution:
+      status: passed
+- title: Authentication endpoint placeholder
+  signature: 'Advanced Qase Features > Authentication endpoint placeholder (Qase ID:
+    14)'
+  status: skipped
+  relations:
+    suite:
+      data:
+      - title: Advanced Qase Features
+        public_id: null
+- title: Verify API returns 404 for non-existent user
+  signature: 'Error Handling > GET non-existent user (404) - verify error status (Qase
+    ID: 8)'
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+    priority: medium
+  params:
+    userId: '999'
+  relations:
+    suite:
+      data:
+      - title: User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send GET request to /users/999
+    execution:
+      status: passed
+  - data:
+      action: Verify empty response body
+    execution:
+      status: passed
+  - data:
+      action: Document expected 404 behavior
+    execution:
+      status: passed
+- title: Verify API returns 404 for non-existent post
+  signature: 'Error Handling > GET non-existent post (404) - attach error response
+    (Qase ID: 9)'
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  params:
+    postId: '9999'
+  relations:
+    suite:
+      data:
+      - title: User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send GET request to non-existent post
+    execution:
+      status: passed
+  - data:
+      action: Attach error response for debugging
+    execution:
+      status: passed
+  - data:
+      action: Verify error response structure
+    execution:
+      status: passed
+  attachments:
+  - file_name: 404-error-response.json
+    mime_type: application/octet-stream
+- title: Verify API handles invalid endpoints gracefully
+  signature: 'Error Handling > GET invalid endpoint (404) - verify graceful handling
+    (Qase ID: 10)'
+  status: passed
+  fields:
+    layer: api
+    severity: normal
+  relations:
+    suite:
+      data:
+      - title: User CRUD Operations
+        public_id: null
+  steps:
+  - data:
+      action: Send request to invalid endpoint
+    execution:
+      status: passed
+  - data:
+      action: Verify no server error
+    execution:
+      status: passed
+  - data:
+      action: Document graceful failure
+    execution:
+      status: passed

--- a/package-lock.json
+++ b/package-lock.json
@@ -945,7 +945,9 @@
       "name": "vitest-example",
       "version": "1.0.0",
       "dependencies": {
-        "qase-javascript-commons": "^2.0.0"
+        "qase-javascript-commons": "^2.0.0",
+        "strip-literal": "^3.1.0",
+        "tinyspy": "^4.0.4"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -24542,6 +24544,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "license": "MIT"
+    },
     "node_modules/strnum": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
@@ -26000,6 +26020,15 @@
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
       "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"

--- a/scripts/clean_expected.py
+++ b/scripts/clean_expected.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Clean expected YAML files by removing dynamic fields that change between runs.
+
+Removes:
+- execution blocks (keeps only top-level status)
+- Step IDs, timestamps (start_time, end_time, duration)
+- Attachment IDs and file_path (keeps file_name and mime_type)
+- Empty collections: fields: {}, attachments: [], params: {}, param_groups: [], steps: []
+- muted: false (default value)
+- message (contains dynamic timestamps and unstable whitespace)
+- stacktrace (contains absolute file paths)
+
+Usage:
+    python3 clean_expected.py <file1.yaml> [file2.yaml ...]
+"""
+
+import re
+import sys
+import yaml
+
+
+def normalize_signature(signature: str) -> str:
+    """Normalize signature by stripping absolute path prefixes.
+
+    Some reporters (e.g., Jest) include the absolute file path in signatures,
+    making them environment-dependent. This function strips everything before
+    the relative test path (e.g., 'test::filename.test.js').
+
+    Examples:
+        13::users::gda::...::jest::test::file.test.js::suite::name
+        → 13::test::file.test.js::suite::name
+    """
+    # Match pattern: {id}::{absolute_path}::test::{file}
+    # Strip absolute path, keep from test directory onwards
+    normalized = re.sub(
+        r"^(\d[\d-]*::)(?:[a-z0-9_.-]+::)*?(test::[a-z0-9_.-]+\.(?:test|spec)\.\w+::)",
+        r"\1\2",
+        signature,
+    )
+    return normalized
+
+
+def clean_attachment(attachment: dict) -> dict | None:
+    """Keep only file_name and mime_type from attachments."""
+    if not attachment:
+        return None
+
+    cleaned = {}
+    if "file_name" in attachment:
+        cleaned["file_name"] = attachment["file_name"]
+    if "mime_type" in attachment:
+        cleaned["mime_type"] = attachment["mime_type"]
+
+    return cleaned if cleaned else None
+
+
+def clean_step(step: dict) -> dict | None:
+    """Recursively clean a test step."""
+    if not step:
+        return None
+
+    cleaned = {}
+
+    # Keep data block (action, expected_result) - remove input_data if empty
+    if "data" in step and step["data"]:
+        data = {}
+        if "action" in step["data"] and step["data"]["action"]:
+            data["action"] = step["data"]["action"]
+        if "expected_result" in step["data"] and step["data"]["expected_result"]:
+            data["expected_result"] = step["data"]["expected_result"]
+        if data:
+            cleaned["data"] = data
+
+    # Keep only execution status
+    if "execution" in step and step["execution"]:
+        execution = {}
+        if "status" in step["execution"]:
+            execution["status"] = step["execution"]["status"]
+
+        # Clean step-level attachments (moved to execution in JS reporter)
+        if "attachments" in step["execution"] and step["execution"]["attachments"]:
+            attachments = [
+                clean_attachment(a)
+                for a in step["execution"]["attachments"]
+                if a
+            ]
+            attachments = [a for a in attachments if a]
+            if attachments:
+                execution["attachments"] = attachments
+
+        if execution:
+            cleaned["execution"] = execution
+
+    # Recursively clean nested steps
+    if "steps" in step and step["steps"]:
+        nested = [clean_step(s) for s in step["steps"] if s]
+        nested = [s for s in nested if s]
+        if nested:
+            cleaned["steps"] = nested
+
+    return cleaned if cleaned else None
+
+
+def clean_result(result: dict) -> dict:
+    """Clean a single test result, removing dynamic and empty fields."""
+    cleaned = {}
+
+    # Keep essential fields
+    if "title" in result:
+        cleaned["title"] = result["title"]
+    if "signature" in result:
+        cleaned["signature"] = normalize_signature(result["signature"])
+    if "testops_ids" in result and result["testops_ids"]:
+        cleaned["testops_ids"] = result["testops_ids"]
+    if "status" in result:
+        cleaned["status"] = result["status"]
+
+    # Keep fields if non-empty
+    if "fields" in result and result["fields"]:
+        cleaned["fields"] = result["fields"]
+
+    # Keep params if non-empty
+    if "params" in result and result["params"]:
+        cleaned["params"] = result["params"]
+
+    # Keep param_groups if non-empty
+    if "param_groups" in result and result["param_groups"]:
+        cleaned["param_groups"] = result["param_groups"]
+
+    # Keep relations (suite hierarchy)
+    if "relations" in result and result["relations"]:
+        cleaned["relations"] = result["relations"]
+
+    # Clean steps
+    if "steps" in result and result["steps"]:
+        steps = [clean_step(s) for s in result["steps"] if s]
+        steps = [s for s in steps if s]
+        if steps:
+            cleaned["steps"] = steps
+
+    # Clean attachments
+    if "attachments" in result and result["attachments"]:
+        attachments = [clean_attachment(a) for a in result["attachments"] if a]
+        attachments = [a for a in attachments if a]
+        if attachments:
+            cleaned["attachments"] = attachments
+
+    # Keep muted only if true
+    if result.get("muted") is True:
+        cleaned["muted"] = True
+
+    # Deliberately skip: message, stacktrace, execution block, id
+
+    return cleaned
+
+
+def clean_expected(data: dict) -> dict:
+    """Clean the top-level expected data structure."""
+    cleaned = {}
+
+    # Keep run stats
+    if "run" in data:
+        cleaned["run"] = data["run"]
+
+    # Clean each result
+    if "results" in data and data["results"]:
+        cleaned["results"] = [clean_result(r) for r in data["results"]]
+
+    return cleaned
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 clean_expected.py <file1.yaml> [file2.yaml ...]")
+        sys.exit(1)
+
+    for filepath in sys.argv[1:]:
+        with open(filepath, "r") as f:
+            data = yaml.safe_load(f)
+
+        if not data:
+            print(f"Skipping empty file: {filepath}")
+            continue
+
+        cleaned = clean_expected(data)
+
+        with open(filepath, "w") as f:
+            yaml.dump(cleaned, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+        print(f"Cleaned: {filepath}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/normalize_report.py
+++ b/scripts/normalize_report.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Normalize signatures in generated report JSON files.
+
+Some reporters (e.g., Jest) include absolute file paths in signatures,
+making them environment-dependent. This script strips the absolute path
+prefix, keeping only the relative test path portion.
+
+Usage:
+    python3 normalize_report.py <report-dir>
+"""
+
+import json
+import os
+import re
+import sys
+
+
+def normalize_signature(signature: str) -> str:
+    """Strip absolute path prefix from signatures.
+
+    Converts:
+        13::users::gda::...::jest::test::file.test.js::suite::name
+    To:
+        13::test::file.test.js::suite::name
+    """
+    return re.sub(
+        r"^(\d[\d-]*::)(?:[a-z0-9_.-]+::)*?(test::[a-z0-9_.-]+\.(?:test|spec)\.\w+::)",
+        r"\1\2",
+        signature,
+    )
+
+
+def normalize_result_file(filepath: str) -> None:
+    """Normalize signatures in a single result JSON file."""
+    with open(filepath, "r") as f:
+        data = json.load(f)
+
+    if "signature" in data:
+        data["signature"] = normalize_signature(data["signature"])
+
+    with open(filepath, "w") as f:
+        json.dump(data, f, indent=4)
+
+
+def normalize_run_file(filepath: str) -> None:
+    """Normalize the run.json summary file (no signatures to fix)."""
+    # run.json doesn't contain signatures, nothing to do
+    pass
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 normalize_report.py <report-dir>")
+        sys.exit(1)
+
+    report_dir = sys.argv[1]
+    results_dir = os.path.join(report_dir, "results")
+
+    if not os.path.isdir(results_dir):
+        print(f"No results directory found in {report_dir}")
+        sys.exit(1)
+
+    count = 0
+    for filename in os.listdir(results_dir):
+        if filename.endswith(".json"):
+            filepath = os.path.join(results_dir, filename)
+            normalize_result_file(filepath)
+            count += 1
+
+    print(f"Normalized {count} result files in {report_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add integration test infrastructure that validates reporter JSON output against Qase report schemas using [reporters-validator](https://github.com/qase-tms/reporters-validator)
- Covers 5 frameworks: Jest, Playwright, Cypress, Mocha, Vitest
- Reference implementation: https://github.com/qase-tms/qase-csharp/pull/51

## What's included

### Expected YAML baselines (`expected/`)
Generated from existing `examples/single/` examples via `reporters-validator prepare`, then cleaned with `scripts/clean_expected.py` to remove dynamic fields (timestamps, IDs, absolute paths, empty collections).

### Scripts (`scripts/`)
- **`clean_expected.py`** — removes dynamic fields from expected YAML (execution blocks, step IDs/timestamps, attachment IDs/file_path, empty collections, muted: false, message, stacktrace). Also normalizes absolute path prefixes in signatures.
- **`normalize_report.py`** — normalizes signatures in generated report JSON files to strip absolute paths (needed because Jest includes full file paths in signatures).

### CI workflow (`.github/workflows/npm.yml`)
New `integration-test` job that:
1. Runs each framework's examples with `QASE_MODE=report`
2. Normalizes signatures in generated reports
3. Validates output against expected YAML + JSON schemas via `reporters-validator validate`

### Vitest example fixes
- Added QaseIds via `addQaseId()` for unique test signatures
- Fixed parameter types (numbers → strings) to match JSON schema
- Added `vitest.integration.config.ts` (excludes profiler setup which has ESM import issues)
- Added `strip-literal` and `tinyspy` as devDependencies (vitest transitive deps not hoisted properly in workspace)

## Test plan

- [x] `reporters-validator validate` passes locally for all 5 frameworks
- [x] CI `integration-test` job passes on push
- [x] Verify Playwright/Cypress tests run correctly in CI with browser installation