### PR TITLE
feat(commons): add internal subpath with shared reporter helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30442,7 +30442,7 @@
       }
     },
     "qase-api-client": {
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.15.0",
@@ -30528,6 +30528,30 @@
       "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "license": "MIT"
     },
+    "qase-cucumberjs/node_modules/qase-javascript-commons": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
+      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "async-mutex": "~0.5.0",
+        "chalk": "^4.1.2",
+        "env-schema": "^5.2.1",
+        "form-data": "^4.0.5",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.35",
+        "qase-api-client": "~1.1.1",
+        "qase-api-v2-client": "~1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "qase-cucumberjs/node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -30536,7 +30560,7 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "qase-javascript-commons": "~2.6.0",
@@ -30558,8 +30582,32 @@
         "cypress": ">=8.0.0"
       }
     },
+    "qase-cypress/node_modules/qase-javascript-commons": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
+      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "async-mutex": "~0.5.0",
+        "chalk": "^4.1.2",
+        "env-schema": "^5.2.1",
+        "form-data": "^4.0.5",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.35",
+        "qase-api-client": "~1.1.1",
+        "qase-api-v2-client": "~1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "qase-javascript-commons": {
-      "version": "2.6.3",
+      "version": "2.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -30627,6 +30675,30 @@
         "jest": ">=28.0.0"
       }
     },
+    "qase-jest/node_modules/qase-javascript-commons": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
+      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "async-mutex": "~0.5.0",
+        "chalk": "^4.1.2",
+        "env-schema": "^5.2.1",
+        "form-data": "^4.0.5",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.35",
+        "qase-api-client": "~1.1.1",
+        "qase-api-v2-client": "~1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
       "version": "1.3.0",
@@ -30645,6 +30717,30 @@
         "@typescript-eslint/parser": "^5.62.0",
         "eslint": "^8.57.1",
         "prettier": "^2.8.8"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "qase-mocha/node_modules/qase-javascript-commons": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
+      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "async-mutex": "~0.5.0",
+        "chalk": "^4.1.2",
+        "env-schema": "^5.2.1",
+        "form-data": "^4.0.5",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.35",
+        "qase-api-client": "~1.1.1",
+        "qase-api-v2-client": "~1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=14"
@@ -30734,9 +30830,33 @@
         "@playwright/test": ">=1.16.3"
       }
     },
+    "qase-playwright/node_modules/qase-javascript-commons": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
+      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "async-mutex": "~0.5.0",
+        "chalk": "^4.1.2",
+        "env-schema": "^5.2.1",
+        "form-data": "^4.0.5",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.35",
+        "qase-api-client": "~1.1.1",
+        "qase-api-v2-client": "~1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "qase-testcafe": {
       "name": "testcafe-reporter-qase",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "qase-javascript-commons": "~2.6.0",
@@ -30745,6 +30865,7 @@
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.14",
+        "ajv": "^8.18.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.4.5"
       },
@@ -30753,6 +30874,30 @@
       },
       "peerDependencies": {
         "testcafe": ">=2.0.0"
+      }
+    },
+    "qase-testcafe/node_modules/qase-javascript-commons": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
+      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "async-mutex": "~0.5.0",
+        "chalk": "^4.1.2",
+        "env-schema": "^5.2.1",
+        "form-data": "^4.0.5",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.35",
+        "qase-api-client": "~1.1.1",
+        "qase-api-v2-client": "~1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "qase-vitest": {
@@ -30775,6 +30920,30 @@
       },
       "peerDependencies": {
         "vitest": ">=3.0.0"
+      }
+    },
+    "qase-vitest/node_modules/qase-javascript-commons": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
+      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "async-mutex": "~0.5.0",
+        "chalk": "^4.1.2",
+        "env-schema": "^5.2.1",
+        "form-data": "^4.0.5",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.35",
+        "qase-api-client": "~1.1.1",
+        "qase-api-v2-client": "~1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "qase-wdio": {
@@ -30861,6 +31030,51 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "qase-wdio/node_modules/qase-javascript-commons": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
+      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "async-mutex": "~0.5.0",
+        "chalk": "^4.1.2",
+        "env-schema": "^5.2.1",
+        "form-data": "^4.0.5",
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.mergewith": "^4.6.2",
+        "mime-types": "^2.1.35",
+        "qase-api-client": "~1.1.1",
+        "qase-api-v2-client": "~1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "qase-wdio/node_modules/qase-javascript-commons/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "qase-wdio/node_modules/qase-javascript-commons/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "qase-wdio/node_modules/strip-ansi": {

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,11 @@
+## 2.7.0
+
+### Added
+- New internal subpath `qase-javascript-commons/internal` exposing helpers for use by Qase reporters in this monorepo: `removeQaseIdsFromTitle`, `extractAndCleanStep`, `getFile`, `parseQaseIdsFromString`, `normalizeSuitePart`. The `/internal` subpath is intended for Qase-owned reporter packages and may change without a major version bump.
+
+### Changed
+- `removeQaseIdsFromTitle` regex unified across reporters to `/\(Qase ID:? ([\d,]+)\)$/i`. This is more permissive than the previous mocha/wdio variants (case-insensitive; also accepts `(Qase ID 1)` without colon) and adds a trailing-position anchor (`$`).
+
 # qase-javascript-commons@2.6.6
 
 ## Bug fixes

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.6.6",
+  "version": "2.7.0",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -13,11 +13,16 @@
       "types": "./dist/profilers/index.d.ts",
       "default": "./dist/profilers/index.js"
     },
