### PR TITLE
fix: classify Cypress command and retry-ability failures as failed

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.6.1
+
+## Bug fixes
+
+- Fixed Cypress test failures being classified as `invalid` instead of `failed`. Cypress uses retry-ability (`Timed out retrying after Nms: ...`) and command syntax (`cy.click() failed`, `cy.wait() timed out`) that don't contain the word `expect`, so genuine UI/command failures previously fell through to the timeout catch-all and were mislabeled as environment errors. `cy.request()` with infrastructure-level errors (e.g. `ECONNREFUSED`) continues to be classified as `invalid`.
+
 # qase-javascript-commons@2.6.0
 
 ## What's new

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/utils/test-status-utils.ts
+++ b/qase-javascript-commons/src/utils/test-status-utils.ts
@@ -102,6 +102,22 @@ function isAssertionError(error: Error, originalStatus: string): boolean {
     return false;
   }
 
+  // Cypress-specific failure detection.
+  // Cypress uses retry-ability and command-based error syntax that don't contain
+  // the word "expect" (unlike Jest/Playwright assertions). Without this branch,
+  // genuine UI/command failures fall through to the "timeout → invalid" catch-all
+  // below and get misclassified as environment errors.
+  //
+  // Why this order: the hasNonAssertionPattern check above already returned
+  // invalid for cy.request() failures (which contain "network"/"connection"),
+  // so reaching this point with a Cypress signature means the error has no
+  // infrastructure markers — the test app failed to behave as expected.
+  const isCypressRetryTimeout = /timed out retrying after \d+ms/.test(errorMessage);
+  const isCypressCommandFailure = /cy\.\w+\(\)\s+(failed|timed out)/.test(errorMessage);
+  if (isCypressRetryTimeout || isCypressCommandFailure) {
+    return true;
+  }
+
   // For timeout errors without expect, treat as invalid
   if (errorMessage.includes('timeout')) {
     return false;

--- a/qase-javascript-commons/test/utils/test-status-utils.test.ts
+++ b/qase-javascript-commons/test/utils/test-status-utils.test.ts
@@ -125,6 +125,54 @@ describe('determineTestStatus', () => {
     });
   });
 
+  describe('when Cypress-specific failure', () => {
+    it('should return failed for cy.click() on non-interactable element (0x0 dimensions)', () => {
+      const error = new Error(
+        'Timed out retrying after 4050ms: cy.click() failed because this element is not visible:\n' +
+        '<button>Submit</button>\n' +
+        'This element <button> is not visible because it has an effective width and height of: 0 x 0 pixels.'
+      );
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for cy.wait() on intercepted route that never fires', () => {
+      const error = new Error(
+        "Timed out retrying after 4000ms: cy.wait() timed out waiting 4000ms for the 1st request to the route: 'myRoute'. No request ever occurred."
+      );
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for Cypress retry-ability prefix with Expected...but never found', () => {
+      const error = new Error(
+        "Timed out retrying after 4000ms: Expected to find element: '.foo', but never found it."
+      );
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for Cypress .should() assertion timeout', () => {
+      const error = new Error(
+        "Timed out retrying after 4000ms: expected '<div>' to be visible"
+      );
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should still return invalid for cy.request() to unreachable server (real infrastructure failure)', () => {
+      const error = new Error(
+        'cy.request() failed trying to load:\n\n' +
+        'https://unreachable.example.com\n\n' +
+        'We attempted to make an http request to this URL but the request failed without a response.\n\n' +
+        'We received this error at the network level:\n\n' +
+        '  > Error: connect ECONNREFUSED 127.0.0.1:8080'
+      );
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.invalid);
+    });
+  });
+
   describe('when non-assertion error', () => {
     it('should return invalid for network error', () => {
       const error = new Error('Network request failed');


### PR DESCRIPTION
## Summary

Fixes Cypress test failures being reported as `invalid` instead of `failed` when they're genuine application issues (e.g. a non-interactable element, an intercepted route that never fires).

**Root cause** — `test-status-utils.ts` was designed around Jest/Playwright assertion language (`expect(x).toBe(y)`). Cypress uses a different vocabulary:

- Retry-ability prefix: `Timed out retrying after 4050ms: cy.click() failed because...`
- Command failures: `cy.wait() timed out waiting 4000ms for the 1st request...`

Neither contains the word `expect`, so genuine UI/command failures were falling through to the `if (errorMessage.includes('timeout')) return false;` catch-all and being marked as `invalid`.

**Fix** — detect Cypress' unique signatures after the infrastructure-marker check:

```ts
const isCypressRetryTimeout = /timed out retrying after \d+ms/.test(errorMessage);
const isCypressCommandFailure = /cy\.\w+\(\)\s+(failed|timed out)/.test(errorMessage);
if (isCypressRetryTimeout || isCypressCommandFailure) {
  return true;
}
```

The order matters: `cy.request()` to an unreachable host carries `network`/`connection`/`ECONNREFUSED` markers and is still caught by the existing `hasNonAssertionPattern` branch first → stays `invalid` (as it should — that's a real infrastructure failure).

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| `cy.click()` on 0x0 element | invalid | **failed** |
| `cy.wait()` on route that never fires | invalid | **failed** |
| `cy.request()` to unreachable server (ECONNREFUSED) | invalid | invalid (unchanged) |
| Cypress `.should()` assertion timeout | failed | failed (unchanged) |
| Jest/Playwright `expect().toBe()` timeout | failed | failed (unchanged) |
| Jest bare `Timeout of 5000ms exceeded` | invalid | invalid (unchanged) |

Reference: reported against [public run](https://app.qase.io/public/report/35d3787eeccf5543f47e1e76571a26ec044a8f68) using `cypress-demo/cypress/Troubleshooting/troubleshooting.cy.js`.

Bumps `qase-javascript-commons` to 2.6.1.

## Test plan

- [x] Added 5 new test cases in `test-status-utils.test.ts` reproducing Tests 1/2/3 from the bug report plus two regression cases (`.should()` timeout, `Expected...but never found`).
- [x] `npm test` in `qase-javascript-commons` — 324 tests pass.
- [x] `npm test` in `qase-cypress` — 50 tests pass.
- [x] `npm run lint` — no new errors.
- [ ] Manual verification in the cypress-demo repo after release.