### PR TITLE
chore: update API clients to latest specification

### DIFF
--- a/qase-api-client/package.json
+++ b/qase-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-client",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Qase TMS Javascript API V1 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-api-v2-client/docs/ResultCreateFields.md
+++ b/qase-api-v2-client/docs/ResultCreateFields.md
@@ -16,6 +16,7 @@ Name | Type | Description | Notes
 **type** | **string** |  | [optional] [default to undefined]
 **muted** | **string** |  | [optional] [default to undefined]
 **is_flaky** | **string** |  | [optional] [default to undefined]
+**tags** | **string** | Comma-separated list of tag titles to assign to the test case | [optional] [default to undefined]
 **executed_by** | **string** | User who executed the test (member id, name or email) | [optional] [default to undefined]
 
 ## Example
@@ -35,6 +36,7 @@ const instance: ResultCreateFields = {
     type,
     muted,
     is_flaky,
+    tags,
     executed_by,
 };
 ```

--- a/qase-api-v2-client/package.json
+++ b/qase-api-v2-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-v2-client",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Qase TMS Javascript API V2 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-api-v2-client/src/model/result-create-fields.ts
+++ b/qase-api-v2-client/src/model/result-create-fields.ts
@@ -88,6 +88,12 @@ export interface ResultCreateFields {
      */
     'is_flaky'?: string;
     /**
+     * Comma-separated list of tag titles to assign to the test case
+     * @type {string}
+     * @memberof ResultCreateFields
+     */
+    'tags'?: string;
+    /**
      * User who executed the test (member id, name or email)
      * @type {string}
      * @memberof ResultCreateFields


### PR DESCRIPTION
## Summary

- Updated API clients to the latest OpenAPI specification

### Targets updated:
- v1 (qase-api-client): 1.1.5 → 1.1.6
- v2 (qase-api-v2-client): 1.0.6 → 1.0.7

### Protected files (skipped):
- qase-api-client/.npmignore
- qase-api-v2-client/.npmignore

### Warnings:
None