+    "./internal": {
+      "types": "./dist/internal/index.d.ts",
+      "default": "./dist/internal/index.js"
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {
-      "profilers": ["./dist/profilers/index.d.ts"]
+      "profilers": ["./dist/profilers/index.d.ts"],
+      "internal": ["./dist/internal/index.d.ts"]
     }
   },
   "homepage": "https://github.com/qase-tms/qase-javascript",

--- a/qase-javascript-commons/src/internal/ids-parser.ts
+++ b/qase-javascript-commons/src/internal/ids-parser.ts
@@ -1,0 +1,15 @@
+/**
+ * Parses a comma-separated string of Qase IDs into an array of numbers.
+ * Whitespace around each entry is trimmed; non-numeric entries are skipped.
+ *
+ * Examples: "1,2,3" → [1, 2, 3], "42" → [42], "" → [].
+ */
+export function parseQaseIdsFromString(value: string): number[] {
+  if (!value?.trim()) {
+    return [];
+  }
+  return value
+    .split(',')
+    .map((part) => parseInt(part.trim(), 10))
+    .filter((n) => !Number.isNaN(n));
+}

--- a/qase-javascript-commons/src/internal/index.ts
+++ b/qase-javascript-commons/src/internal/index.ts
@@ -1,0 +1,7 @@
+export { removeQaseIdsFromTitle } from './title';
+export { extractAndCleanStep } from './step-parser';
+export type { ExtractedStep } from './step-parser';
+export { getFile } from './suite-file';
+export type { FileSuiteNode } from './suite-file';
+export { parseQaseIdsFromString } from './ids-parser';
+export { normalizeSuitePart } from './suite-normalizer';

--- a/qase-javascript-commons/src/internal/step-parser.ts
+++ b/qase-javascript-commons/src/internal/step-parser.ts
@@ -1,0 +1,36 @@
+export interface ExtractedStep {
+  expectedResult: string | null;
+  data: string | null;
+  cleanedString: string;
+}
+
+/**
+ * Parses a step string for inline `QaseExpRes:` (expected result) and `QaseData:`
+ * (data) markers. Returns the extracted parts and the input string with markers
+ * removed. If no markers are present, returns nulls and the original string.
+ */
+export function extractAndCleanStep(input: string): ExtractedStep {
+  let expectedResult: string | null = null;
+  let data: string | null = null;
+  let cleanedString = input;
+
+  const hasExpectedResult = input.includes('QaseExpRes:');
+  const hasData = input.includes('QaseData:');
+
+  if (hasExpectedResult || hasData) {
+    const regex = /QaseExpRes:\s*:?\s*(.*?)\s*(?=QaseData:|$)QaseData:\s*:?\s*(.*)?/;
+    const match = input.match(regex);
+
+    if (match) {
+      expectedResult = match[1]?.trim() ?? null;
+      data = match[2]?.trim() ?? null;
+
+      cleanedString = input
+        .replace(/QaseExpRes:\s*:?\s*.*?(?=QaseData:|$)/, '')
+        .replace(/QaseData:\s*:?\s*.*/, '')
+        .trim();
+    }
+  }
+
+  return { expectedResult, data, cleanedString };
+}

