### PR TITLE
refactor(cypress): use shared helpers from commons/internal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30560,10 +30560,10 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.6.0",
+        "qase-javascript-commons": "~2.7.0",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -30580,30 +30580,6 @@
       },
       "peerDependencies": {
         "cypress": ">=8.0.0"
-      }
-    },
-    "qase-cypress/node_modules/qase-javascript-commons": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
-      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "^8.18.0",
-        "async-mutex": "~0.5.0",
-        "chalk": "^4.1.2",
-        "env-schema": "^5.2.1",
-        "form-data": "^4.0.5",
-        "lodash.get": "^4.4.2",
-        "lodash.merge": "^4.6.2",
-        "lodash.mergewith": "^4.6.2",
-        "mime-types": "^2.1.35",
-        "qase-api-client": "~1.1.1",
-        "qase-api-v2-client": "~1.0.4",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "qase-javascript-commons": {

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,10 @@
+# cypress-qase-reporter@3.5.0
+
+## Changed
+
+- Bumped `qase-javascript-commons` to `~2.7.0`.
+- Internal: replaced local copies of `removeQaseIdsFromTitle`, `getFile`, and the suite-part normalizer with imports from `qase-javascript-commons/internal`.
+
 # cypress-qase-reporter@3.4.0
 
 ## What's new

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -51,7 +51,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.6.0",
+    "qase-javascript-commons": "~2.7.0",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -21,6 +21,20 @@ import {
   parseProjectMappingFromTitle,
   parseProjectMappingFromTags,
 } from 'qase-javascript-commons';
+import {
+  removeQaseIdsFromTitle,
+  getFile as getFileFromNode,
+  normalizeSuitePart,
+  FileSuiteNode,
+} from 'qase-javascript-commons/internal';
+
+/**
+ * Adapter around the shared `getFile` helper to bridge the Mocha `Suite`
+ * type (whose `parent` is `Suite | undefined`) with `FileSuiteNode`
+ * (whose `parent` is optional under `exactOptionalPropertyTypes`).
+ */
+const getFile = (suite: Suite): string | undefined =>
+  getFileFromNode(suite as unknown as FileSuiteNode);
 
 import { configSchema } from './configSchema';
 import { ReporterOptionsType } from './options';
@@ -164,7 +178,7 @@ export class CypressQaseReporter extends reporters.Base {
    * @private
    */
   private getTestIdentifier(test: Test): string {
-    const file = test.parent ? this.getFile(test.parent) ?? '' : '';
+    const file = test.parent ? getFile(test.parent) ?? '' : '';
     const suitePath = test.parent ? test.parent.titlePath().join(' > ') : '';
     let testTitle = test.fullTitle();
     // Remove "before each" hook prefix and quotes if present (can be anywhere in the string)
@@ -283,7 +297,7 @@ export class CypressQaseReporter extends reporters.Base {
     // For skipped tests, we don't have metadata since the test never ran
     // But we can still check for cucumber tags if the test has a parent with a file
     if (test.parent) {
-      const file = this.getFile(test.parent);
+      const file = getFile(test.parent);
       if (file) {
         const tags = extractTags(file, test.title);
         const fromTags = parseProjectMappingFromTags(tags);
@@ -320,7 +334,7 @@ export class CypressQaseReporter extends reporters.Base {
         ? (legacyIds.length === 1 ? legacyIds[0]! : legacyIds)
         : null,
       testops_project_mapping: hasProjectMapping ? projectMapping : null,
-      title: fromTitle.cleanedTitle || this.removeQaseIdsFromTitle(test.title),
+      title: fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title),
       preparedAttachments: [],
     } as unknown as TestResultType;
 
@@ -422,7 +436,7 @@ export class CypressQaseReporter extends reporters.Base {
       steps.push(...this.convertCypressMessages(metadata.cucumberSteps, test.state ?? 'failed'));
 
       if (test.parent) {
-        const file = this.getFile(test.parent);
+        const file = getFile(test.parent);
 
         if (file) {
           const tags = extractTags(file, test.title);
@@ -484,7 +498,7 @@ export class CypressQaseReporter extends reporters.Base {
         ? (legacyIds.length === 1 ? legacyIds[0]! : legacyIds)
         : null,
       testops_project_mapping: hasProjectMapping ? projectMapping : null,
-      title: metadata?.title ?? (fromTitle.cleanedTitle || this.removeQaseIdsFromTitle(test.title)),
+      title: metadata?.title ?? (fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title)),
       preparedAttachments: [],
     } as unknown as TestResultType;
 
@@ -500,7 +514,7 @@ export class CypressQaseReporter extends reporters.Base {
    */
   private getSignature(test: Test, ids: number[], params: Record<string, string>) {
     const suites = [];
-    const file = test.parent ? this.getFile(test.parent) : undefined;
+    const file = test.parent ? getFile(test.parent) : undefined;
 
     if (file) {
       suites.push(file.split(path.sep).join('::'));
@@ -508,11 +522,11 @@ export class CypressQaseReporter extends reporters.Base {
 
     if (test.parent) {
       for (const suite of test.parent.titlePath()) {
-        suites.push(suite.toLowerCase().replace(/\s/g, '_'));
+        suites.push(normalizeSuitePart(suite));
       }
     }
 
-    suites.push(test.title.toLowerCase().replace(/\s/g, '_'));
+    suites.push(normalizeSuitePart(test.title));
 
     return generateSignature(ids, suites, params);
   }
@@ -522,7 +536,7 @@ export class CypressQaseReporter extends reporters.Base {
       return '';
     }
 
-    const file = this.getFile(test.parent);
+    const file = getFile(test.parent);
     if (!file) {
       return '';
     }
@@ -531,35 +545,6 @@ export class CypressQaseReporter extends reporters.Base {
     const fileName = pathParts[pathParts.length - 1];
 
     return fileName ? fileName : '';
-  }
-
-  /**
-   * @param {Suite} suite
-   * @private
-   */
-  private getFile(suite: Suite): string | undefined {
-    if (suite.file) {
-      return suite.file;
-    }
-
-    if (suite.parent) {
-      return this.getFile(suite.parent);
-    }
-
-    return undefined;
-  }
-
-  /**
-   * @param {string} title
-   * @returns {string}
-   * @private
-   */
-  private removeQaseIdsFromTitle(title: string): string {
-    const matches = title.match(/\(Qase ID: ([0-9,]+)\)$/i);
-    if (matches) {
-      return title.replace(matches[0], '').trimEnd();
-    }
-    return title;
   }
 
   private convertCypressMessages(messages: StepStart[], testStatus: string): TestStepType[] {


### PR DESCRIPTION
## Summary
- Replaces local copies of `removeQaseIdsFromTitle`, `getFile`, and the suite-part normalizer with imports from `qase-javascript-commons/internal`
- Bumps commons pin `~2.6.0` -> `~2.7.0`
- Bumps `qase-cypress` version `3.4.0` -> `3.5.0`
- Phase 1 of design `docs/superpowers/specs/2026-04-27-reporters-helper-extraction-design.md`

## Smoke test
- [x] `npm run build/lint/test --workspace=qase-cypress` green
- [x] `examples/single/cypress` runs with `QASE_MODE=report` and produces a report