### PR TITLE
refactor(playwright): use shared helpers from commons/internal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30785,11 +30785,11 @@
     },
     "qase-playwright": {
       "name": "playwright-qase-reporter",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
-        "qase-javascript-commons": "~2.6.0",
+        "qase-javascript-commons": "~2.7.0",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -30804,30 +30804,6 @@
       },
       "peerDependencies": {
         "@playwright/test": ">=1.16.3"
-      }
-    },
-    "qase-playwright/node_modules/qase-javascript-commons": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
-      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "^8.18.0",
-        "async-mutex": "~0.5.0",
-        "chalk": "^4.1.2",
-        "env-schema": "^5.2.1",
-        "form-data": "^4.0.5",
-        "lodash.get": "^4.4.2",
-        "lodash.merge": "^4.6.2",
-        "lodash.mergewith": "^4.6.2",
-        "mime-types": "^2.1.35",
-        "qase-api-client": "~1.1.1",
-        "qase-api-v2-client": "~1.0.4",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "qase-testcafe": {

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,10 @@
+# playwright-qase-reporter@2.4.0
+
+## Changed
+
+- Bumped `qase-javascript-commons` to `~2.7.0`.
+- Internal: replaced local copies of `removeQaseIdsFromTitle` and `extractAndCleanStep` with imports from `qase-javascript-commons/internal`. `extractQaseIdsFromAnnotation` now delegates id-string parsing to `parseQaseIdsFromString` (also tolerates whitespace and skips non-numeric entries).
+
 # playwright-qase-reporter@2.3.0
 
 ## What's new

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.2",
-    "qase-javascript-commons": "~2.6.0",
+    "qase-javascript-commons": "~2.7.0",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-playwright/src/reporter.ts
+++ b/qase-playwright/src/reporter.ts
@@ -19,6 +19,11 @@ import {
   determineTestStatus,
   parseProjectMappingFromTitle,
 } from 'qase-javascript-commons';
+import {
+  removeQaseIdsFromTitle,
+  extractAndCleanStep,
+  parseQaseIdsFromString,
+} from 'qase-javascript-commons/internal';
 import { MetadataMessage, ReporterContentType } from './playwright';
 // Duplicated from fixture.ts to avoid importing @playwright/test in reporter context
 const PROFILER_CONTENT_TYPE = 'application/qase.profiler-steps+json';
@@ -283,7 +288,7 @@ export class PlaywrightQaseReporter implements Reporter {
 
       const attachments = this.stepAttachments.get(testStep);
 
-      const stepData = this.extractAndCleanStep(testStep.title);
+      const stepData = extractAndCleanStep(testStep.title);
 
       const id = uuidv4();
       const step: TestStepType = {
@@ -408,7 +413,7 @@ export class PlaywrightQaseReporter implements Reporter {
     }
 
     const titleParsed = parseProjectMappingFromTitle(test.title);
-    const testTitle = titleParsed.cleanedTitle || this.removeQaseIdsFromTitle(test.title);
+    const testTitle = titleParsed.cleanedTitle || removeQaseIdsFromTitle(test.title);
 
     const annotationProjectMapping = this.extractProjectMappingFromAnnotation(test.annotations);
     const ids = this.extractQaseIdsFromAnnotation(test.annotations);
@@ -556,19 +561,6 @@ export class PlaywrightQaseReporter implements Reporter {
   }
 
   /**
-   * @param {string} title
-   * @returns {string}
-   * @private
-   */
-  private removeQaseIdsFromTitle(title: string): string {
-    const matches = title.match(/\(Qase ID: ([0-9,]+)\)$/i);
-    if (matches) {
-      return title.replace(matches[0], '').trimEnd();
-    }
-    return title;
-  }
-
-  /**
    * @param annotation
    * @returns {number[]}
    * @private
@@ -577,15 +569,9 @@ export class PlaywrightQaseReporter implements Reporter {
     const ids: number[] = [];
     for (const item of annotation) {
       if (item.type.toLowerCase() === 'qaseid' && item.description) {
-        if (item.description.includes(',')) {
-          ids.push(...item.description.split(',').map((id) => parseInt(id)));
-          continue;
-        }
-
-        ids.push(parseInt(item.description));
+        ids.push(...parseQaseIdsFromString(item.description));
       }
     }
-
     return ids;
   }
 
@@ -642,36 +628,6 @@ export class PlaywrightQaseReporter implements Reporter {
     }
 
     return true;
-  }
-
-  private extractAndCleanStep(input: string): {
-    expectedResult: string | null;
-    data: string | null;
-    cleanedString: string
-  } {
-    let expectedResult: string | null = null;
-    let data: string | null = null;
-    let cleanedString = input;
-
-    const hasExpectedResult = input.includes('QaseExpRes:');
-    const hasData = input.includes('QaseData:');
-
-    if (hasExpectedResult || hasData) {
-      const regex = /QaseExpRes:\s*:?\s*(.*?)\s*(?=QaseData:|$)QaseData:\s*:?\s*(.*)?/;
-      const match = input.match(regex);
-
-      if (match) {
-        expectedResult = match[1]?.trim() ?? null;
-        data = match[2]?.trim() ?? null;
-
-        cleanedString = input
-          .replace(/QaseExpRes:\s*:?\s*.*?(?=QaseData:|$)/, '')
-          .replace(/QaseData:\s*:?\s*.*/, '')
-          .trim();
-      }
-    }
-
-    return { expectedResult, data, cleanedString };
   }
 
 }