--- a/qase-javascript-commons/src/internal/suite-file.ts
+++ b/qase-javascript-commons/src/internal/suite-file.ts
@@ -1,0 +1,22 @@
+/**
+ * Minimal structural shape compatible with both Mocha's `Suite` (used by
+ * qase-mocha) and Cypress's runner Suite (used by qase-cypress).
+ */
+export interface FileSuiteNode {
+  file?: string;
+  parent?: FileSuiteNode;
+}
+
+/**
+ * Walks up `node.parent` until a node with a non-empty `file` property is
+ * reached. Returns the file path, or undefined if no ancestor has one.
+ */
+export function getFile(node: FileSuiteNode): string | undefined {
+  if (node.file) {
+    return node.file;
+  }
+  if (node.parent) {
+    return getFile(node.parent);
+  }
+  return undefined;
+}

--- a/qase-javascript-commons/src/internal/suite-normalizer.ts
+++ b/qase-javascript-commons/src/internal/suite-normalizer.ts
@@ -1,0 +1,8 @@
+/**
+ * Lowercases the input and replaces every whitespace character with an
+ * underscore. Used by reporters to normalize suite/title segments before
+ * passing them into `generateSignature`.
+ */
+export function normalizeSuitePart(value: string): string {
+  return value.toLowerCase().replace(/\s/g, '_');
+}

--- a/qase-javascript-commons/src/internal/title.ts
+++ b/qase-javascript-commons/src/internal/title.ts
@@ -1,0 +1,13 @@
+const QASE_ID_TRAILER_REGEXP = /\(Qase ID:? ([\d,]+)\)$/i;
+
+/**
+ * Strips a trailing `(Qase ID: 1,2,3)` (or `(Qase ID 1)` without colon) from a test title.
+ * Returns the original title untouched if no match is found.
+ */
+export function removeQaseIdsFromTitle(title: string): string {
+  const match = title.match(QASE_ID_TRAILER_REGEXP);
+  if (match) {
+    return title.replace(match[0], '').trimEnd();
+  }
+  return title;
+}

--- a/qase-javascript-commons/test/internal/ids-parser.test.ts
+++ b/qase-javascript-commons/test/internal/ids-parser.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from '@jest/globals';
+import { parseQaseIdsFromString } from '../../src/internal/ids-parser';
+
+describe('parseQaseIdsFromString', () => {
+  it('parses a single id', () => {
+    expect(parseQaseIdsFromString('42')).toEqual([42]);
+  });
+
+  it('parses a comma-separated list', () => {
+    expect(parseQaseIdsFromString('1,2,3')).toEqual([1, 2, 3]);
+  });
+
+  it('trims whitespace around ids', () => {
+    expect(parseQaseIdsFromString(' 1 , 2 , 3 ')).toEqual([1, 2, 3]);
+  });
+
+  it('skips entries that are not numeric', () => {
+    expect(parseQaseIdsFromString('1,abc,3')).toEqual([1, 3]);
+  });
+
+  it('returns an empty array for an empty string', () => {
+    expect(parseQaseIdsFromString('')).toEqual([]);
+  });
+
+  it('returns an empty array for a whitespace-only string', () => {
+    expect(parseQaseIdsFromString('   ')).toEqual([]);
+  });
+});

--- a/qase-javascript-commons/test/internal/step-parser.test.ts
+++ b/qase-javascript-commons/test/internal/step-parser.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from '@jest/globals';
+import { extractAndCleanStep } from '../../src/internal/step-parser';
+
+describe('extractAndCleanStep', () => {
+  it('returns nulls and original string when no markers are present', () => {
+    expect(extractAndCleanStep('do something')).toEqual({
+      expectedResult: null,
+      data: null,
+      cleanedString: 'do something',
+    });
+  });
+
+  it('extracts both expected result and data', () => {
+    const result = extractAndCleanStep('click button QaseExpRes: button is highlighted QaseData: blue');
+    expect(result.expectedResult).toBe('button is highlighted');
+    expect(result.data).toBe('blue');
+    expect(result.cleanedString).toBe('click button');
+  });
+
+  it('handles double-colon variant', () => {
+    const result = extractAndCleanStep('step QaseExpRes:: yes QaseData:: data');
+    expect(result.expectedResult).toBe('yes');
+    expect(result.data).toBe('data');
+    expect(result.cleanedString).toBe('step');
+  });
+
+  it('returns nulls for empty input', () => {
+    expect(extractAndCleanStep('')).toEqual({
+      expectedResult: null,
+      data: null,
+      cleanedString: '',
+    });
+  });
+});

