### PR TITLE
chore: bump qase-javascript-commons to 2.6.2

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.6.2
+
+## Bug fixes
+
+- Fixed Cypress failure classification in real browser environments. Cypress errors false-positive on the `"http"` non-assertion pattern because (a) browser stack traces contain URLs like `https://localhost/__cypress/runner/...` and (b) all error messages include docs links like `https://on.cypress.io/...`. The classifier now unconditionally trusts Cypress' retry-ability prefix (`Timed out retrying after Nms:`) as a genuine test failure signal, since this prefix is exclusive to DOM-interacting commands and never appears in infrastructure failures (`cy.request()`, `cy.task()`).
+
 # qase-javascript-commons@2.6.1
 
 ## Bug fixes

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
2.6.1 was already published to npm before the browser stack trace fix (#932) landed. Bump to 2.6.2 so the complete Cypress classification fix is available via `npm update`.