--- a/qase-playwright/test/reporter.test.ts
+++ b/qase-playwright/test/reporter.test.ts
@@ -2,6 +2,7 @@
 import { expect } from '@jest/globals';
 import { PlaywrightQaseReporter } from '../src/reporter';
 import { ReporterContentType } from '../src/playwright';
+import { removeQaseIdsFromTitle, extractAndCleanStep } from 'qase-javascript-commons/internal';
 
 // Mocks for Playwright types
 const testCaseMock = {
@@ -259,8 +260,7 @@ describe('PlaywrightQaseReporter', () => {
   describe('extractAndCleanStep', () => {
     it('should extract expected result and data from step title', () => {
       const input = 'Click button QaseExpRes:: Button should be clicked QaseData:: Button data';
-      // @ts-ignore
-      const result = reporter['extractAndCleanStep'](input);
+      const result = extractAndCleanStep(input);
       expect(result.expectedResult).toBe('Button should be clicked');
       expect(result.data).toBe('Button data');
       expect(result.cleanedString).toBe('Click button');
@@ -268,8 +268,7 @@ describe('PlaywrightQaseReporter', () => {
 
     it('should handle step with only expected result', () => {
       const input = 'Click button QaseExpRes:: Button should be clicked QaseData:';
-      // @ts-ignore
-      const result = reporter['extractAndCleanStep'](input);
+      const result = extractAndCleanStep(input);
       expect(result.expectedResult).toBe('Button should be clicked');
       expect(result.data).toBe(null);
       expect(result.cleanedString).toBe('Click button');
@@ -277,8 +276,7 @@ describe('PlaywrightQaseReporter', () => {
 
     it('should handle step with only data', () => {
       const input = 'Click button QaseExpRes: QaseData:: Button data';
-      // @ts-ignore
-      const result = reporter['extractAndCleanStep'](input);
+      const result = extractAndCleanStep(input);
       expect(result.expectedResult).toBe('');
       expect(result.data).toBe('Button data');
       expect(result.cleanedString).toBe('Click button');
@@ -286,8 +284,7 @@ describe('PlaywrightQaseReporter', () => {
 
     it('should return original string if no QaseExpRes or QaseData', () => {
       const input = 'Click button';
-      // @ts-ignore
-      const result = reporter['extractAndCleanStep'](input);
+      const result = extractAndCleanStep(input);
       expect(result.expectedResult).toBe(null);
       expect(result.data).toBe(null);
       expect(result.cleanedString).toBe('Click button');
@@ -296,18 +293,15 @@ describe('PlaywrightQaseReporter', () => {
 
   describe('removeQaseIdsFromTitle', () => {
     it('should remove Qase ID from title', () => {
-      // @ts-ignore
-      const result = reporter['removeQaseIdsFromTitle']('Test (Qase ID: 123)');
+      const result = removeQaseIdsFromTitle('Test (Qase ID: 123)');
       expect(result).toBe('Test');
     });
     it('should remove multiple Qase IDs from title', () => {
-      // @ts-ignore
-      const result = reporter['removeQaseIdsFromTitle']('Test (Qase ID: 123,456)');
+      const result = removeQaseIdsFromTitle('Test (Qase ID: 123,456)');
       expect(result).toBe('Test');
     });
     it('should return original title if no Qase ID', () => {
-      // @ts-ignore
-      const result = reporter['removeQaseIdsFromTitle']('Test without ID');
+      const result = removeQaseIdsFromTitle('Test without ID');
       expect(result).toBe('Test without ID');
     });
   });


### PR DESCRIPTION
## Summary
- Replaces local copies of `removeQaseIdsFromTitle` and `extractAndCleanStep` with imports from `qase-javascript-commons/internal`
- Simplifies `extractQaseIdsFromAnnotation` by delegating id-string parsing to `parseQaseIdsFromString`
- Bumps commons pin `~2.6.0` -> `~2.7.0`
- Bumps `qase-playwright` version `2.3.0` -> `2.4.0`
- Phase 1 of design `docs/superpowers/specs/2026-04-27-reporters-helper-extraction-design.md`

## Smoke test
- [x] `npm run build/lint/test --workspace=qase-playwright` green
- [x] `examples/single/playwright` runs with `QASE_MODE=report` and produces a report