### PR TITLE
fix: handle Cypress browser stack traces in failure classification

### DIFF
--- a/qase-javascript-commons/src/utils/test-status-utils.ts
+++ b/qase-javascript-commons/src/utils/test-status-utils.ts
@@ -88,6 +88,12 @@ function isAssertionError(error: Error, originalStatus: string): boolean {
     errorMessage.includes(pattern) || errorStack.includes(pattern)
   );
 
+  // Cypress-specific failure patterns (computed early — needed in multiple branches).
+  // "Timed out retrying after Nms" is Cypress' retry-ability prefix for DOM commands.
+  // "cy.<cmd>() failed" / "cy.<cmd>() timed out" is Cypress' command failure syntax.
+  const isCypressRetryTimeout = /timed out retrying after \d+ms/.test(errorMessage);
+  const isCypressCommandFailure = /cy\.\w+\(\)\s+(failed|timed out)/.test(errorMessage);
+
   if (hasNonAssertionPattern) {
     const hasAssertionContext = assertionPatterns.some(pattern =>
       errorMessage.includes(pattern) || errorStack.includes(pattern)
@@ -99,21 +105,26 @@ function isAssertionError(error: Error, originalStatus: string): boolean {
     if (isRunnerFailed && hasAssertionContext && !isSyntaxError) {
       return true;
     }
+
+    // Cypress override: Cypress stack traces contain browser URLs
+    // (https://localhost/__cypress/runner/...) which false-positive on the "http"
+    // pattern above. When the error MESSAGE itself has a Cypress retry-ability
+    // prefix or command failure, and the message doesn't contain a real
+    // infrastructure marker (network, connection, etc.), this is a genuine
+    // application failure, not an environment issue.
+    if ((isCypressRetryTimeout || isCypressCommandFailure) && isRunnerFailed) {
+      const hasMessageInfraMarker = nonAssertionPatternsWithoutTimeout.some(pattern =>
+        errorMessage.includes(pattern)
+      );
+      if (!hasMessageInfraMarker) {
+        return true;
+      }
+    }
+
     return false;
   }
 
-  // Cypress-specific failure detection.
-  // Cypress uses retry-ability and command-based error syntax that don't contain
-  // the word "expect" (unlike Jest/Playwright assertions). Without this branch,
-  // genuine UI/command failures fall through to the "timeout → invalid" catch-all
-  // below and get misclassified as environment errors.
-  //
-  // Why this order: the hasNonAssertionPattern check above already returned
-  // invalid for cy.request() failures (which contain "network"/"connection"),
-  // so reaching this point with a Cypress signature means the error has no
-  // infrastructure markers — the test app failed to behave as expected.
-  const isCypressRetryTimeout = /timed out retrying after \d+ms/.test(errorMessage);
-  const isCypressCommandFailure = /cy\.\w+\(\)\s+(failed|timed out)/.test(errorMessage);
+  // Cypress failure without any non-assertion pattern at all (clean stack trace)
   if (isCypressRetryTimeout || isCypressCommandFailure) {
     return true;
   }

--- a/qase-javascript-commons/test/utils/test-status-utils.test.ts
+++ b/qase-javascript-commons/test/utils/test-status-utils.test.ts
@@ -126,20 +126,37 @@ describe('determineTestStatus', () => {
   });
 
   describe('when Cypress-specific failure', () => {
+    // Helper: simulate real Cypress stack trace with browser URLs
+    const cypressStack = (msg: string) =>
+      `CypressError: ${msg}\n` +
+      '    at cypressErr (https://localhost:3000/__cypress/runner/cypress_runner.js:180818:16)\n' +
+      '    at Context.runnable.fn (https://localhost:3000/__cypress/runner/cypress_runner.js:190234:20)';
+
     it('should return failed for cy.click() on non-interactable element (0x0 dimensions)', () => {
       const error = new Error(
         'Timed out retrying after 4050ms: cy.click() failed because this element is not visible:\n' +
         '<button>Submit</button>\n' +
         'This element <button> is not visible because it has an effective width and height of: 0 x 0 pixels.'
       );
+      error.stack = cypressStack(error.message);
       const result = determineTestStatus(error, 'failed');
       expect(result).toBe(TestStatusEnum.failed);
     });
 
     it('should return failed for cy.wait() on intercepted route that never fires', () => {
       const error = new Error(
-        "Timed out retrying after 4000ms: cy.wait() timed out waiting 4000ms for the 1st request to the route: 'myRoute'. No request ever occurred."
+        "cy.wait() timed out waiting 5000ms for the 1st request to the route: 'myRoute'. No request ever occurred."
       );
+      error.stack = cypressStack(error.message);
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for cy.click() with retry-ability prefix and browser stack trace', () => {
+      const error = new Error(
+        'Timed out retrying after 4000ms: cy.click() failed because this element is detached from the DOM.'
+      );
+      error.stack = cypressStack(error.message);
       const result = determineTestStatus(error, 'failed');
       expect(result).toBe(TestStatusEnum.failed);
     });
@@ -148,6 +165,7 @@ describe('determineTestStatus', () => {
       const error = new Error(
         "Timed out retrying after 4000ms: Expected to find element: '.foo', but never found it."
       );
+      error.stack = cypressStack(error.message);
       const result = determineTestStatus(error, 'failed');
       expect(result).toBe(TestStatusEnum.failed);
     });
@@ -156,6 +174,7 @@ describe('determineTestStatus', () => {
       const error = new Error(
         "Timed out retrying after 4000ms: expected '<div>' to be visible"
       );
+      error.stack = cypressStack(error.message);
       const result = determineTestStatus(error, 'failed');
       expect(result).toBe(TestStatusEnum.failed);
     });
@@ -168,6 +187,7 @@ describe('determineTestStatus', () => {
         'We received this error at the network level:\n\n' +
         '  > Error: connect ECONNREFUSED 127.0.0.1:8080'
       );
+      error.stack = cypressStack(error.message);
       const result = determineTestStatus(error, 'failed');
       expect(result).toBe(TestStatusEnum.invalid);
     });


### PR DESCRIPTION
## Summary

Follow-up to #930. The previous fix added Cypress-specific detection patterns but placed them **after** the `hasNonAssertionPattern` block. In real Cypress environments, error stack traces contain browser URLs (`https://localhost/__cypress/runner/...`) which false-positive on the `"http"` pattern in `nonAssertionPatterns`, causing the function to return `invalid` before the Cypress check was ever reached.

**Root cause**: `hasNonAssertionPattern` checks both `errorMessage` and `errorStack`. Cypress stack traces always contain HTTP URLs → `"http"` matches → block enters → no assertion context found → returns `false` (invalid).

**Fix**: Move the Cypress pattern detection (retry-ability prefix + `cy.<cmd>()` failures) **inside** the `hasNonAssertionPattern` block with a message-level infrastructure guard:

```ts
if ((isCypressRetryTimeout || isCypressCommandFailure) && isRunnerFailed) {
  const hasMessageInfraMarker = nonAssertionPatternsWithoutTimeout.some(pattern =>
    errorMessage.includes(pattern)
  );
  if (!hasMessageInfraMarker) {
    return true; // genuine app failure, not infra
  }
}
```

This distinguishes:
- `cy.click()` failure with `http` only in stack trace URL → **failed** (app bug)
- `cy.request()` failure with `network`/`http` in the error message itself → **invalid** (infra)

## Behavior matrix (verified with realistic Cypress browser stack traces)

| Scenario | Stack has http URL | Message has infra marker | Result |
|---|---|---|---|
| `cy.click()` on 0x0 element | yes | no | **failed** |
| `cy.wait()` on route that never fires | yes | no | **failed** |
| `cy.click()` detached DOM element | yes | no | **failed** |
| Cypress `.should()` assertion timeout | yes | no | **failed** |
| `cy.request()` ECONNREFUSED | yes | yes (network, http, connection) | **invalid** |
| Jest/Playwright (unchanged) | no | varies | unchanged |

## Test plan

- [x] All Cypress tests now use realistic browser stack traces (`https://localhost:3000/__cypress/runner/...`)
- [x] Added test for `cy.click()` on detached DOM element with browser stack
- [x] Fixed `cy.wait()` test to use actual Cypress message format (without retry prefix)
- [x] 325 tests in commons + 50 in cypress — all pass