### PR TITLE
fix: trust Cypress retry-ability prefix for failure classification

### DIFF
--- a/qase-javascript-commons/src/utils/test-status-utils.ts
+++ b/qase-javascript-commons/src/utils/test-status-utils.ts
@@ -88,11 +88,11 @@ function isAssertionError(error: Error, originalStatus: string): boolean {
     errorMessage.includes(pattern) || errorStack.includes(pattern)
   );
 
-  // Cypress-specific failure patterns (computed early — needed in multiple branches).
-  // "Timed out retrying after Nms" is Cypress' retry-ability prefix for DOM commands.
-  // "cy.<cmd>() failed" / "cy.<cmd>() timed out" is Cypress' command failure syntax.
+  // Cypress retry-ability prefix: "Timed out retrying after Nms:" is added by
+  // Cypress' retry mechanism exclusively for DOM-interacting commands (cy.get,
+  // cy.click, cy.should, cy.wait with aliases). It never appears in infra
+  // failures (cy.request, cy.task). This is the most reliable Cypress signal.
   const isCypressRetryTimeout = /timed out retrying after \d+ms/.test(errorMessage);
-  const isCypressCommandFailure = /cy\.\w+\(\)\s+(failed|timed out)/.test(errorMessage);
 
   if (hasNonAssertionPattern) {
     const hasAssertionContext = assertionPatterns.some(pattern =>
@@ -106,26 +106,21 @@ function isAssertionError(error: Error, originalStatus: string): boolean {
       return true;
     }
 
-    // Cypress override: Cypress stack traces contain browser URLs
-    // (https://localhost/__cypress/runner/...) which false-positive on the "http"
-    // pattern above. When the error MESSAGE itself has a Cypress retry-ability
-    // prefix or command failure, and the message doesn't contain a real
-    // infrastructure marker (network, connection, etc.), this is a genuine
-    // application failure, not an environment issue.
-    if ((isCypressRetryTimeout || isCypressCommandFailure) && isRunnerFailed) {
-      const hasMessageInfraMarker = nonAssertionPatternsWithoutTimeout.some(pattern =>
-        errorMessage.includes(pattern)
-      );
-      if (!hasMessageInfraMarker) {
-        return true;
-      }
+    // Cypress override: the retry-ability prefix is a strong signal that the
+    // test was actively interacting with the application via a retryable command.
+    // Cypress errors false-positive on "http" because (a) browser stack traces
+    // contain URLs and (b) all error messages include docs links
+    // (https://on.cypress.io/...). The retry prefix itself is never
+    // infrastructure, so we trust it unconditionally.
+    if (isCypressRetryTimeout && isRunnerFailed) {
+      return true;
     }
 
     return false;
   }
 
-  // Cypress failure without any non-assertion pattern at all (clean stack trace)
-  if (isCypressRetryTimeout || isCypressCommandFailure) {
+  // Cypress failure without any non-assertion pattern (clean stack trace)
+  if (isCypressRetryTimeout) {
     return true;
   }
 

--- a/qase-javascript-commons/test/utils/test-status-utils.test.ts
+++ b/qase-javascript-commons/test/utils/test-status-utils.test.ts
@@ -132,11 +132,16 @@ describe('determineTestStatus', () => {
       '    at cypressErr (https://localhost:3000/__cypress/runner/cypress_runner.js:180818:16)\n' +
       '    at Context.runnable.fn (https://localhost:3000/__cypress/runner/cypress_runner.js:190234:20)';
 
+    // Real Cypress messages use backticks around commands and include docs URLs.
+    // These tests use actual Cypress error message format captured from Cypress 15.x.
+
     it('should return failed for cy.click() on non-interactable element (0x0 dimensions)', () => {
       const error = new Error(
-        'Timed out retrying after 4050ms: cy.click() failed because this element is not visible:\n' +
-        '<button>Submit</button>\n' +
-        'This element <button> is not visible because it has an effective width and height of: 0 x 0 pixels.'
+        'Timed out retrying after 4000ms: `cy.click()` failed because this element is not visible:\n\n' +
+        '`<button id="zero-size" style="width:0;height:0;padding:0;border:0;overflow:hidden;">Hidden</button>`\n\n' +
+        'This element `<button#zero-size>` is not visible because it has an effective width and height of: `0 x 0` pixels.\n\n' +
+        'Fix this problem, or use `{force: true}` to disable error checking.\n\n' +
+        'https://on.cypress.io/element-cannot-be-interacted-with'
       );
       error.stack = cypressStack(error.message);
       const result = determineTestStatus(error, 'failed');
@@ -145,16 +150,18 @@ describe('determineTestStatus', () => {
 
     it('should return failed for cy.wait() on intercepted route that never fires', () => {
       const error = new Error(
-        "cy.wait() timed out waiting 5000ms for the 1st request to the route: 'myRoute'. No request ever occurred."
+        'Timed out retrying after 4000ms: `cy.wait()` timed out waiting `4000ms` for the 1st request to the route: `neverFires`. No request ever occurred.\n\n' +
+        'https://on.cypress.io/wait'
       );
       error.stack = cypressStack(error.message);
       const result = determineTestStatus(error, 'failed');
       expect(result).toBe(TestStatusEnum.failed);
     });
 
-    it('should return failed for cy.click() with retry-ability prefix and browser stack trace', () => {
+    it('should return failed for cy.click() on detached DOM element', () => {
       const error = new Error(
-        'Timed out retrying after 4000ms: cy.click() failed because this element is detached from the DOM.'
+        'Timed out retrying after 4000ms: `cy.click()` failed because this element is detached from the DOM.\n\n' +
+        'https://on.cypress.io/element-has-detached-from-dom'
       );
       error.stack = cypressStack(error.message);
       const result = determineTestStatus(error, 'failed');
@@ -163,7 +170,8 @@ describe('determineTestStatus', () => {
 
     it('should return failed for Cypress retry-ability prefix with Expected...but never found', () => {
       const error = new Error(
-        "Timed out retrying after 4000ms: Expected to find element: '.foo', but never found it."
+        "Timed out retrying after 4000ms: Expected to find element: '.foo', but never found it.\n\n" +
+        'https://on.cypress.io/element-not-found'
       );
       error.stack = cypressStack(error.message);
       const result = determineTestStatus(error, 'failed');
@@ -172,20 +180,36 @@ describe('determineTestStatus', () => {
 
     it('should return failed for Cypress .should() assertion timeout', () => {
       const error = new Error(
-        "Timed out retrying after 4000ms: expected '<div>' to be visible"
+        "Timed out retrying after 4000ms: expected '<div>' to be visible\n\n" +
+        'https://on.cypress.io/assertions'
       );
       error.stack = cypressStack(error.message);
       const result = determineTestStatus(error, 'failed');
       expect(result).toBe(TestStatusEnum.failed);
     });
 
-    it('should still return invalid for cy.request() to unreachable server (real infrastructure failure)', () => {
+    it('should still return invalid for cy.request() timeout (real infrastructure failure)', () => {
       const error = new Error(
-        'cy.request() failed trying to load:\n\n' +
+        '`cy.request()` timed out waiting `4000ms` for a response from your server.\n\n' +
+        'The request we sent was:\n\n' +
+        'Method: GET\n' +
+        'URL: http://192.0.2.1:1/\n\n' +
+        'No response was received within the timeout.\n\n' +
+        'https://on.cypress.io/request'
+      );
+      error.stack = cypressStack(error.message);
+      const result = determineTestStatus(error, 'failed');
+      expect(result).toBe(TestStatusEnum.invalid);
+    });
+
+    it('should still return invalid for cy.request() with ECONNREFUSED', () => {
+      const error = new Error(
+        '`cy.request()` failed trying to load:\n\n' +
         'https://unreachable.example.com\n\n' +
         'We attempted to make an http request to this URL but the request failed without a response.\n\n' +
         'We received this error at the network level:\n\n' +
-        '  > Error: connect ECONNREFUSED 127.0.0.1:8080'
+        '  > Error: connect ECONNREFUSED 127.0.0.1:8080\n\n' +
+        'https://on.cypress.io/request'
       );
       error.stack = cypressStack(error.message);
       const result = determineTestStatus(error, 'failed');


### PR DESCRIPTION
## Summary

Follow-up to #930 and #931. Previous fixes were bypassed in real Cypress environments because the `"http"` non-assertion pattern matched:
1. **Browser URLs in stack traces**: `https://localhost/__cypress/runner/cypress_runner.js:180818:16`
2. **Docs links in error messages**: `https://on.cypress.io/element-cannot-be-interacted-with`

Both caused `hasNonAssertionPattern` to fire, short-circuiting before Cypress-specific checks.

### Root insight

Cypress' **retry-ability prefix** `"Timed out retrying after Nms:"` is the most reliable signal:
- Present in ALL retryable command failures: `cy.get()`, `cy.click()`, `cy.should()`, `cy.wait('@alias')`
- **Never** present in infrastructure failures: `cy.request()`, `cy.task()`
- Added exclusively by Cypress' retry mechanism for DOM-interacting commands

### Fix

Trust the retry prefix unconditionally inside `hasNonAssertionPattern`:

```ts
if (isCypressRetryTimeout && isRunnerFailed) {
  return true;
}
```

No fragile infra-marker exclusion lists needed.

### E2E Verification (Cypress 15.x against saucedemo.com)

```
[INFO] qase: Test 1 - cy.click() on 0x0 element (expected: failed) failed      ✅
[INFO] qase: Test 2 - cy.request() to unreachable server (expected: invalid) invalid ✅
[INFO] qase: Test 3 - cy.wait() on intercepted route (expected: failed) failed  ✅
```

### Tests updated to match real Cypress format

All test messages now use actual Cypress 15.x format:
- Backticks around commands: `` `cy.click()` ``
- Docs URLs in messages: `https://on.cypress.io/...`
- Browser URLs in stack traces: `https://localhost:3000/__cypress/runner/...`

326 tests in commons + 50 in cypress — all pass.

## Test plan

- [x] Unit tests with realistic Cypress error format (37 status-utils tests pass)
- [x] Full commons test suite (326 pass)
- [x] Full cypress reporter test suite (50 pass)
- [x] E2E verification with real Cypress 15.x against saucedemo.com
- [ ] Verification against cypress-demo repo (syahidah-215473271062034 branch)