### PR TITLE
refactor(commons): decompose QaseReporter, dedupe utils, extract ReportSerializer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30559,7 +30559,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.6.0",
+      "version": "2.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,50 @@
+# qase-javascript-commons@2.6.3
+
+## Internal refactoring
+
+The `QaseReporter` God class (~680 lines) has been split into focused components,
+and spec-compliant report serialization has been extracted into its own module.
+**The public API is unchanged** — all exports, method signatures, option shapes,
+environment variables, and the JSON report format are preserved verbatim. The
+report format is additionally verified in CI against the official Qase report
+schemas via `reporters-validator`.
+
+New internal components:
+
+- `src/qase/options-resolver.ts` — env + config composition, state restore,
+  `withState` detection.
+- `src/qase/reporter-factory.ts` — mode-based reporter instantiation with
+  option validation (replaces the inline `switch` that previously lived inside
+  `QaseReporter.createReporter`).
+- `src/qase/status-processor.ts` — status mapping + filtering.
+- `src/reporters/shared/fallback-coordinator.ts` — encapsulates the
+  upstream → fallback → disabled cascade that was previously repeated in five
+  lifecycle methods of `QaseReporter`.
+- `src/utils/token-masker.ts` — reusable `maskToken` / `sanitizeOptionsForLog`.
+- `src/formatter/report-serializer.ts` — pure spec-compliant serializer
+  (RSLT-01/02, STEP-01/02/03 rules), lifted out of `ReportReporter`.
+
+Shared utilities:
+
+- `DEFAULT_BATCH_SIZE` constant and `resolveTestOpsBaseUrl` helper now live
+  in `src/reporters/shared/` (previously duplicated between `TestOpsReporter`
+  and `TestOpsMultiReporter`).
+
+## Bug fixes
+
+- **Fallback activation on upstream creation failure.** Previously, if the
+  upstream reporter failed to construct (for example, misconfigured TestOps
+  client) and a `fallback` mode was configured, the reporter would disable
+  itself instead of switching to the fallback. Now the fallback is correctly
+  activated. **Note for users:** pipelines with a broken upstream
+  configuration and a `report` fallback will now start producing local report
+  artifacts where previously nothing was produced.
+- `publish()` no longer double-calls both reporters when already in fallback
+  mode — it now runs exactly one reporter.
+- `StateManager.setMode(off)` on fallback failure now respects the
+  `withState` flag, so frameworks that don't use persistent state no longer
+  write state during shutdown.
+
 # qase-javascript-commons@2.6.2
 
 ## Bug fixes

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/formatter/index.ts
+++ b/qase-javascript-commons/src/formatter/index.ts
@@ -1,3 +1,4 @@
 export { type FormatterInterface } from './formatter-interface';
 export { JsonFormatter } from './json-formatter';
 export { JsonpFormatter } from './jsonp-formatter';
+export { ReportSerializer, type ReportSerializerInterface } from './report-serializer';

--- a/qase-javascript-commons/src/formatter/report-serializer.ts
+++ b/qase-javascript-commons/src/formatter/report-serializer.ts
@@ -1,0 +1,107 @@
+import { Attachment, TestResultType, TestStepType, StepType } from '../models';
+import { StepTextData, StepGherkinData } from '../models/step-data';
+
+export interface ReportSerializerInterface {
+  serializeResult(result: TestResultType): Record<string, unknown>;
+  serializeStep(step: TestStepType): Record<string, unknown>;
+  serializeAttachment(att: Attachment): Record<string, unknown>;
+}
+
+/**
+ * Transforms internal TestResultType / TestStepType into Qase Report
+ * spec-compliant JSON (RSLT-01/02, STEP-01/02/03 rules).
+ *
+ * Pure: no I/O, no logger, no state. Suitable for golden-testing.
+ */
+export class ReportSerializer implements ReportSerializerInterface {
+  serializeResult(result: TestResultType): Record<string, unknown> {
+    const testopsIds = this.transformTestopsIds(result.testops_id);
+    const paramGroups = this.transformGroupParams(result.group_params);
+
+    return {
+      id: result.id,
+      title: result.title,
+      signature: result.signature,
+      execution: result.execution,
+      fields: result.fields,
+      attachments: result.attachments.map((a) => this.serializeAttachment(a)),
+      steps: result.steps.map((s) => this.serializeStep(s)),
+      params: result.params,
+      param_groups: paramGroups,
+      testops_ids: testopsIds,
+      relations: result.relations,
+      muted: result.muted,
+      message: result.message,
+      tags: result.tags,
+    };
+  }
+
+  serializeStep(step: TestStepType): Record<string, unknown> {
+    const data = this.serializeStepData(step);
+    const attachments = step.attachments.map((a) => this.serializeAttachment(a));
+
+    return {
+      id: step.id,
+      step_type: step.step_type,
+      data,
+      parent_id: step.parent_id,
+      execution: { ...step.execution, attachments },
+      steps: step.steps.map((s) => this.serializeStep(s)),
+    };
+  }
+
+  serializeAttachment(att: Attachment): Record<string, unknown> {
+    return {
+      id: att.id,
+      file_name: att.file_name,
+      mime_type: att.mime_type,
+      file_path: att.file_path,
+    };
+  }
+
+  private transformTestopsIds(testopsId: unknown): number[] | null {
+    if (testopsId === null) return null;
+    return Array.isArray(testopsId)
+      ? (testopsId as number[])
+      : [testopsId as number];
+  }
+
+  private transformGroupParams(
+    groupParams: Record<string, string>,
+  ): string[][] {
+    const keys = Object.keys(groupParams);
+    return keys.length === 0 ? [] : [keys];
+  }
+
+  private serializeStepData(step: TestStepType): Record<string, unknown> {
+    const data = { ...step.data } as unknown as Record<string, unknown>;
+
+    if (step.step_type === StepType.TEXT && 'data' in data) {
+      const textData = data as unknown as StepTextData;
+      return {
+        action: textData.action,
+        expected_result: textData.expected_result,
+        input_data: textData.data,
+      };
+    }
+
+    if (
+      step.step_type === StepType.GHERKIN &&
+      'keyword' in data &&
+      'name' in data
+    ) {
+      const gherkinData = data as unknown as StepGherkinData;
+      return {
+        action: `${gherkinData.keyword} ${gherkinData.name}`,
+        expected_result: null,
+        input_data: null,
+      };
+    }
+
+    if (step.step_type === StepType.REQUEST && 'request_method' in data) {
+      return data;
+    }
+
+    return data;
+  }
+}

--- a/qase-javascript-commons/src/qase.ts
+++ b/qase-javascript-commons/src/qase.ts
@@ -1,33 +1,20 @@
-import envSchema from 'env-schema';
 import chalk from 'chalk';
 
-import {
-  InternalReporterInterface,
-  TestOpsReporter,
-  TestOpsMultiReporter,
-  ReportReporter,
-} from './reporters';
-import { composeOptions, ModeEnum, OptionsType } from './options';
-import {
-  EnvApiEnum,
-  EnvEnum,
-  EnvRunEnum,
-  EnvTestOpsEnum,
-  envToConfig,
-  envValidationSchema,
-} from './env';
+import { InternalReporterInterface } from './reporters';
+import { ModeEnum, OptionsType } from './options';
 import { TestStatusEnum, TestResultType, Attachment } from './models';
-import { DriverEnum, FsWriter } from './writer';
+import { ConfigType } from './config';
 
 import { DisabledException } from './utils/disabled-exception';
 import { Logger, LoggerInterface } from './utils/logger';
-import { StateManager, StateModel } from './state/state';
-import { ConfigType } from './config';
 import { getHostInfo } from './utils/hostData';
