### PR TITLE
fix(commons): handle undefined tags in ResultTransformer

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.6.5
+
+## Bug fixes
+
+- Fixed `TypeError: Cannot read properties of undefined (reading 'length')` when publishing test results. The `ResultTransformer` now safely handles missing `tags` property on test results created as plain object literals by framework reporters (jest, cypress, playwright, cucumberjs, newman, testcafe, wdio).
+
 # qase-javascript-commons@2.6.3
 
 ## Internal refactoring

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/client/services/result-transformer.ts
+++ b/qase-javascript-commons/src/client/services/result-transformer.ts
@@ -65,7 +65,7 @@ export class ResultTransformer {
       signature: result.signature,
     };
 
-    if (result.tags.length > 0) {
+    if (result.tags && result.tags.length > 0) {
       model.fields = {
         ...model.fields,
         tags: [...new Set(result.tags)].join(','),

--- a/qase-javascript-commons/test/client/services/result-transformer.test.ts
+++ b/qase-javascript-commons/test/client/services/result-transformer.test.ts
@@ -83,6 +83,13 @@ describe('ResultTransformer', () => {
       expect(model.testops_ids).toBeNull();
     });
 
+    it('should handle undefined tags', async () => {
+      const result = makeResult();
+      delete result.tags;
+      const model = await transformer.transform(result, mockUploader);
+      expect(model.fields.tags).toBeUndefined();
+    });
+
     it('should merge tags into fields', async () => {
       const model = await transformer.transform(
         makeResult({ tags: ['smoke', 'regression', 'smoke'] }),


### PR DESCRIPTION
## Summary

- Fixed `TypeError: Cannot read properties of undefined (reading 'length')` in `ResultTransformer.transform()` that broke jest-qase-reporter@2.3.0 (and potentially other reporters)
- Root cause: framework reporters create `TestResultType` as plain object literals (via `as unknown as TestResultType`) without `tags` field, bypassing the class constructor that initializes `tags = []`
- Added guard check `result.tags && result.tags.length > 0` before accessing the property
- Bumped qase-javascript-commons to 2.6.5

## Test plan

- [x] Added unit test for `undefined` tags scenario
- [x] All 456 existing tests pass
- [ ] Verify with jest-qase-reporter end-to-end