### PR TITLE
fix(commons): treat Playwright timedOut/interrupted as failed

### DIFF
--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+# qase-javascript-commons@2.6.6
+
+## Bug fixes
+
+- Fixed Playwright timeout tests being reported as `invalid` instead of `failed`. When Playwright reports a test with `timedOut` or `interrupted` status, the `determineTestStatus` function now returns `failed` directly, bypassing the error-message heuristic that previously misclassified timeout errors as non-assertion (infrastructure) failures. Other reporters (Cypress, Jest, Mocha, TestCafe) are unaffected because they do not use these runner-specific status values.
+
 # qase-javascript-commons@2.6.5
 
 ## Bug fixes

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/utils/test-status-utils.ts
+++ b/qase-javascript-commons/src/utils/test-status-utils.ts
@@ -12,6 +12,14 @@ export function determineTestStatus(error: Error | null, originalStatus: string)
     return mapOriginalStatus(originalStatus);
   }
 
+  // When the test runner explicitly reports timeout or interruption,
+  // treat as failed regardless of error content.
+  // (e.g. Playwright's timedOut/interrupted statuses)
+  const normalizedStatus = originalStatus.toLowerCase();
+  if (normalizedStatus === 'timedout' || normalizedStatus === 'interrupted') {
+    return TestStatusEnum.failed;
+  }
+
   // Check if it's an assertion error
   if (isAssertionError(error, originalStatus)) {
     return TestStatusEnum.failed;

--- a/qase-javascript-commons/test/utils/test-status-utils.test.ts
+++ b/qase-javascript-commons/test/utils/test-status-utils.test.ts
@@ -217,6 +217,32 @@ describe('determineTestStatus', () => {
     });
   });
 
+  describe('when runner reports timedOut or interrupted status', () => {
+    it('should return failed for timedOut with timeout error (Playwright test timeout)', () => {
+      const error = new Error('Test timeout of 2000ms exceeded.');
+      const result = determineTestStatus(error, 'timedOut');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for timedOut with navigation timeout error', () => {
+      const error = new Error('page.waitForTimeout: Timeout 5000ms exceeded.');
+      const result = determineTestStatus(error, 'timedOut');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should return failed for interrupted with error', () => {
+      const error = new Error('Test was interrupted due to maxFailures limit');
+      const result = determineTestStatus(error, 'interrupted');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+
+    it('should handle case-insensitive timedOut status', () => {
+      const error = new Error('Test timeout of 2000ms exceeded.');
+      const result = determineTestStatus(error, 'TIMEDOUT');
+      expect(result).toBe(TestStatusEnum.failed);
+    });
+  });
+
   describe('when non-assertion error', () => {
     it('should return invalid for network error', () => {
       const error = new Error('Network request failed');


### PR DESCRIPTION
## Summary

- Playwright tests that time out (`timedOut` status) were reported to Qase as `Invalid` instead of `Failed`
- Added early return in `determineTestStatus()`: when the test runner explicitly reports `timedOut` or `interrupted`, return `failed` directly — bypassing the error-message heuristic that misclassified timeout errors
- Other reporters (Cypress, Jest, Mocha, TestCafe) are unaffected — they don't use these Playwright-specific status values

## Test plan

- [x] Unit tests: 4 new tests in `test-status-utils.test.ts` (timedOut with error, navigation timeout, interrupted, case-insensitive)
- [x] All 460 commons tests pass
- [x] All 65 playwright reporter tests pass
- [x] E2E: Playwright test with `test.setTimeout(2000)` + `page.waitForTimeout(5000)` → reports `failed` (verified via `QASE_MODE=report` JSON output)
- [x] E2E: Cypress retry-timeout (`cy.get` with missing element) → still reports `failed` (no regression)