--- a/qase-javascript-commons/test/internal/suite-file.test.ts
+++ b/qase-javascript-commons/test/internal/suite-file.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from '@jest/globals';
+import { getFile, FileSuiteNode } from '../../src/internal/suite-file';
+
+describe('getFile', () => {
+  it('returns the suite file when present on the node itself', () => {
+    const suite: FileSuiteNode = { file: '/tests/foo.spec.ts' };
+    expect(getFile(suite)).toBe('/tests/foo.spec.ts');
+  });
+
+  it('walks up the parent chain', () => {
+    const root: FileSuiteNode = { file: '/tests/bar.spec.ts' };
+    const child: FileSuiteNode = { parent: root };
+    const grandchild: FileSuiteNode = { parent: child };
+    expect(getFile(grandchild)).toBe('/tests/bar.spec.ts');
+  });
+
+  it('returns undefined when no ancestor has a file', () => {
+    const root: FileSuiteNode = {};
+    const child: FileSuiteNode = { parent: root };
+    expect(getFile(child)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty leaf', () => {
+    expect(getFile({})).toBeUndefined();
+  });
+});

--- a/qase-javascript-commons/test/internal/suite-normalizer.test.ts
+++ b/qase-javascript-commons/test/internal/suite-normalizer.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@jest/globals';
+import { normalizeSuitePart } from '../../src/internal/suite-normalizer';
+
+describe('normalizeSuitePart', () => {
+  it('lowercases and replaces all whitespace with underscores', () => {
+    expect(normalizeSuitePart('Login Flow')).toBe('login_flow');
+  });
+
+  it('replaces every whitespace character (tabs, multiple spaces)', () => {
+    expect(normalizeSuitePart('a  b\tc')).toBe('a__b_c');
+  });
+
+  it('returns lowercased input for already-normalized strings', () => {
+    expect(normalizeSuitePart('LOGIN')).toBe('login');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(normalizeSuitePart('')).toBe('');
+  });
+});

--- a/qase-javascript-commons/test/internal/title.test.ts
+++ b/qase-javascript-commons/test/internal/title.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from '@jest/globals';
+import { removeQaseIdsFromTitle } from '../../src/internal/title';
+
+describe('removeQaseIdsFromTitle', () => {
+  it('strips a single Qase ID with colon at end', () => {
+    expect(removeQaseIdsFromTitle('login flow (Qase ID: 1)')).toBe('login flow');
+  });
+
+  it('strips a comma-separated id list at end', () => {
+    expect(removeQaseIdsFromTitle('login flow (Qase ID: 1,2,3)')).toBe('login flow');
+  });
+
+  it('accepts the optional colon variant', () => {
+    expect(removeQaseIdsFromTitle('login flow (Qase ID 42)')).toBe('login flow');
+  });
+
+  it('is case-insensitive', () => {
+    expect(removeQaseIdsFromTitle('login flow (qase id: 7)')).toBe('login flow');
+  });
+
+  it('only strips the trailing match, not mid-title', () => {
+    expect(removeQaseIdsFromTitle('foo (Qase ID: 1) bar')).toBe('foo (Qase ID: 1) bar');
+  });
+
+  it('returns the original title when nothing matches', () => {
+    expect(removeQaseIdsFromTitle('plain title')).toBe('plain title');
+  });
+
+  it('trims trailing whitespace after removal', () => {
+    expect(removeQaseIdsFromTitle('hello   (Qase ID: 9)')).toBe('hello');
+  });
+
+  it('handles empty string', () => {
+    expect(removeQaseIdsFromTitle('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- New `qase-javascript-commons/internal` subpath via `package.json` "exports" + `typesVersions`
- Five helpers extracted: `removeQaseIdsFromTitle`, `extractAndCleanStep`, `getFile`, `parseQaseIdsFromString`, `normalizeSuitePart`
- Each helper covered by Jest tests (commons total 455 → 486)
- Commons 2.6.6 → 2.7.0
- No public API change; no reporter changes (those land in follow-up PRs)
- Phase 1 of design `docs/superpowers/specs/2026-04-27-reporters-helper-extraction-design.md`

## Notes on behavioral changes
- `removeQaseIdsFromTitle` regex is now `/\(Qase ID:? ([\d,]+)\)$/i` — a union of the previous reporter-local variants. More permissive than previous mocha/wdio variants (case-insensitive; accepts `(Qase ID 1)` without colon) and adds a trailing-position anchor (`$`). Reporters will pick this up in follow-up PRs.
- `parseQaseIdsFromString` adds whitespace trimming and `NaN` filtering on top of the previous inline `split(',').map(parseInt)` logic in playwright/wdio.

## Test plan
- [x] `npm run build --workspace=qase-javascript-commons` succeeds
- [x] `npm test --workspace=qase-javascript-commons` is green (486 passed)
- [x] `node -e "require('qase-javascript-commons/internal')"` resolves and lists all five helpers