-import { ClientV2 } from './client/clientV2';
-import { TestOpsOptionsType } from './models/config/TestOpsOptionsType';
-import { applyStatusMapping } from './utils/status-mapping-utils';
-import { HostData } from './models/host-data';
+import { sanitizeOptionsForLog } from './utils/token-masker';
+import { StateManager, StateModel } from './state/state';
+
+import { OptionsResolver, ResolvedOptions } from './qase/options-resolver';
+import { ReporterFactory } from './qase/reporter-factory';
+import { StatusProcessor } from './qase/status-processor';
+import { FallbackCoordinator } from './reporters/shared/fallback-coordinator';
 
 /**
  * @type {Record<TestStatusEnum, (test: TestResultType) => string>}
@@ -63,301 +50,225 @@ export interface ReporterInterface {
 
 /**
  * @class QaseReporter
- * @implements AbstractReporter
+ *
+ * Thin orchestrator: delegates to OptionsResolver, ReporterFactory,
+ * StatusProcessor, and FallbackCoordinator. Public API is preserved.
  */
 export class QaseReporter implements ReporterInterface {
   private static instance: QaseReporter | null;
 
-  /**
-   * @type {InternalReporterInterface}
-   * @private
-   */
-  private readonly upstreamReporter?: InternalReporterInterface;
-
-  /**
-   * @type {InternalReporterInterface}
-   * @private
-   */
-  private readonly fallbackReporter?: InternalReporterInterface;
-
-  /**
-   * @type {boolean | undefined}
-   * @private
-   */
-  private readonly captureLogs: boolean | undefined;
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  private disabled = false;
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  private useFallback = false;
-
   private readonly logger: LoggerInterface;
+  private readonly options: ConfigType & OptionsType;
+  private readonly withState: boolean;
+  private readonly captureLogs: boolean | undefined;
+  private readonly statusProcessor: StatusProcessor;
+  private readonly fallback: FallbackCoordinator;
 
   private startTestRunOperation?: Promise<void> | undefined;
-
-  private options: ConfigType & OptionsType;
-
-  private withState: boolean;
-
-  private readonly hostData: HostData;
 
   /**
    * @param {OptionsType} options
    */
   private constructor(options: OptionsType) {
-    this.withState = this.setWithState(options);
+    const resolved = new OptionsResolver().resolve(options);
+    this.options = resolved.composed;
+    this.withState = resolved.withState;
+    this.captureLogs = resolved.composed.captureLogs;
 
-    if (this.withState) {
-      if (StateManager.isStateExists()) {
-        const state = StateManager.getState();
-        if (state.IsModeChanged && state.Mode) {
-          process.env[EnvEnum.mode] = state.Mode.toString();
+    this.logger = this.buildLogger(resolved);
+    this.logger.logDebug(
+      `Config: ${JSON.stringify(sanitizeOptionsForLog(resolved.composed))}`,
+    );
+
+    const hostData = getHostInfo(options.frameworkPackage, options.reporterName);
+    this.logger.logDebug(`Host data: ${JSON.stringify(hostData)}`);
+
+    const factory = new ReporterFactory(this.logger, hostData);
+    const { upstream, fallback, disabled, useFallbackFromStart } =
+      this.buildReporters(factory, resolved);
+
+    this.statusProcessor = new StatusProcessor(
+      this.logger,
+      resolved.composed.statusMapping,
+      resolved.composed.testops?.statusFilter as string[] | undefined,
+    );
+
+    this.fallback = new FallbackCoordinator(this.logger, upstream, fallback, {
+      onFallbackActivated: () => {
+        if (this.withState) {
+          StateManager.setMode(resolved.composed.fallback as ModeEnum);
         }
-
-        if (state.RunId) {
-          process.env[EnvRunEnum.id] = state.RunId.toString();
+      },
+      onDisabled: () => {
+        if (this.withState) {
+          StateManager.setMode(ModeEnum.off);
         }
-      }
+      },
+    });
+
+    if (disabled) {
+      this.fallback.setDisabled(true);
+    }
+    if (useFallbackFromStart) {
+      this.fallback.setUseFallback(true);
     }
 
-    const env = envToConfig(envSchema({ schema: envValidationSchema }));
-    const composedOptions = composeOptions(options, env);
-    this.options = composedOptions;
+    this.persistInitialState(resolved, disabled, useFallbackFromStart);
+  }
 
-    // Process logging options with backward compatibility
-    const loggerOptions: {
-      debug?: boolean | undefined,
-      consoleLogging?: boolean | undefined,
-      fileLogging?: boolean | undefined,
-    } = {
-      debug: composedOptions.debug,
-    };
+  private buildLogger(resolved: ResolvedOptions): LoggerInterface {
+    const opts: {
+      debug?: boolean | undefined;
+      consoleLogging?: boolean | undefined;
+      fileLogging?: boolean | undefined;
+    } = { debug: resolved.composed.debug };
 
-    if (composedOptions.logging?.console !== undefined) {
-      loggerOptions.consoleLogging = composedOptions.logging.console;
+    if (resolved.composed.logging?.console !== undefined) {
+      opts.consoleLogging = resolved.composed.logging.console;
     }
-
-    if (composedOptions.logging?.file !== undefined) {
-      loggerOptions.fileLogging = composedOptions.logging.file;
+    if (resolved.composed.logging?.file !== undefined) {
+      opts.fileLogging = resolved.composed.logging.file;
     }
+    return new Logger(opts);
+  }
 
-    this.logger = new Logger(loggerOptions);
-    this.logger.logDebug(`Config: ${JSON.stringify(this.sanitizeOptions(composedOptions))}`);
-
-    const effectiveMode = (composedOptions.mode as ModeEnum) || ModeEnum.off;
-    const effectiveFallback = (composedOptions.fallback as ModeEnum) || ModeEnum.off;
-    this.hostData = getHostInfo(options.frameworkPackage, options.reporterName);
-    this.logger.logDebug(`Host data: ${JSON.stringify(this.hostData)}`);
-
-    this.captureLogs = composedOptions.captureLogs;
+  private buildReporters(
+    factory: ReporterFactory,
+    resolved: ResolvedOptions,
+  ): {
+    upstream: InternalReporterInterface | undefined;
+    fallback: InternalReporterInterface | undefined;
+    disabled: boolean;
+    useFallbackFromStart: boolean;
+  } {
+    let upstream: InternalReporterInterface | undefined;
+    let fallbackReporter: InternalReporterInterface | undefined;
+    let disabled = false;
+    let upstreamFailed = false;
 
     try {
-      this.upstreamReporter = this.createReporter(
-        effectiveMode,
-        composedOptions,
+      upstream = factory.create(
+        resolved.effectiveMode,
+        resolved.composed,
+        this.withState,
       );
     } catch (error) {
       if (error instanceof DisabledException) {
-        this.disabled = true;
+        disabled = true;
       } else {
         this.logger.logError('Unable to create upstream reporter:', error);
-
-        if (composedOptions.fallback != undefined) {
-          this.disabled = true;
-          return;
+        if (resolved.composed.fallback === undefined) {
+          disabled = true;
+          return { upstream, fallback: fallbackReporter, disabled, useFallbackFromStart: false };
         }
-
-        this.useFallback = true;
+        upstreamFailed = true;
       }
     }
 
     try {
-      this.fallbackReporter = this.createReporter(
-        effectiveFallback,
-        composedOptions,
+      fallbackReporter = factory.create(
+        resolved.effectiveFallback,
+        resolved.composed,
+        this.withState,
       );
     } catch (error) {
       if (error instanceof DisabledException) {
-        if (this.useFallback) {
-          this.disabled = true;
-        }
+        if (upstreamFailed) disabled = true;
       } else {
         this.logger.logError('Unable to create fallback reporter:', error);
-
-        if (this.useFallback && this.upstreamReporter === undefined) {
-          this.disabled = true;
-        }
+        if (upstreamFailed && upstream === undefined) disabled = true;
       }
     }
 
-    if (this.withState) {
-      if (!StateManager.isStateExists()) {
-        const state: StateModel = {
-          RunId: undefined,
-          Mode: this.useFallback ? composedOptions.fallback as ModeEnum : composedOptions.mode as ModeEnum,
-          IsModeChanged: undefined,
-        };
+    const useFallbackFromStart = upstreamFailed && fallbackReporter !== undefined;
 
-        if (this.disabled) {
-          state.Mode = ModeEnum.off;
-        }
-
-        StateManager.setState(state);
-      }
-    }
+    return { upstream, fallback: fallbackReporter, disabled, useFallbackFromStart };
   }
 
-  async uploadAttachment(attachment: Attachment): Promise<string> {
-    if (this.disabled) {
-      return '';
+  private persistInitialState(
+    resolved: ResolvedOptions,
+    disabled: boolean,
+    useFallbackFromStart: boolean,
+  ): void {
+    if (!this.withState) return;
+    if (StateManager.isStateExists()) return;
+
+    const state: StateModel = {
+      RunId: undefined,
+      Mode: useFallbackFromStart
+        ? (resolved.composed.fallback as ModeEnum)
+        : (resolved.composed.mode as ModeEnum),
+      IsModeChanged: undefined,
+    };
+
+    if (disabled) {
+      state.Mode = ModeEnum.off;
     }
 
-    if (this.useFallback) {
-      return await this.fallbackReporter?.uploadAttachment(attachment) ?? '';
-    }
-
-    return await this.upstreamReporter?.uploadAttachment(attachment) ?? '';
+    StateManager.setState(state);
   }
 
-  getResults(): TestResultType[] {
-    if (this.disabled) {
-      return [];
+  public static getInstance(options: OptionsType): QaseReporter {
+    if (!QaseReporter.instance) {
+      QaseReporter.instance = new QaseReporter(options);
     }
-
-    if (this.useFallback) {
-      return this.fallbackReporter?.getTestResults() ?? [];
-    }
-
-    return this.upstreamReporter?.getTestResults() ?? [];
+    return QaseReporter.instance;
   }
 
-  setTestResults(results: TestResultType[]): void {
-    if (this.disabled) {
-      return;
-    }
-
-    if (this.useFallback) {
-      this.fallbackReporter?.setTestResults(results);
-    } else {
-      this.upstreamReporter?.setTestResults(results);
-    }
+  public getStatusMapping(): Record<string, string> | undefined {
+    return this.options.statusMapping;
   }
 
-  async sendResults(): Promise<void> {
-    if (this.disabled) {
-      return;
-    }
-
-    try {
-      await this.upstreamReporter?.sendResults();
-    } catch (error) {
-      this.logger.logError('Unable to send the results to the upstream reporter:', error);
-
-      if (this.fallbackReporter == undefined) {
-        if (this.withState) {
-          StateManager.setMode(ModeEnum.off);
-        }
-        return;
-      }
-
-      if (!this.useFallback) {
-        this.fallbackReporter.setTestResults(this.upstreamReporter?.getTestResults() ?? []);
-        this.useFallback = true;
-      }
-
-      try {
-        await this.fallbackReporter.sendResults();
-        if (this.withState) {
-          StateManager.setMode(this.options.fallback as ModeEnum);
-        }
-      } catch (error) {
-        this.logger.logError('Unable to send the results to the fallback reporter:', error);
-        if (this.withState) {
-          StateManager.setMode(ModeEnum.off);
-        }
-      }
-    }
+  public async uploadAttachment(attachment: Attachment): Promise<string> {
+    const result = await this.fallback.run(
+      (r) => r.uploadAttachment(attachment),
+      'upload attachment',
+    );
+    return result ?? '';
   }
 
-  async complete(): Promise<void> {
-    if (this.withState) {
-      StateManager.clearState();
-    }
-    if (this.disabled) {
-      return;
-    }
-
-    try {
-      await this.upstreamReporter?.complete();
-    } catch (error) {
-      this.logger.logError('Unable to complete the run in the upstream reporter:', error);
-
-      if (this.fallbackReporter == undefined) {
-        return;
-      }
-
-      if (!this.useFallback) {
-        this.fallbackReporter.setTestResults(this.upstreamReporter?.getTestResults() ?? []);
-        this.useFallback = true;
-      }
-
-      try {
-        await this.fallbackReporter.complete();
-      } catch (error) {
-        this.logger.logError('Unable to complete the run in the fallback reporter:', error);
-      }
-    }
+  public getResults(): TestResultType[] {
+    if (this.fallback.isDisabled()) return [];
+    const active = this.fallback.isUsingFallback()
+      ? this.fallback.getFallback()
+      : this.fallback.getUpstream();
+    return active?.getTestResults() ?? [];
   }
 
-  /**
-   * @returns {void}
-   */
+  public setTestResults(results: TestResultType[]): void {
+    if (this.fallback.isDisabled()) return;
+    const active = this.fallback.isUsingFallback()
+      ? this.fallback.getFallback()
+      : this.fallback.getUpstream();
+    active?.setTestResults(results);
+  }
+
+  public async addTestResult(result: TestResultType): Promise<void> {
+    if (this.fallback.isDisabled()) return;
+
+    const processed = this.statusProcessor.process(result);
+    if (!processed) return;
+
+    await this.startTestRunOperation;
+    this.logger.log(resultLogMap[processed.execution.status](processed));
+    await this.fallback.run(
+      (r) => r.addTestResult(processed),
+      'add the result',
+    );
+  }
+
   public startTestRun(): void {
-    if (this.withState) {
-      StateManager.clearState();
-    }
+    if (this.withState) StateManager.clearState();
+    this.fallback.reset();
+    this.logger.logDebug('Starting test run');
 
-    this.disabled = false;
-    this.useFallback = false;
-
-    if (!this.disabled) {
-
-      this.logger.logDebug('Starting test run');
-
-      try {
-        this.startTestRunOperation = this.upstreamReporter?.startTestRun();
-      } catch (error) {
-        this.logger.logError('Unable to start test run in the upstream reporter: ', error);
-
-        if (this.fallbackReporter == undefined) {
-          this.disabled = true;
-          if (this.withState) {
-            StateManager.setMode(ModeEnum.off);
-          }
-          return;
-        }
-
-        try {
-          this.startTestRunOperation = this.fallbackReporter.startTestRun();
-          if (this.withState) {
-            StateManager.setMode(this.options.fallback as ModeEnum);
-          }
-        } catch (error) {
-          this.logger.logError('Unable to start test run in the fallback reporter: ', error);
-          this.disabled = true;
-          if (this.withState) {
-            StateManager.setMode(ModeEnum.off);
-          }
-        }
-      }
-    }
+    const runOp = this.fallback.run(
+      async (r) => {
+        await r.startTestRun();
+      },
+      'start test run',
+    );
+    this.startTestRunOperation = runOp.then(() => undefined);
   }
 
   public async startTestRunAsync(): Promise<void> {
@@ -365,318 +276,30 @@ export class QaseReporter implements ReporterInterface {
     await this.startTestRunOperation;
   }
 
-  /**
-   * @param {OptionsType} options
-   * @returns {QaseReporter}
-   */
-  public static getInstance(options: OptionsType): QaseReporter {
-    if (!QaseReporter.instance) {
-      QaseReporter.instance = new QaseReporter(options);
-    }
-
-    return QaseReporter.instance;
+  public async sendResults(): Promise<void> {
+    if (this.fallback.isDisabled()) return;
+    await this.fallback.run((r) => r.sendResults(), 'send the results');
   }
 
-  /**
-   * Get status mapping configuration
-   * @returns Status mapping configuration or undefined
-   */
-  public getStatusMapping(): Record<string, string> | undefined {
-    return this.options.statusMapping;
-  }
-
-  /**
-   * @param {TestResultType} result
-   */
-  public async addTestResult(result: TestResultType) {
-    if (!this.disabled) {
-      // Apply status mapping if configured
-      const statusMapping = this.getStatusMapping();
-      if (statusMapping) {
-        const originalStatus = result.execution.status;
-        const mappedStatus = applyStatusMapping(originalStatus, statusMapping);
-        if (mappedStatus !== originalStatus) {
-          this.logger.logDebug(`Status mapping applied: ${originalStatus} -> ${mappedStatus}`);
-          result.execution.status = mappedStatus;
-        }
-      }
-
-      // Check if result should be filtered out based on status
-      if (this.shouldFilterResult(result)) {
-        this.logger.logDebug(`Filtering out test result with status: ${result.execution.status}`);
-        return;
-      }
-
+  public async publish(): Promise<void> {
+    if (!this.fallback.isDisabled()) {
       await this.startTestRunOperation;
-
-      this.logTestItem(result);
-
-      if (this.useFallback) {
-        await this.addTestResultToFallback(result);
-        return;
-      }
-
-      try {
-        await this.upstreamReporter?.addTestResult(result);
-      } catch (error) {
-        this.logger.logError('Unable to add the result to the upstream reporter:', error);
-
-        if (this.fallbackReporter == undefined) {
-          this.disabled = true;
-          if (this.withState) {
-            StateManager.setMode(ModeEnum.off);
-          }
-          return;
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (!this.useFallback) {
-          this.fallbackReporter.setTestResults(this.upstreamReporter?.getTestResults() ?? []);
-          this.useFallback = true;
-        }
-
-        await this.addTestResultToFallback(result);
-      }
+      this.logger.logDebug('Publishing test run results');
+      await this.fallback.run(
+        (r) => r.publish(),
+        'publish the run results',
+      );
     }
+    if (this.withState) StateManager.clearState();
   }
 
-  /**
-   * @param {TestResultType} result
-   * @private
-   */
-  private shouldFilterResult(result: TestResultType): boolean {
-    const statusFilter = this.options.testops?.statusFilter;
-
-    if (!statusFilter || statusFilter.length === 0) {
-      return false;
-    }
-
-    // Convert TestStatusEnum to string for comparison
-    const statusString = result.execution.status.toString();
-
-    this.logger.logDebug(`Checking filter: status="${statusString}", filter=${JSON.stringify(statusFilter)}`);
-
-    // Check if the status is in the filter list
-    const shouldFilter = statusFilter.includes(statusString);
-
-    this.logger.logDebug(`Filter result: ${shouldFilter ? 'FILTERED' : 'NOT FILTERED'}`);
-
-    return shouldFilter;
+  public async complete(): Promise<void> {
+    if (this.withState) StateManager.clearState();
+    if (this.fallback.isDisabled()) return;
+    await this.fallback.run((r) => r.complete(), 'complete the run');
   }
 
-  /**
-   * @param {TestResultType} result
-   * @private
-   */
-  private async addTestResultToFallback(result: TestResultType): Promise<void> {
-    try {
-      await this.fallbackReporter?.addTestResult(result);
-      if (this.withState) {
-        StateManager.setMode(this.options.fallback as ModeEnum);
-      }
-    } catch (error) {
-      this.logger.logError('Unable to add the result to the fallback reporter:', error);
-      this.disabled = true;
-      StateManager.setMode(ModeEnum.off);
-    }
-  }
-
-  /**
-   * @returns {boolean}
-   */
   public isCaptureLogs(): boolean {
     return this.captureLogs ?? false;
-  }
-
-  /**
-   * @returns {Promise<void>}
-   */
-  public async publish(): Promise<void> {
-    if (!this.disabled) {
-
-      await this.startTestRunOperation;
-
-      this.logger.logDebug('Publishing test run results');
-
-      if (this.useFallback) {
-        await this.publishFallback();
-      }
-
-      try {
-        await this.upstreamReporter?.publish();
-      } catch (error) {
-        this.logger.logError('Unable to publish the run results to the upstream reporter:', error);
-
-        if (this.fallbackReporter == undefined) {
-          this.disabled = true;
-          if (this.withState) {
-            StateManager.setMode(ModeEnum.off);
-          }
-          return;
-        }
-
-        if (!this.useFallback) {
-          this.fallbackReporter.setTestResults(this.upstreamReporter?.getTestResults() ?? []);
-          this.useFallback = true;
-        }
-
-        await this.publishFallback();
-      }
-    }
-    if (this.withState) {
-      StateManager.clearState();
-    }
-  }
-
-  /**
-   * @returns {Promise<void>}
-   */
-  private async publishFallback(): Promise<void> {
-    try {
-      await this.fallbackReporter?.publish();
-      if (this.withState) {
-        StateManager.setMode(this.options.fallback as ModeEnum);
-      }
-    } catch (error) {
-      if (this.withState) {
-        StateManager.setMode(ModeEnum.off);
-      }
-      this.logger.logError('Unable to publish the run results to the fallback reporter:', error);
-      this.disabled = true;
-    }
-  }
-
-  /**
-   * @todo implement mode registry
-   * @param {ModeEnum} mode
-   * @param {OptionsType} options
-   * @returns {InternalReporterInterface}
-   * @private
-   */
-  private createReporter(
-    mode: ModeEnum,
-    options: OptionsType,
-  ): InternalReporterInterface {
-
-    switch (mode) {
-      case ModeEnum.testops: {
-        if (!options.testops?.api?.token) {
-          throw new Error(
-            `Either "testops.api.token" parameter or "${EnvApiEnum.token}" environment variable is required in "testops" mode`,
-          );
-        }
-
-        if (!options.testops.project) {
-          throw new Error(
-            `Either "testops.project" parameter or "${EnvTestOpsEnum.project}" environment variable is required in "testops" mode`,
-          );
-        }
-
-        const apiClient = new ClientV2(
-          this.logger,
-          options.testops as TestOpsOptionsType,
-          options.environment,
-          options.rootSuite,
-          this.hostData,
-          options.reporterName,
-          options.frameworkPackage
-        );
-
-        return new TestOpsReporter(
-          this.logger,
-          apiClient,
-          this.withState,
-          options.testops.project,
-          options.testops.api.host,
-          options.testops.batch?.size,
-          options.testops.run?.id,
-          options.testops.showPublicReportLink
-        );
-      }
-
-      case ModeEnum.testops_multi: {
-        if (!options.testops?.api?.token) {
-          throw new Error(
-            `Either "testops.api.token" parameter or "${EnvApiEnum.token}" environment variable is required in "testops_multi" mode`,
-          );
-        }
-
-        const multi = options.testops_multi;
-        if (!multi?.projects?.length) {
-          throw new Error(
-            '"testops_multi.projects" must contain at least one project with a "code" field',
-          );
-        }
-        for (const p of multi.projects) {
-          if (!p?.code) {
-            throw new Error('Each project in "testops_multi.projects" must have a "code" field');
-          }
-        }
-
-        return new TestOpsMultiReporter(
-          this.logger,
-          options.testops as TestOpsOptionsType,
-          multi,
-          this.withState,
-          this.hostData,
-          options.reporterName,
-          options.frameworkPackage,
-          options.environment,
-          options.testops.api?.host,
-          options.testops.batch?.size,
-          options.testops.showPublicReportLink
-        );
-      }
-
-      case ModeEnum.report: {
-        const localOptions = options.report?.connections?.[DriverEnum.local];
-        const writer = new FsWriter(localOptions);
-
-        return new ReportReporter(
-          this.logger,
-          writer,
-          options.frameworkPackage,
-          options.reporterName,
-          options.environment,
-          options.rootSuite,
-          options.testops?.run?.id,
-          this.hostData);
-      }
-
-      case ModeEnum.off:
-        throw new DisabledException();
-
-      default:
-        throw new Error(`Unknown mode type`);
-    }
-  }
-
-  /**
-   * @param {TestResultType} test
-   * @private
-   */
-  private logTestItem(test: TestResultType) {
-    this.logger.log(resultLogMap[test.execution.status](test));
-  }
-
-  private setWithState(options: OptionsType): boolean {
-    return options.frameworkName === 'cypress' || !options.frameworkName;
-  }
-
-  private maskToken(token: string): string {
-    if (token.length <= 7) {
-      return '*'.repeat(token.length);
-    }
-    return `${token.slice(0, 3)}****${token.slice(-4)}`;
-  }
-
-  private sanitizeOptions(options: ConfigType & OptionsType): ConfigType & OptionsType {
-    const sanitized = JSON.parse(JSON.stringify(options)) as ConfigType & OptionsType;
-
-    if (sanitized.testops?.api?.token) {
-      sanitized.testops.api.token = this.maskToken(sanitized.testops.api.token);
-    }
-
-    return sanitized;
   }
 }

--- a/qase-javascript-commons/src/qase/options-resolver.ts
+++ b/qase-javascript-commons/src/qase/options-resolver.ts
@@ -1,0 +1,57 @@
+import envSchema from 'env-schema';
+import {
+  EnvEnum,
+  EnvRunEnum,
+  envToConfig,
+  envValidationSchema,
+} from '../env';
+import { composeOptions, ModeEnum, OptionsType } from '../options';
+import { ConfigType } from '../config';
+import { StateManager } from '../state/state';
+
+export interface ResolvedOptions {
+  effectiveMode: ModeEnum;
+  effectiveFallback: ModeEnum;
+  composed: ConfigType & OptionsType;
+  withState: boolean;
+}
+
+/**
+ * Composes the final options used by QaseReporter:
+ * - restores mode / runId from state (when withState is active)
+ * - merges env-derived config with user options
+ * - determines effective mode / fallback values
+ */
+export class OptionsResolver {
+  resolve(options: OptionsType): ResolvedOptions {
+    const withState = this.detectWithState(options);
+    if (withState) {
+      this.restoreFromState();
+    }
+
+    const env = envToConfig(envSchema({ schema: envValidationSchema }));
+    const composed = composeOptions(options, env);
+
+    return {
+      effectiveMode: (composed.mode as ModeEnum) ?? ModeEnum.off,
+      effectiveFallback: (composed.fallback as ModeEnum) ?? ModeEnum.off,
+      composed,
+      withState,
+    };
+  }
+
+  private detectWithState(options: OptionsType): boolean {
+    return options.frameworkName === 'cypress' || !options.frameworkName;
+  }
+
+  private restoreFromState(): void {
+    if (!StateManager.isStateExists()) return;
+    const state = StateManager.getState();
+    if (state.IsModeChanged && state.Mode) {
+      process.env[EnvEnum.mode] = state.Mode.toString();
+    }
+    if (state.RunId) {
+      process.env[EnvRunEnum.id] = state.RunId.toString();
+    }
+  }
+}

--- a/qase-javascript-commons/src/qase/reporter-factory.ts
+++ b/qase-javascript-commons/src/qase/reporter-factory.ts
@@ -1,0 +1,138 @@
+import {
+  InternalReporterInterface,
+  TestOpsReporter,
+  TestOpsMultiReporter,
+  ReportReporter,
+} from '../reporters';
+import { ModeEnum, OptionsType } from '../options';
+import { ConfigType } from '../config';
+import { EnvApiEnum, EnvTestOpsEnum } from '../env';
+import { LoggerInterface } from '../utils/logger';
+import { DisabledException } from '../utils/disabled-exception';
+import { HostData } from '../models/host-data';
+import { TestOpsOptionsType } from '../models/config/TestOpsOptionsType';
+import { ClientV2 } from '../client/clientV2';
+import { DriverEnum, FsWriter } from '../writer';
+
+/**
+ * Builds a mode-specific InternalReporterInterface. Throws DisabledException
+ * for `ModeEnum.off` so callers can distinguish "disabled-by-config" from a
+ * real failure.
+ */
+export class ReporterFactory {
+  constructor(
+    private readonly logger: LoggerInterface,
+    private readonly hostData: HostData,
+  ) {}
+
+  create(
+    mode: ModeEnum,
+    options: ConfigType & OptionsType,
+    withState: boolean,
+  ): InternalReporterInterface {
+    switch (mode) {
+      case ModeEnum.testops:
+        return this.createTestOps(options, withState);
+      case ModeEnum.testops_multi:
+        return this.createTestOpsMulti(options, withState);
+      case ModeEnum.report:
+        return this.createReport(options);
+      case ModeEnum.off:
+        throw new DisabledException();
+      default:
+        throw new Error(`Unknown mode type`);
+    }
+  }
+
+  private createTestOps(
+    options: ConfigType & OptionsType,
+    withState: boolean,
+  ): TestOpsReporter {
+    if (!options.testops?.api?.token) {
+      throw new Error(
+        `Either "testops.api.token" parameter or "${EnvApiEnum.token}" environment variable is required in "testops" mode`,
+      );
+    }
+    if (!options.testops.project) {
+      throw new Error(
+        `Either "testops.project" parameter or "${EnvTestOpsEnum.project}" environment variable is required in "testops" mode`,
+      );
+    }
+
+    const apiClient = new ClientV2(
+      this.logger,
+      options.testops as TestOpsOptionsType,
+      options.environment,
+      options.rootSuite,
+      this.hostData,
+      options.reporterName,
+      options.frameworkPackage,
+    );
+
+    return new TestOpsReporter(
+      this.logger,
+      apiClient,
+      withState,
+      options.testops.project,
+      options.testops.api.host,
+      options.testops.batch?.size,
+      options.testops.run?.id,
+      options.testops.showPublicReportLink,
+    );
+  }
+
+  private createTestOpsMulti(
+    options: ConfigType & OptionsType,
+    withState: boolean,
+  ): TestOpsMultiReporter {
+    if (!options.testops?.api?.token) {
+      throw new Error(
+        `Either "testops.api.token" parameter or "${EnvApiEnum.token}" environment variable is required in "testops_multi" mode`,
+      );
+    }
+
+    const multi = options.testops_multi;
+    if (!multi?.projects?.length) {
+      throw new Error(
+        '"testops_multi.projects" must contain at least one project with a "code" field',
+      );
+    }
+    for (const p of multi.projects) {
+      if (!p?.code) {
+        throw new Error(
+          'Each project in "testops_multi.projects" must have a "code" field',
+        );
+      }
+    }
+
+    return new TestOpsMultiReporter(
+      this.logger,
+      options.testops as TestOpsOptionsType,
+      multi,
+      withState,
+      this.hostData,
+      options.reporterName,
+      options.frameworkPackage,
+      options.environment,
+      options.testops.api?.host,
+      options.testops.batch?.size,
+      options.testops.showPublicReportLink,
+    );
+  }
+
+  private createReport(options: ConfigType & OptionsType): ReportReporter {
+    const localOptions = options.report?.connections?.[DriverEnum.local];
+    const writer = new FsWriter(localOptions);
+
+    return new ReportReporter(
+      this.logger,
+      writer,
+      options.frameworkPackage,
+      options.reporterName,
+      options.environment,
+      options.rootSuite,
+      options.testops?.run?.id,
+      this.hostData,
+    );
+  }
+}

--- a/qase-javascript-commons/src/qase/status-processor.ts
+++ b/qase-javascript-commons/src/qase/status-processor.ts
@@ -1,0 +1,53 @@
+import { TestResultType } from '../models';
+import { LoggerInterface } from '../utils/logger';
+import { applyStatusMapping } from '../utils/status-mapping-utils';
+
+/**
+ * Applies status mapping (rename rule) and status filter (drop rule) to a test
+ * result. Mutates `result.execution.status` when a mapping rule matches, then
+ * returns either the (possibly mutated) result or `null` if it should be
+ * filtered out.
+ */
+export class StatusProcessor {
+  constructor(
+    private readonly logger: LoggerInterface,
+    private readonly statusMapping: Record<string, string> | undefined,
+    private readonly statusFilter: string[] | undefined,
+  ) {}
+
+  process(result: TestResultType): TestResultType | null {
+    this.applyMapping(result);
+    if (this.shouldFilter(result)) {
+      this.logger.logDebug(
+        `Filtering out test result with status: ${result.execution.status}`,
+      );
+      return null;
+    }
+    return result;
+  }
+
+  private applyMapping(result: TestResultType): void {
+    if (!this.statusMapping) return;
+    const originalStatus = result.execution.status;
+    const mapped = applyStatusMapping(originalStatus, this.statusMapping);
+    if (mapped !== originalStatus) {
+      this.logger.logDebug(
+        `Status mapping applied: ${originalStatus} -> ${mapped}`,
+      );
+      result.execution.status = mapped;
+    }
+  }
+
+  private shouldFilter(result: TestResultType): boolean {
+    if (!this.statusFilter || this.statusFilter.length === 0) return false;
+    const statusString = result.execution.status.toString();
+    this.logger.logDebug(
+      `Checking filter: status="${statusString}", filter=${JSON.stringify(this.statusFilter)}`,
+    );
+    const shouldFilter = this.statusFilter.includes(statusString);
+    this.logger.logDebug(
+      `Filter result: ${shouldFilter ? 'FILTERED' : 'NOT FILTERED'}`,
+    );
+    return shouldFilter;
+  }
+}

--- a/qase-javascript-commons/src/reporters/report-reporter.ts
+++ b/qase-javascript-commons/src/reporters/report-reporter.ts
@@ -1,10 +1,10 @@
 import { AbstractReporter } from './abstract-reporter';
-import { Attachment, Report, TestStatusEnum, TestStepType, StepType, TestResultType } from '../models';
-import { StepTextData, StepGherkinData } from '../models/step-data';
+import { Attachment, Report, TestStatusEnum, TestStepType, TestResultType } from '../models';
 import { WriterInterface } from '../writer';
 import { LoggerInterface } from '../utils/logger';
 import { getHostInfo } from '../utils/hostData';
 import { HostData } from '../models/host-data';
+import { ReportSerializer, ReportSerializerInterface } from '../formatter/report-serializer';
 
 /**
  * @class ReportReporter
@@ -16,6 +16,7 @@ export class ReportReporter extends AbstractReporter {
   private readonly runId: number | undefined;
   private readonly rootSuite: string | undefined;
   private readonly hostData: HostData | undefined;
+  private readonly serializer: ReportSerializerInterface;
   private startTime: number = Date.now();
 
   /**
@@ -27,6 +28,7 @@ export class ReportReporter extends AbstractReporter {
    * @param {string | undefined} rootSuite
    * @param {number | undefined} runId
    * @param {HostData | undefined} hostData
+   * @param {ReportSerializerInterface} serializer
    */
   constructor(
     logger: LoggerInterface,
@@ -37,12 +39,14 @@ export class ReportReporter extends AbstractReporter {
     rootSuite?: string,
     runId?: number,
     hostData?: HostData,
+    serializer: ReportSerializerInterface = new ReportSerializer(),
   ) {
     super(logger);
     this.environment = environment;
     this.runId = runId;
     this.rootSuite = rootSuite;
     this.hostData = hostData;
+    this.serializer = serializer;
   }
 
   /**
@@ -93,7 +97,7 @@ export class ReportReporter extends AbstractReporter {
       }
 
       // Serialize to spec-compliant format before writing
-      const serialized = this.serializeResultForReport(result);
+      const serialized = this.serializer.serializeResult(result);
       await this.writer.writeTestResult(serialized as unknown as TestResultType);
     }
   }
@@ -182,150 +186,4 @@ export class ReportReporter extends AbstractReporter {
     return steps;
   }
 
-  /**
-   * Serialize a test result to spec-compliant JSON format.
-   * Transforms internal model fields to match the Qase Report specification.
-   * @private
-   */
-  private serializeResultForReport(result: TestResultType): Record<string, unknown> {
-    // Transform testops_id -> testops_ids (RSLT-01)
-    let testopsIds: number[] | null = null;
-    if (result.testops_id !== null) {
-      testopsIds = Array.isArray(result.testops_id)
-        ? result.testops_id
-        : [result.testops_id];
-    }
-
-    // Transform group_params -> param_groups (RSLT-02)
-    const paramGroups = this.transformGroupParams(result.group_params);
-
-    // Serialize attachments (exclude size and content fields)
-    const attachments = result.attachments.map(att => this.serializeAttachment(att));
-
-    // Serialize steps (handle data.data -> data.input_data and attachments -> execution.attachments)
-    const steps = this.serializeSteps(result.steps);
-
-    // Build spec-compliant result object
-    const serialized: Record<string, unknown> = {
-      id: result.id,
-      title: result.title,
-      signature: result.signature,
-      execution: result.execution,
-      fields: result.fields,
-      attachments: attachments,
-      steps: steps,
-      params: result.params,
-      param_groups: paramGroups,
-      testops_ids: testopsIds,
-      relations: result.relations,
-      muted: result.muted,
-      message: result.message,
-      tags: result.tags,
-    };
-
-    // Internal-only fields are excluded: testops_id, group_params, run_id, author, testops_project_mapping, preparedAttachments
-    return serialized;
-  }
-
-  /**
-   * Transform group_params Record to param_groups array of arrays.
-   * Same logic as clientV2.ts transformGroupParams.
-   * @private
-   */
-  private transformGroupParams(groupParams: Record<string, string>): string[][] {
-    const keys = Object.keys(groupParams);
-    if (keys.length === 0) {
-      return [];
-    }
-    return [keys];
-  }
-
-  /**
-   * Serialize attachment for report output (exclude size and content fields).
-   * @private
-   */
-  private serializeAttachment(att: Attachment): Record<string, unknown> {
-    return {
-      id: att.id,
-      file_name: att.file_name,
-      mime_type: att.mime_type,
-      file_path: att.file_path,
-    };
-  }
-
-  /**
-   * Serialize steps recursively, transforming:
-   * - data.data -> data.input_data (STEP-01)
-   * - attachments -> execution.attachments (STEP-02)
-   * @private
-   */
-  private serializeSteps(steps: TestStepType[]): Record<string, unknown>[] {
-    return steps.map(step => this.serializeStep(step));
-  }
-
-  /**
-   * Serialize a single step to spec-compliant format.
-   * @private
-   */
-  private serializeStep(step: TestStepType): Record<string, unknown> {
-    // Transform step data (handle data.data -> data.input_data for text steps)
-    const data = this.serializeStepData(step);
-
-    // Serialize step attachments
-    const attachments = step.attachments.map(att => this.serializeAttachment(att));
-
-    // Move attachments into execution.attachments (STEP-02)
-    const execution = {
-      ...step.execution,
-      attachments: attachments,
-    };
-
-    // Recursively serialize nested steps
-    const nestedSteps = this.serializeSteps(step.steps);
-
-    return {
-      id: step.id,
-      step_type: step.step_type,
-      data: data,
-      parent_id: step.parent_id,
-      execution: execution,
-      steps: nestedSteps,
-      // Note: attachments field is NOT at top-level in serialized output
-    };
-  }
-
-  /**
-   * Serialize step data, transforming data.data -> data.input_data for text steps.
-   * @private
-   */
-  private serializeStepData(step: TestStepType): Record<string, unknown> {
-    const data = { ...step.data };
-
-    // For text steps, rename data.data to data.input_data (STEP-01)
-    if (step.step_type === StepType.TEXT && 'data' in data) {
-      const textData = data as StepTextData;
-      return {
-        action: textData.action,
-        expected_result: textData.expected_result,
-        input_data: textData.data, // Rename: data -> input_data
-      };
-    }
-
-    // For gherkin steps, convert to text format (STEP-03)
-    if (step.step_type === StepType.GHERKIN && 'keyword' in data && 'name' in data) {
-      const gherkinData = data as StepGherkinData;
-      return {
-        action: `${gherkinData.keyword} ${gherkinData.name}`,
-        expected_result: null,
-        input_data: null, // JS GherkinData has no data field
-      };
-    }
-
-    // For request steps, pass raw fields through (all 7 StepRequestData fields are preserved)
-    if (step.step_type === StepType.REQUEST && 'request_method' in data) {
-      return data as Record<string, unknown>;
-    }
-
-    return data;
-  }
 }

--- a/qase-javascript-commons/src/reporters/shared/fallback-coordinator.ts
+++ b/qase-javascript-commons/src/reporters/shared/fallback-coordinator.ts
@@ -1,0 +1,138 @@
+import { InternalReporterInterface } from '../abstract-reporter';
+import { LoggerInterface } from '../../utils/logger';
+
+export interface FallbackCoordinatorCallbacks {
+  onUpstreamFailure?: () => void;
+  onFallbackFailure?: () => void;
+  onFallbackActivated?: () => void;
+  onDisabled?: () => void;
+}
+
+/**
+ * Encapsulates the upstream → fallback → disabled cascade used across all
+ * `QaseReporter` lifecycle methods. Keeps both reporters' state (useFallback
+ * / disabled) in one place instead of spreading try/catch blocks everywhere.
+ */
+export class FallbackCoordinator {
+  private useFallback = false;
+  private disabled = false;
+  private onDisabledFired = false;
+
+  constructor(
+    private readonly logger: LoggerInterface,
+    private readonly upstream: InternalReporterInterface | undefined,
+    private readonly fallback: InternalReporterInterface | undefined,
+    private readonly callbacks: FallbackCoordinatorCallbacks = {},
+  ) {}
+
+  isDisabled(): boolean {
+    return this.disabled;
+  }
+
+  isUsingFallback(): boolean {
+    return this.useFallback;
+  }
+
+  setDisabled(value: boolean): void {
+    this.disabled = value;
+  }
+
+  setUseFallback(value: boolean): void {
+    this.useFallback = value;
+  }
+
+  getUpstream(): InternalReporterInterface | undefined {
+    return this.upstream;
+  }
+
+  getFallback(): InternalReporterInterface | undefined {
+    return this.fallback;
+  }
+
+  /**
+   * Clear the disabled / useFallback flags so the coordinator can be reused
+   * for a fresh test run. Does not re-arm the `onDisabled` callback — it
+   * only fires once per coordinator lifetime regardless of resets.
+   */
+  reset(): void {
+    this.disabled = false;
+    this.useFallback = false;
+  }
+
+  /**
+   * Run `op` on the currently active reporter. On upstream failure, switch to
+   * the fallback (copying accumulated results over once) and retry. On
+   * fallback failure, disable the coordinator.
+   *
+   * Returns the operation's result, or `undefined` if the coordinator is
+   * disabled or the operation produced no value.
+   */
+  async run<T>(
+    op: (reporter: InternalReporterInterface) => Promise<T>,
+    opName: string,
+  ): Promise<T | undefined> {
+    if (this.disabled) return undefined;
+
+    if (this.useFallback) {
+      return this.runOnFallback(op, opName);
+    }
+
+    if (!this.upstream) {
+      // No upstream configured — route directly to fallback without
+      // copying results (there are none to copy).
+      if (!this.fallback) return undefined;
+      this.useFallback = true;
+      return this.runOnFallback(op, opName);
+    }
+
+    try {
+      return await op(this.upstream);
+    } catch (error) {
+      this.logger.logError(`Unable to ${opName} in the upstream reporter:`, error);
+      this.callbacks.onUpstreamFailure?.();
+
+      if (!this.fallback) {
+        this.disable();
+        return undefined;
+      }
+
+      this.activateFallback();
+      return this.runOnFallback(op, opName);
+    }
+  }
+
+  private disable(): void {
+    if (this.disabled) return;
+    this.disabled = true;
+    if (!this.onDisabledFired) {
+      this.onDisabledFired = true;
+      this.callbacks.onDisabled?.();
+    }
+  }
+
+  private activateFallback(): void {
+    if (this.useFallback) return;
+    const results = this.upstream?.getTestResults() ?? [];
+    this.fallback?.setTestResults(results);
+    this.useFallback = true;
+    this.callbacks.onFallbackActivated?.();
+  }
+
+  private async runOnFallback<T>(
+    op: (reporter: InternalReporterInterface) => Promise<T>,
+    opName: string,
+  ): Promise<T | undefined> {
+    if (!this.fallback) {
+      this.disable();
+      return undefined;
+    }
+    try {
+      return await op(this.fallback);
+    } catch (error) {
+      this.logger.logError(`Unable to ${opName} in the fallback reporter:`, error);
+      this.callbacks.onFallbackFailure?.();
+      this.disable();
+      return undefined;
+    }
+  }
+}

--- a/qase-javascript-commons/src/reporters/shared/testops-constants.ts
+++ b/qase-javascript-commons/src/reporters/shared/testops-constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Default number of test results per upload batch.
+ * Used by TestOpsReporter and TestOpsMultiReporter when no explicit batch size is configured.
+ */
+export const DEFAULT_BATCH_SIZE = 200;

--- a/qase-javascript-commons/src/reporters/shared/testops-url.ts
+++ b/qase-javascript-commons/src/reporters/shared/testops-url.ts
@@ -1,0 +1,14 @@
+/**
+ * Resolve the TestOps app URL from an API host.
+ *
+ * Rules:
+ * - undefined / empty / "qase.io" → "https://app.qase.io"
+ * - "api.domain"                  → "https://app.domain"
+ * - anything else                 → "https://<host>"
+ */
+export function resolveTestOpsBaseUrl(host: string | undefined): string {
+  if (!host || host === 'qase.io') {
+    return 'https://app.qase.io';
+  }
+  return `https://${host.replace('api', 'app')}`;
+}

--- a/qase-javascript-commons/src/reporters/testops-multi-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-multi-reporter.ts
@@ -12,8 +12,8 @@ import { LoggerInterface } from '../utils/logger';
 import { Mutex } from 'async-mutex';
 import { ClientV2 } from '../client/clientV2';
 import { HostData } from '../models/host-data';
-
-const defaultChunkSize = 200;
+import { DEFAULT_BATCH_SIZE } from './shared/testops-constants';
+import { resolveTestOpsBaseUrl } from './shared/testops-url';
 
 /**
  * Multi-project TestOps reporter. Sends test results to multiple Qase projects
@@ -60,8 +60,8 @@ export class TestOpsMultiReporter extends AbstractReporter {
     showPublicReportLink?: boolean,
   ) {
     super(logger);
-    this.baseUrl = this.getBaseUrl(baseUrl ?? testopsOptions.api?.host);
-    this.batchSize = batchSize ?? testopsOptions.batch?.size ?? defaultChunkSize;
+    this.baseUrl = resolveTestOpsBaseUrl(baseUrl ?? testopsOptions.api?.host);
+    this.batchSize = batchSize ?? testopsOptions.batch?.size ?? DEFAULT_BATCH_SIZE;
     this.showPublicReportLink = showPublicReportLink ?? testopsOptions.showPublicReportLink;
 
     this.defaultProject =
@@ -349,13 +349,6 @@ export class TestOpsMultiReporter extends AbstractReporter {
       return await client.uploadAttachment(attachment);
     }
     return '';
-  }
-
-  private getBaseUrl(url: string | undefined): string {
-    if (!url || url === 'qase.io') {
-      return 'https://app.qase.io';
-    }
-    return `https://${url.replace('api', 'app')}`;
   }
 
   private showLink(projectCode: string, id: number | null, title: string): void {

--- a/qase-javascript-commons/src/reporters/testops-reporter.ts
+++ b/qase-javascript-commons/src/reporters/testops-reporter.ts
@@ -11,8 +11,8 @@ import { LoggerInterface } from '../utils/logger';
 import { StateManager } from '../state/state';
 import { Mutex } from 'async-mutex';
 import { IClient } from '../client/interface';
-
-const defaultChunkSize = 200;
+import { DEFAULT_BATCH_SIZE } from './shared/testops-constants';
+import { resolveTestOpsBaseUrl } from './shared/testops-url';
 
 /**
  * @class TestOpsReporter
@@ -50,8 +50,8 @@ export class TestOpsReporter extends AbstractReporter {
     private showPublicReportLink?: boolean,
   ) {
     super(logger);
-    this.baseUrl = this.getBaseUrl(baseUrl);
-    this.batchSize = batchSize ?? defaultChunkSize;
+    this.baseUrl = resolveTestOpsBaseUrl(baseUrl);
+    this.batchSize = batchSize ?? DEFAULT_BATCH_SIZE;
     this.runId = runId;
   }
 
@@ -158,13 +158,13 @@ export class TestOpsReporter extends AbstractReporter {
     const remainingResults = this.results.slice(this.firstIndex);
 
     if (this.firstIndex < this.results.length) {
-      if (remainingResults.length <= defaultChunkSize) {
+      if (remainingResults.length <= DEFAULT_BATCH_SIZE) {
         await this.publishResults(remainingResults);
         return;
       }
 
-      for (let i = 0; i < remainingResults.length; i += defaultChunkSize) {
-        await this.publishResults(remainingResults.slice(i, i + defaultChunkSize));
+      for (let i = 0; i < remainingResults.length; i += DEFAULT_BATCH_SIZE) {
+        await this.publishResults(remainingResults.slice(i, i + DEFAULT_BATCH_SIZE));
       }
     }
 
@@ -198,19 +198,6 @@ export class TestOpsReporter extends AbstractReporter {
     }
 
     this.logger.log(chalk`{green Run ${this.runId} completed}`);
-  }
-
-  /**
-   * @param {string | undefined} url
-   * @return string
-   * @private
-   */
-  private getBaseUrl(url: string | undefined): string {
-    if (!url || url === 'qase.io') {
-      return 'https://app.qase.io';
-    }
-
-    return `https://${url.replace('api', 'app')}`;
   }
 
   /**

--- a/qase-javascript-commons/src/utils/token-masker.ts
+++ b/qase-javascript-commons/src/utils/token-masker.ts
@@ -1,0 +1,24 @@
+/**
+ * Mask a token for safe logging.
+ * Tokens with 7 chars or fewer are fully masked. Longer tokens expose only
+ * the first 3 and last 4 characters.
+ */
+export function maskToken(token: string): string {
+  if (token.length <= 7) {
+    return '*'.repeat(token.length);
+  }
+  return `${token.slice(0, 3)}****${token.slice(-4)}`;
+}
+
+/**
+ * Produce a deep-cloned copy of options with `testops.api.token` masked.
+ * Safe to log — never mutates the input.
+ */
+export function sanitizeOptionsForLog<T>(options: T): T {
+  const sanitized = JSON.parse(JSON.stringify(options)) as
+    T & { testops?: { api?: { token?: string } } };
+  if (sanitized.testops?.api?.token) {
+    sanitized.testops.api.token = maskToken(sanitized.testops.api.token);
+  }
+  return sanitized as T;
+}

--- a/qase-javascript-commons/test/formatter/report-serializer.test.ts
+++ b/qase-javascript-commons/test/formatter/report-serializer.test.ts
@@ -1,0 +1,161 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-assertion, @typescript-eslint/require-await */
+import { expect } from '@jest/globals';
+import { ReportSerializer } from '../../src/formatter/report-serializer';
+import {
+  Attachment,
+  StepStatusEnum,
+  StepType,
+  TestResultType,
+  TestStatusEnum,
+  TestStepType,
+} from '../../src/models';
+
+const attachment = (id: string, fileName: string): Attachment =>
+  ({
+    id,
+    file_name: fileName,
+    mime_type: 'text/plain',
+    file_path: `/tmp/${fileName}`,
+    size: 42,
+    content: 'x',
+  }) as unknown as Attachment;
+
+const textStep = (id: string, action: string): TestStepType =>
+  ({
+    id,
+    step_type: StepType.TEXT,
+    data: { action, expected_result: 'ok', data: 'raw-input' },
+    parent_id: null,
+    execution: { status: StepStatusEnum.passed, duration: 5, start_time: 1 } as any,
+    steps: [],
+    attachments: [attachment(`${id}-att`, `${id}.txt`)],
+  }) as unknown as TestStepType;
+
+const gherkinStep = (id: string, keyword: string, name: string): TestStepType =>
+  ({
+    id,
+    step_type: StepType.GHERKIN,
+    data: { keyword, name },
+    parent_id: null,
+    execution: { status: StepStatusEnum.passed, duration: 5, start_time: 1 } as any,
+    steps: [],
+    attachments: [],
+  }) as unknown as TestStepType;
+
+const baseResult = (overrides: Partial<TestResultType>): TestResultType =>
+  ({
+    id: 'res-1',
+    title: 'Test',
+    signature: 'sig',
+    execution: { status: TestStatusEnum.passed, duration: 10 } as any,
+    fields: {},
+    attachments: [],
+    steps: [],
+    params: {},
+    group_params: {},
+    testops_id: null,
+    relations: null,
+    muted: false,
+    message: '',
+    tags: [],
+    ...overrides,
+  }) as unknown as TestResultType;
+
+describe('ReportSerializer.serializeResult', () => {
+  const s = new ReportSerializer();
+
+  it('transforms scalar testops_id → testops_ids array', () => {
+    const out = s.serializeResult(baseResult({ testops_id: 42 as any }));
+    expect(out.testops_ids).toEqual([42]);
+    expect(out).not.toHaveProperty('testops_id');
+  });
+
+  it('keeps array testops_id as-is under testops_ids', () => {
+    const out = s.serializeResult(baseResult({ testops_id: [1, 2, 3] as any }));
+    expect(out.testops_ids).toEqual([1, 2, 3]);
+  });
+
+  it('maps null testops_id to null testops_ids', () => {
+    const out = s.serializeResult(baseResult({ testops_id: null as any }));
+    expect(out.testops_ids).toBeNull();
+  });
+
+  it('transforms group_params map into param_groups array of keys', () => {
+    const out = s.serializeResult(baseResult({ group_params: { a: '1', b: '2' } }));
+    expect(out.param_groups).toEqual([['a', 'b']]);
+  });
+
+  it('emits empty param_groups when group_params is empty', () => {
+    const out = s.serializeResult(baseResult({ group_params: {} }));
+    expect(out.param_groups).toEqual([]);
+  });
+
+  it('serializes attachments without size and content fields', () => {
+    const out = s.serializeResult(
+      baseResult({ attachments: [attachment('a1', 'a1.txt')] }),
+    );
+    expect(out.attachments).toEqual([
+      {
+        id: 'a1',
+        file_name: 'a1.txt',
+        mime_type: 'text/plain',
+        file_path: '/tmp/a1.txt',
+      },
+    ]);
+  });
+
+  it('excludes internal fields', () => {
+    const out = s.serializeResult(
+      baseResult({
+        testops_id: null as any,
+        group_params: {},
+      }),
+    );
+    expect(out).not.toHaveProperty('testops_id');
+    expect(out).not.toHaveProperty('group_params');
+    expect(out).not.toHaveProperty('run_id');
+    expect(out).not.toHaveProperty('author');
+    expect(out).not.toHaveProperty('testops_project_mapping');
+    expect(out).not.toHaveProperty('preparedAttachments');
+  });
+});
+
+describe('ReportSerializer.serializeStep', () => {
+  const s = new ReportSerializer();
+
+  it('renames text step data.data → data.input_data', () => {
+    const out = s.serializeStep(textStep('s1', 'click'));
+    const data = out.data as any;
+    expect(data.action).toBe('click');
+    expect(data.expected_result).toBe('ok');
+    expect(data.input_data).toBe('raw-input');
+    expect(data).not.toHaveProperty('data');
+  });
+
+  it('moves step attachments under execution.attachments and drops top-level', () => {
+    const out = s.serializeStep(textStep('s1', 'click'));
+    const execution = out.execution as any;
+    expect(Array.isArray(execution.attachments)).toBe(true);
+    expect(execution.attachments).toHaveLength(1);
+    expect(execution.attachments[0]).not.toHaveProperty('size');
+    expect(out).not.toHaveProperty('attachments');
+  });
+
+  it('converts gherkin step to text format', () => {
+    const out = s.serializeStep(gherkinStep('s1', 'Given', 'a user'));
+    const data = out.data as any;
+    expect(data.action).toBe('Given a user');
+    expect(data.expected_result).toBeNull();
+    expect(data.input_data).toBeNull();
+  });
+
+  it('serializes nested steps recursively', () => {
+    const child = textStep('c1', 'inner');
+    const parent = textStep('p1', 'outer');
+    parent.steps = [child];
+    const out = s.serializeStep(parent);
+    const nested = (out.steps as any[])[0];
+    expect(nested.id).toBe('c1');
+    expect((nested.data as any).action).toBe('inner');
+  });
+});

--- a/qase-javascript-commons/test/qase/options-resolver.test.ts
+++ b/qase-javascript-commons/test/qase/options-resolver.test.ts
@@ -1,0 +1,131 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-assertion, @typescript-eslint/require-await, @typescript-eslint/unbound-method */
+import { expect } from '@jest/globals';
+import { OptionsResolver } from '../../src/qase/options-resolver';
+import { ModeEnum } from '../../src/options';
+import { EnvEnum, EnvRunEnum } from '../../src/env';
+
+jest.mock('../../src/state/state', () => ({
+  StateManager: {
+    isStateExists: jest.fn(),
+    getState: jest.fn(),
+  },
+}));
+
+import { StateManager } from '../../src/state/state';
+
+const resetEnv = () => {
+  delete process.env[EnvEnum.mode];
+  delete process.env[EnvRunEnum.id];
+  delete process.env.QASE_MODE;
+  delete process.env.QASE_TESTOPS_API_TOKEN;
+};
+
+describe('OptionsResolver', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    resetEnv();
+  });
+
+  describe('detect withState', () => {
+    it('is true for cypress frameworkName', () => {
+      (StateManager.isStateExists as jest.Mock).mockReturnValue(false);
+      const r = new OptionsResolver().resolve({
+        frameworkName: 'cypress',
+        frameworkPackage: 'cypress',
+        reporterName: 'qase-cypress',
+        mode: ModeEnum.off,
+      });
+      expect(r.withState).toBe(true);
+    });
+
+    it('is true when frameworkName is missing', () => {
+      (StateManager.isStateExists as jest.Mock).mockReturnValue(false);
+      const r = new OptionsResolver().resolve({
+        frameworkName: '',
+        frameworkPackage: '',
+        reporterName: '',
+        mode: ModeEnum.off,
+      });
+      expect(r.withState).toBe(true);
+    });
+
+    it('is false for non-cypress frameworks', () => {
+      (StateManager.isStateExists as jest.Mock).mockReturnValue(false);
+      const r = new OptionsResolver().resolve({
+        frameworkName: 'playwright',
+        frameworkPackage: 'playwright',
+        reporterName: 'qase-playwright',
+        mode: ModeEnum.off,
+      });
+      expect(r.withState).toBe(false);
+    });
+  });
+
+  describe('state restore', () => {
+    it('restores Mode env var when state flags mode changed', () => {
+      (StateManager.isStateExists as jest.Mock).mockReturnValue(true);
+      (StateManager.getState as jest.Mock).mockReturnValue({
+        RunId: undefined,
+        Mode: ModeEnum.report,
+        IsModeChanged: true,
+      });
+      new OptionsResolver().resolve({
+        frameworkName: 'cypress',
+        frameworkPackage: 'cypress',
+        reporterName: 'qase-cypress',
+      });
+      expect(process.env[EnvEnum.mode]).toBe(ModeEnum.report.toString());
+    });
+
+    it('restores Run id env var when state has one', () => {
+      (StateManager.isStateExists as jest.Mock).mockReturnValue(true);
+      (StateManager.getState as jest.Mock).mockReturnValue({
+        RunId: 42,
+        Mode: undefined,
+        IsModeChanged: false,
+      });
+      new OptionsResolver().resolve({
+        frameworkName: 'cypress',
+        frameworkPackage: 'cypress',
+        reporterName: 'qase-cypress',
+      });
+      expect(process.env[EnvRunEnum.id]).toBe('42');
+    });
+
+    it('does not read state when withState is false', () => {
+      (StateManager.isStateExists as jest.Mock).mockReturnValue(true);
+      new OptionsResolver().resolve({
+        frameworkName: 'playwright',
+        frameworkPackage: 'playwright',
+        reporterName: 'qase-playwright',
+      });
+      expect(StateManager.getState).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('effective modes', () => {
+    it('defaults both mode and fallback to off when unset', () => {
+      (StateManager.isStateExists as jest.Mock).mockReturnValue(false);
+      const r = new OptionsResolver().resolve({
+        frameworkName: 'playwright',
+        frameworkPackage: 'playwright',
+        reporterName: 'qase-playwright',
+      });
+      expect(r.effectiveMode).toBe(ModeEnum.off);
+      expect(r.effectiveFallback).toBe(ModeEnum.off);
+    });
+
+    it('passes through user-specified mode and fallback', () => {
+      (StateManager.isStateExists as jest.Mock).mockReturnValue(false);
+      const r = new OptionsResolver().resolve({
+        frameworkName: 'playwright',
+        frameworkPackage: 'playwright',
+        reporterName: 'qase-playwright',
+        mode: ModeEnum.testops,
+        fallback: ModeEnum.report,
+      });
+      expect(r.effectiveMode).toBe(ModeEnum.testops);
+      expect(r.effectiveFallback).toBe(ModeEnum.report);
+    });
+  });
+});

--- a/qase-javascript-commons/test/qase/reporter-factory.test.ts
+++ b/qase-javascript-commons/test/qase/reporter-factory.test.ts
@@ -1,0 +1,158 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-assertion, @typescript-eslint/require-await */
+import { expect } from '@jest/globals';
+import { ReporterFactory } from '../../src/qase/reporter-factory';
+import { ModeEnum, OptionsType } from '../../src/options';
+import { ConfigType } from '../../src/config';
+import { EnvApiEnum, EnvTestOpsEnum } from '../../src/env';
+import { LoggerInterface } from '../../src/utils/logger';
+import { HostData } from '../../src/models/host-data';
+import { DisabledException } from '../../src/utils/disabled-exception';
+import { TestOpsReporter, TestOpsMultiReporter, ReportReporter } from '../../src/reporters';
+
+jest.mock('qase-api-v2-client', () => ({
+  Configuration: jest.fn(),
+  ResultsApi: jest.fn(),
+  ResultStepStatus: {
+    PASSED: 'passed',
+    FAILED: 'failed',
+    BLOCKED: 'blocked',
+    SKIPPED: 'skipped',
+  },
+}));
+
+jest.mock('qase-api-client', () => ({
+  Configuration: jest.fn(),
+  RunsApi: jest.fn(),
+  EnvironmentsApi: jest.fn(),
+  AttachmentsApi: jest.fn(),
+  ConfigurationsApi: jest.fn(),
+}));
+
+const silentLogger = (): jest.Mocked<LoggerInterface> => ({
+  log: jest.fn(),
+  logDebug: jest.fn(),
+  logError: jest.fn(),
+});
+
+const emptyHostData: HostData = {} as HostData;
+
+const baseOptions = (): ConfigType & OptionsType =>
+  ({
+    frameworkName: 'playwright',
+    frameworkPackage: 'playwright',
+    reporterName: 'qase-playwright',
+  }) as unknown as ConfigType & OptionsType;
+
+describe('ReporterFactory', () => {
+  let factory: ReporterFactory;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    factory = new ReporterFactory(silentLogger(), emptyHostData);
+  });
+
+  describe('off mode', () => {
+    it('throws DisabledException', () => {
+      expect(() => factory.create(ModeEnum.off, baseOptions(), false)).toThrow(
+        DisabledException,
+      );
+    });
+  });
+
+  describe('testops mode validation', () => {
+    it('throws when token missing', () => {
+      const opts = { ...baseOptions(), testops: { project: 'DEMO' } } as any;
+      expect(() => factory.create(ModeEnum.testops, opts, false)).toThrow(
+        new RegExp(`testops.api.token.*${EnvApiEnum.token}`),
+      );
+    });
+
+    it('throws when project missing', () => {
+      const opts = { ...baseOptions(), testops: { api: { token: 't' } } } as any;
+      expect(() => factory.create(ModeEnum.testops, opts, false)).toThrow(
+        new RegExp(`testops.project.*${EnvTestOpsEnum.project}`),
+      );
+    });
+
+    it('creates TestOpsReporter when options are valid', () => {
+      const opts = {
+        ...baseOptions(),
+        testops: { api: { token: 't' }, project: 'DEMO' },
+      } as any;
+      const r = factory.create(ModeEnum.testops, opts, false);
+      expect(r).toBeInstanceOf(TestOpsReporter);
+    });
+  });
+
+  describe('testops_multi mode validation', () => {
+    it('throws when token missing', () => {
+      const opts = {
+        ...baseOptions(),
+        testops_multi: { projects: [{ code: 'A' }] },
+      } as any;
+      expect(() => factory.create(ModeEnum.testops_multi, opts, false)).toThrow(
+        /testops.api.token/,
+      );
+    });
+
+    it('throws when projects list is empty', () => {
+      const opts = {
+        ...baseOptions(),
+        testops: { api: { token: 't' } },
+        testops_multi: { projects: [] },
+      } as any;
+      expect(() => factory.create(ModeEnum.testops_multi, opts, false)).toThrow(
+        /testops_multi.projects/,
+      );
+    });
+
+    it('throws when any project lacks a code', () => {
+      const opts = {
+        ...baseOptions(),
+        testops: { api: { token: 't' } },
+        testops_multi: { projects: [{ code: 'A' }, { code: '' }] },
+      } as any;
+      expect(() => factory.create(ModeEnum.testops_multi, opts, false)).toThrow(
+        /Each project.*code/,
+      );
+    });
+
+    it('creates TestOpsMultiReporter when options are valid', () => {
+      const opts = {
+        ...baseOptions(),
+        testops: { api: { token: 't' } },
+        testops_multi: { projects: [{ code: 'A' }] },
+      } as any;
+      const r = factory.create(ModeEnum.testops_multi, opts, false);
+      expect(r).toBeInstanceOf(TestOpsMultiReporter);
+    });
+
+    it('threads withState through to TestOpsMultiReporter', () => {
+      const opts = {
+        ...baseOptions(),
+        testops: { api: { token: 't' } },
+        testops_multi: { projects: [{ code: 'A' }] },
+      } as any;
+      // Verify both true and false produce an instance (no exception).
+      // The 4th constructor argument is withState per the class signature.
+      expect(factory.create(ModeEnum.testops_multi, opts, true)).toBeInstanceOf(TestOpsMultiReporter);
+      expect(factory.create(ModeEnum.testops_multi, opts, false)).toBeInstanceOf(TestOpsMultiReporter);
+    });
+  });
+
+  describe('report mode', () => {
+    it('creates ReportReporter', () => {
+      const opts = { ...baseOptions() } as any;
+      const r = factory.create(ModeEnum.report, opts, false);
+      expect(r).toBeInstanceOf(ReportReporter);
+    });
+  });
+
+  describe('unknown mode', () => {
+    it('throws', () => {
+      expect(() =>
+        factory.create('garbage' as ModeEnum, baseOptions(), false),
+      ).toThrow('Unknown mode type');
+    });
+  });
+});

--- a/qase-javascript-commons/test/qase/status-processor.test.ts
+++ b/qase-javascript-commons/test/qase/status-processor.test.ts
@@ -1,0 +1,84 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-assertion, @typescript-eslint/require-await */
+import { expect } from '@jest/globals';
+import { StatusProcessor } from '../../src/qase/status-processor';
+import { TestResultType, TestStatusEnum } from '../../src/models';
+import { LoggerInterface } from '../../src/utils/logger';
+
+const silentLogger = (): jest.Mocked<LoggerInterface> => ({
+  log: jest.fn(),
+  logDebug: jest.fn(),
+  logError: jest.fn(),
+});
+
+const makeResult = (status: TestStatusEnum): TestResultType =>
+  ({
+    id: 'r1',
+    title: 'test',
+    execution: { status, duration: 10 } as any,
+  }) as unknown as TestResultType;
+
+describe('StatusProcessor', () => {
+  describe('status mapping', () => {
+    it('leaves status untouched when no mapping is provided', () => {
+      const p = new StatusProcessor(silentLogger(), undefined, undefined);
+      const r = makeResult(TestStatusEnum.passed);
+      const out = p.process(r);
+      expect(out).toBe(r);
+      expect(r.execution.status).toBe(TestStatusEnum.passed);
+    });
+
+    it('applies mapping rule to matching status', () => {
+      const p = new StatusProcessor(
+        silentLogger(),
+        { passed: TestStatusEnum.blocked },
+        undefined,
+      );
+      const r = makeResult(TestStatusEnum.passed);
+      p.process(r);
+      expect(r.execution.status).toBe(TestStatusEnum.blocked);
+    });
+
+    it('leaves status untouched when rule does not match', () => {
+      const p = new StatusProcessor(
+        silentLogger(),
+        { failed: TestStatusEnum.skipped },
+        undefined,
+      );
+      const r = makeResult(TestStatusEnum.passed);
+      p.process(r);
+      expect(r.execution.status).toBe(TestStatusEnum.passed);
+    });
+  });
+
+  describe('status filter', () => {
+    it('returns the result when filter is empty', () => {
+      const p = new StatusProcessor(silentLogger(), undefined, []);
+      const r = makeResult(TestStatusEnum.skipped);
+      expect(p.process(r)).toBe(r);
+    });
+
+    it('returns null when status is in the filter list', () => {
+      const p = new StatusProcessor(silentLogger(), undefined, ['skipped']);
+      const r = makeResult(TestStatusEnum.skipped);
+      expect(p.process(r)).toBeNull();
+    });
+
+    it('returns the result when status is not in the filter list', () => {
+      const p = new StatusProcessor(silentLogger(), undefined, ['skipped']);
+      const r = makeResult(TestStatusEnum.passed);
+      expect(p.process(r)).toBe(r);
+    });
+  });
+
+  describe('combined', () => {
+    it('filters by post-mapping status', () => {
+      const p = new StatusProcessor(
+        silentLogger(),
+        { passed: TestStatusEnum.skipped },
+        ['skipped'],
+      );
+      const r = makeResult(TestStatusEnum.passed);
+      expect(p.process(r)).toBeNull();
+    });
+  });
+});

--- a/qase-javascript-commons/test/reporters/shared/fallback-coordinator.test.ts
+++ b/qase-javascript-commons/test/reporters/shared/fallback-coordinator.test.ts
@@ -1,0 +1,218 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unnecessary-type-assertion, @typescript-eslint/require-await, @typescript-eslint/unbound-method */
+import { expect } from '@jest/globals';
+import {
+  FallbackCoordinator,
+} from '../../../src/reporters/shared/fallback-coordinator';
+import { InternalReporterInterface } from '../../../src/reporters';
+import { LoggerInterface } from '../../../src/utils/logger';
+
+const silentLogger = (): jest.Mocked<LoggerInterface> => ({
+  log: jest.fn(),
+  logDebug: jest.fn(),
+  logError: jest.fn(),
+});
+
+const makeReporter = (): jest.Mocked<InternalReporterInterface> => ({
+  addTestResult: jest.fn(),
+  publish: jest.fn(),
+  startTestRun: jest.fn(),
+  getTestResults: jest.fn().mockReturnValue([]),
+  setTestResults: jest.fn(),
+  sendResults: jest.fn(),
+  complete: jest.fn(),
+  uploadAttachment: jest.fn(),
+});
+
+describe('FallbackCoordinator', () => {
+  it('runs upstream when both reporters succeed', async () => {
+    const upstream = makeReporter();
+    const fallback = makeReporter();
+    upstream.publish.mockResolvedValue(undefined);
+
+    const coord = new FallbackCoordinator(silentLogger(), upstream, fallback);
+    await coord.run(r => r.publish(), 'publish');
+
+    expect(upstream.publish).toHaveBeenCalledTimes(1);
+    expect(fallback.publish).not.toHaveBeenCalled();
+    expect(coord.isUsingFallback()).toBe(false);
+    expect(coord.isDisabled()).toBe(false);
+  });
+
+  it('switches to fallback when upstream throws', async () => {
+    const upstream = makeReporter();
+    const fallback = makeReporter();
+    upstream.publish.mockRejectedValue(new Error('boom'));
+    upstream.getTestResults.mockReturnValue([{ id: 'x' } as any]);
+    fallback.publish.mockResolvedValue(undefined);
+
+    const coord = new FallbackCoordinator(silentLogger(), upstream, fallback);
+    await coord.run(r => r.publish(), 'publish');
+
+    expect(fallback.setTestResults).toHaveBeenCalledWith([{ id: 'x' }]);
+    expect(fallback.publish).toHaveBeenCalledTimes(1);
+    expect(coord.isUsingFallback()).toBe(true);
+    expect(coord.isDisabled()).toBe(false);
+  });
+
+  it('disables when upstream fails and no fallback is configured', async () => {
+    const upstream = makeReporter();
+    upstream.publish.mockRejectedValue(new Error('boom'));
+
+    const coord = new FallbackCoordinator(silentLogger(), upstream, undefined);
+    await coord.run(r => r.publish(), 'publish');
+
+    expect(coord.isDisabled()).toBe(true);
+    expect(coord.isUsingFallback()).toBe(false);
+  });
+
+  it('disables when both upstream and fallback fail', async () => {
+    const upstream = makeReporter();
+    const fallback = makeReporter();
+    upstream.publish.mockRejectedValue(new Error('boom-up'));
+    fallback.publish.mockRejectedValue(new Error('boom-fb'));
+
+    const coord = new FallbackCoordinator(silentLogger(), upstream, fallback);
+    await coord.run(r => r.publish(), 'publish');
+
+    expect(coord.isDisabled()).toBe(true);
+  });
+
+  it('skips upstream entirely once using fallback', async () => {
+    const upstream = makeReporter();
+    const fallback = makeReporter();
+    upstream.publish.mockRejectedValueOnce(new Error('boom'));
+    fallback.publish.mockResolvedValue(undefined);
+
+    const coord = new FallbackCoordinator(silentLogger(), upstream, fallback);
+    await coord.run(r => r.publish(), 'publish'); // triggers switch
+    await coord.run(r => r.publish(), 'publish'); // second call hits fallback only
+
+    expect(upstream.publish).toHaveBeenCalledTimes(1);
+    expect(fallback.publish).toHaveBeenCalledTimes(2);
+  });
+
+  it('is a no-op when disabled', async () => {
+    const upstream = makeReporter();
+    const coord = new FallbackCoordinator(silentLogger(), upstream, undefined);
+    coord.setDisabled(true);
+
+    await coord.run(r => r.publish(), 'publish');
+
+    expect(upstream.publish).not.toHaveBeenCalled();
+  });
+
+  it('invokes lifecycle callbacks', async () => {
+    const upstream = makeReporter();
+    const fallback = makeReporter();
+    upstream.publish.mockRejectedValue(new Error('boom'));
+    fallback.publish.mockResolvedValue(undefined);
+
+    const onUpstream = jest.fn();
+    const onActivated = jest.fn();
+
+    const coord = new FallbackCoordinator(silentLogger(), upstream, fallback, {
+      onUpstreamFailure: onUpstream,
+      onFallbackActivated: onActivated,
+    });
+    await coord.run(r => r.publish(), 'publish');
+
+    expect(onUpstream).toHaveBeenCalledTimes(1);
+    expect(onActivated).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the upstream result on success', async () => {
+    const upstream = makeReporter();
+    upstream.uploadAttachment.mockResolvedValue('hash-123');
+
+    const coord = new FallbackCoordinator(silentLogger(), upstream, undefined);
+    const result = await coord.run(r => r.uploadAttachment({} as any), 'upload');
+
+    expect(result).toBe('hash-123');
+  });
+
+  describe('reset', () => {
+    it('clears disabled and useFallback flags', async () => {
+      const upstream = makeReporter();
+      upstream.publish.mockRejectedValue(new Error('boom'));
+
+      const coord = new FallbackCoordinator(silentLogger(), upstream, undefined);
+      await coord.run(r => r.publish(), 'publish');
+      expect(coord.isDisabled()).toBe(true);
+
+      coord.reset();
+      expect(coord.isDisabled()).toBe(false);
+      expect(coord.isUsingFallback()).toBe(false);
+    });
+  });
+
+  describe('undefined upstream with fallback', () => {
+    it('routes run() to fallback without copying results', async () => {
+      const fallback = makeReporter();
+      fallback.publish.mockResolvedValue(undefined);
+
+      const coord = new FallbackCoordinator(silentLogger(), undefined, fallback);
+      await coord.run(r => r.publish(), 'publish');
+
+      expect(fallback.publish).toHaveBeenCalledTimes(1);
+      expect(fallback.setTestResults).not.toHaveBeenCalled();
+      expect(coord.isUsingFallback()).toBe(true);
+    });
+
+    it('disables when both upstream and fallback are undefined', async () => {
+      const coord = new FallbackCoordinator(silentLogger(), undefined, undefined);
+      const result = await coord.run(r => r.publish(), 'publish');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('onDisabled callback', () => {
+    it('fires once when upstream fails and no fallback is configured', async () => {
+      const upstream = makeReporter();
+      upstream.publish.mockRejectedValue(new Error('boom'));
+      const onDisabled = jest.fn();
+
+      const coord = new FallbackCoordinator(silentLogger(), upstream, undefined, { onDisabled });
+      await coord.run(r => r.publish(), 'publish');
+      await coord.run(r => r.publish(), 'publish'); // second call should not re-fire
+
+      expect(onDisabled).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires once when both upstream and fallback fail', async () => {
+      const upstream = makeReporter();
+      const fallback = makeReporter();
+      upstream.publish.mockRejectedValue(new Error('boom-up'));
+      fallback.publish.mockRejectedValue(new Error('boom-fb'));
+      const onDisabled = jest.fn();
+
+      const coord = new FallbackCoordinator(silentLogger(), upstream, fallback, { onDisabled });
+      await coord.run(r => r.publish(), 'publish');
+
+      expect(onDisabled).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire when setDisabled(true) is called manually', async () => {
+      const upstream = makeReporter();
+      const onDisabled = jest.fn();
+
+      const coord = new FallbackCoordinator(silentLogger(), upstream, undefined, { onDisabled });
+      coord.setDisabled(true);
+
+      expect(onDisabled).not.toHaveBeenCalled();
+    });
+
+    it('does not re-fire after reset() + new failure', async () => {
+      const upstream = makeReporter();
+      upstream.publish.mockRejectedValue(new Error('boom'));
+      const onDisabled = jest.fn();
+
+      const coord = new FallbackCoordinator(silentLogger(), upstream, undefined, { onDisabled });
+      await coord.run(r => r.publish(), 'publish');
+      coord.reset();
+      await coord.run(r => r.publish(), 'publish');
+
+      expect(onDisabled).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/qase-javascript-commons/test/reporters/shared/testops-url.test.ts
+++ b/qase-javascript-commons/test/reporters/shared/testops-url.test.ts
@@ -1,0 +1,24 @@
+import { expect } from '@jest/globals';
+import { resolveTestOpsBaseUrl } from '../../../src/reporters/shared/testops-url';
+
+describe('resolveTestOpsBaseUrl', () => {
+  it('returns default app URL when host is undefined', () => {
+    expect(resolveTestOpsBaseUrl(undefined)).toBe('https://app.qase.io');
+  });
+
+  it('returns default app URL for canonical "qase.io" host', () => {
+    expect(resolveTestOpsBaseUrl('qase.io')).toBe('https://app.qase.io');
+  });
+
+  it('rewrites "api" subdomain to "app" for custom hosts', () => {
+    expect(resolveTestOpsBaseUrl('api.custom.example')).toBe('https://app.custom.example');
+  });
+
+  it('prepends https scheme even when host has no "api" substring', () => {
+    expect(resolveTestOpsBaseUrl('staging.example')).toBe('https://staging.example');
+  });
+
+  it('handles empty string as undefined', () => {
+    expect(resolveTestOpsBaseUrl('')).toBe('https://app.qase.io');
+  });
+});

--- a/qase-javascript-commons/test/utils/token-masker.test.ts
+++ b/qase-javascript-commons/test/utils/token-masker.test.ts
@@ -1,0 +1,47 @@
+import { expect } from '@jest/globals';
+import { maskToken, sanitizeOptionsForLog } from '../../src/utils/token-masker';
+
+describe('maskToken', () => {
+  it('replaces characters with asterisks when token is 7 chars or shorter', () => {
+    expect(maskToken('')).toBe('');
+    expect(maskToken('abc')).toBe('***');
+    expect(maskToken('abcdefg')).toBe('*******');
+  });
+
+  it('keeps first 3 + last 4 chars for longer tokens', () => {
+    expect(maskToken('abcdefgh')).toBe('abc****efgh');
+    expect(maskToken('abcdefghijklmno')).toBe('abc****lmno');
+  });
+});
+
+describe('sanitizeOptionsForLog', () => {
+  it('masks testops.api.token when present', () => {
+    const input = {
+      testops: { api: { token: 'abcdefghij', host: 'qase.io' } },
+      other: 42,
+    };
+    const out = sanitizeOptionsForLog(input);
+    expect(out.testops.api.token).toBe('abc****ghij');
+    expect(out.testops.api.host).toBe('qase.io');
+    expect(out.other).toBe(42);
+  });
+
+  it('returns deep clone — does not mutate input', () => {
+    const input = { testops: { api: { token: 'abcdefghij' } } };
+    const out = sanitizeOptionsForLog(input);
+    expect(input.testops.api.token).toBe('abcdefghij');
+    expect(out).not.toBe(input);
+  });
+
+  it('is a no-op when no token is present', () => {
+    const input = { testops: { api: { host: 'qase.io' } }, mode: 'report' };
+    const out = sanitizeOptionsForLog(input);
+    expect(out).toEqual(input);
+  });
+
+  it('is a no-op when testops block is missing entirely', () => {
+    const input = { mode: 'report' };
+    const out = sanitizeOptionsForLog(input);
+    expect(out).toEqual(input);
+  });
+});


### PR DESCRIPTION
## Summary

Refactor internals of `qase-javascript-commons` without changing its public API. Three goals:
1. Eliminate duplication (shared constants, URL resolver, fallback cascade)
2. Decompose the 682-line `QaseReporter` God class into focused, testable components
3. Extract spec-compliant report serialization into its own module

**All public exports, method signatures, option shapes, env vars and JSON output formats are preserved verbatim.** Only the internal organization changes.

## Key changes

### New shared building blocks
- `src/reporters/shared/testops-constants.ts` — `DEFAULT_BATCH_SIZE` (replaced 2 copies)
- `src/reporters/shared/testops-url.ts` — `resolveTestOpsBaseUrl()` pure function (replaced 2 identical private methods)
- `src/reporters/shared/fallback-coordinator.ts` — encapsulates the upstream→fallback→disabled cascade (replaced 5 repeated try/catch blocks in `qase.ts`); supports `reset()`, `onDisabled` callback, auto-routing when upstream is undefined
- `src/utils/token-masker.ts` — `maskToken` + `sanitizeOptionsForLog`
- `src/formatter/report-serializer.ts` — pure spec-compliant result/step/attachment serializer (RSLT-01/02, STEP-01/02/03)

### New orchestrator components
- `src/qase/options-resolver.ts` — env + config composition, state restore, `withState` detection
- `src/qase/reporter-factory.ts` — mode-based reporter creation (replaces the inline switch in `QaseReporter.createReporter`)
- `src/qase/status-processor.ts` — status mapping + filtering

### `QaseReporter` rewritten as thin orchestrator
- `src/qase.ts`: **682 → 305 lines** (-55%)
- Delegates to `OptionsResolver`, `ReporterFactory`, `StatusProcessor`, `FallbackCoordinator`
- Public `ReporterInterface` and all `QaseReporter` method signatures preserved verbatim

### `ReportReporter` refactored
- `src/reporters/report-reporter.ts`: **331 → 189 lines** (-43%)
- Serialization methods (`serializeResultForReport`, `serializeSteps`, `serializeStep`, `serializeStepData`, `serializeAttachment`, `transformGroupParams`) moved into `ReportSerializer`
- Constructor accepts optional `serializer: ReportSerializerInterface = new ReportSerializer()` — existing callers unchanged

### Bonus bug fixes (discovered during code review of Task 8)
Three pre-existing bugs in the original `QaseReporter` were incidentally corrected by the rewrite:
1. Constructor upstream-failure logic was inverted — disabled when a fallback was configured instead of using it
2. `publish()` double-called upstream after fallback when already in fallback mode
3. `addTestResultToFallback` disabled state without checking `withState` guard

## Test plan

- [x] `npm test --workspace=qase-javascript-commons` — **389/389 passed** (was 326, +63 new unit tests)
- [x] `npm run build --workspace=qase-javascript-commons` — clean compile
- [x] `npm test --workspaces` — all workspaces pass (one pre-existing failure in a framework package, unchanged from `main`)
- [x] No new lint errors (same 58 errors as baseline; 6 fewer warnings)
- [x] No deletions in `src/index.ts` (public API surface intact)
- [x] `git diff main -- qase-javascript-commons/src/index.ts` is empty

## Stats

- 11 commits (one per logical task, TDD with tests-first discipline)
- +1554 insertions, -738 deletions across 20 files
- 7 new test suites, 63 new tests
