### PR TITLE
refactor(mocha): use shared helpers from commons/internal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30653,12 +30653,12 @@
     },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "deasync-promise": "^1.0.1",
         "mocha": "^11.7.5",
-        "qase-javascript-commons": "~2.6.0",
+        "qase-javascript-commons": "~2.7.0",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -30669,30 +30669,6 @@
         "@typescript-eslint/parser": "^5.62.0",
         "eslint": "^8.57.1",
         "prettier": "^2.8.8"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "qase-mocha/node_modules/qase-javascript-commons": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
-      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "^8.18.0",
-        "async-mutex": "~0.5.0",
-        "chalk": "^4.1.2",
-        "env-schema": "^5.2.1",
-        "form-data": "^4.0.5",
-        "lodash.get": "^4.4.2",
-        "lodash.merge": "^4.6.2",
-        "lodash.mergewith": "^4.6.2",
-        "mime-types": "^2.1.35",
-        "qase-api-client": "~1.1.1",
-        "qase-api-v2-client": "~1.0.4",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=14"

--- a/qase-mocha/changelog.md
+++ b/qase-mocha/changelog.md
@@ -1,3 +1,10 @@
+# mocha-qase-reporter@1.4.0
+
+## Changed
+
+- Bumped `qase-javascript-commons` to `~2.7.0`.
+- Internal: replaced local copies of `removeQaseIdsFromTitle`, `extractAndCleanStep`, `getFile`, and the suite-part normalizer with imports from `qase-javascript-commons/internal`. Removed the deprecated static `qaseIdRegExp`. Note: `removeQaseIdsFromTitle` is now case-insensitive, requires the id segment at the end of the title, and accepts `(Qase ID 1)` without colon.
+
 # mocha-qase-reporter@1.3.0
 
 ## What's new

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -43,7 +43,7 @@
   "dependencies": {
     "mocha": "^11.7.5",
     "deasync-promise": "^1.0.1",
-    "qase-javascript-commons": "~2.6.0",
+    "qase-javascript-commons": "~2.7.0",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -15,6 +15,13 @@ import {
   determineTestStatus,
   parseProjectMappingFromTitle,
 } from 'qase-javascript-commons';
+import {
+  removeQaseIdsFromTitle,
+  extractAndCleanStep,
+  getFile as getFileFromNode,
+  FileSuiteNode,
+  normalizeSuitePart,
+} from 'qase-javascript-commons/internal';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
 import deasyncPromise from 'deasync-promise';
 import { extname, join } from 'node:path';
@@ -39,6 +46,14 @@ class currentTest {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return,@typescript-eslint/restrict-template-expressions
 const resolveParallelModeSetupFile = () => join(__dirname, `parallel${extname(__filename)}`);
+
+/**
+ * Adapter around the shared `getFile` helper to bridge the Mocha `Suite`
+ * type (whose `parent` is `Suite | undefined`) with `FileSuiteNode`
+ * (whose `parent` is optional under `exactOptionalPropertyTypes`).
+ */
+const getFile = (suite: Suite): string | undefined =>
+  getFileFromNode(suite as unknown as FileSuiteNode);
 
 export class MochaQaseReporter extends reporters.Base {
 
@@ -287,7 +302,7 @@ export class MochaQaseReporter extends reporters.Base {
       },
       testops_id: hasProjectMapping ? null : (ids.length > 0 ? ids : null),
       testops_project_mapping: hasProjectMapping ? fromTitle.projectMapping : null,
-      title: this.metadata.title && this.metadata.title != '' ? this.metadata.title : (fromTitle.cleanedTitle || this.removeQaseIdsFromTitle(test.title)),
+      title: this.metadata.title && this.metadata.title != '' ? this.metadata.title : (fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title)),
     } as TestResultType;
 
     void this.reporter.addTestResult(result);
@@ -303,7 +318,7 @@ export class MochaQaseReporter extends reporters.Base {
    */
   private getSignature(test: Mocha.Test, ids: number[], params: Record<string, string>) {
     const suites = [];
-    const file = test.parent ? this.getFile(test.parent) : undefined;
+    const file = test.parent ? getFile(test.parent) : undefined;
 
     if (file) {
       const executionPath = process.cwd() + '/';
@@ -313,29 +328,13 @@ export class MochaQaseReporter extends reporters.Base {
 
     if (test.parent) {
       for (const suite of test.parent.titlePath()) {
-        suites.push(suite.toLowerCase().replace(/\s/g, '_'));
+        suites.push(normalizeSuitePart(suite));
       }
     }
 
-    suites.push(test.title.toLowerCase().replace(/\s/g, '_'));
+    suites.push(normalizeSuitePart(test.title));
 
     return generateSignature(ids, suites, params);
-  }
-
-  /**
-   * @param {Suite} suite
-   * @private
-   */
-  private getFile(suite: Suite): string | undefined {
-    if (suite.file) {
-      return suite.file;
-    }
-
-    if (suite.parent) {
-      return this.getFile(suite.parent);
-    }
-
-    return undefined;
   }
 
   /**
@@ -430,7 +429,7 @@ export class MochaQaseReporter extends reporters.Base {
       ? `${title} QaseExpRes:${expectedResult ? `: ${expectedResult}` : ''} QaseData:${data ? `: ${data}` : ''}` 
       : title;
 
-    const stepData = this.extractAndCleanStep(stepTitle);
+    const stepData = extractAndCleanStep(stepTitle);
 
     const step: TestStepType = {
       step_type: StepType.TEXT,
@@ -463,59 +462,4 @@ export class MochaQaseReporter extends reporters.Base {
     this.currentTest.steps.push(step);
     this.currentType = previousType;
   };
-
-  /**
-   * @param {string} title
-   * @returns {string}
-   * @private
-   */
-  private removeQaseIdsFromTitle(title: string): string {
-    const matches = title.match(MochaQaseReporter.qaseIdRegExp);
-    if (matches) {
-      return title.replace(matches[0], '').trimEnd();
-    }
-    return title;
-  }
-
-  /**
-   * @type {RegExp}
-   */
-  /** @deprecated Use parseProjectMappingFromTitle from qase-javascript-commons for multi-project support. */
-  static qaseIdRegExp = /\(Qase ID: ([\d,]+)\)/;
-
-  /**
-   * Extract expected result and data from step title and return cleaned string
-   * @param {string} input
-   * @returns {{expectedResult: string | null, data: string | null, cleanedString: string}}
-   * @private
-   */
-  private extractAndCleanStep(input: string): {
-    expectedResult: string | null;
-    data: string | null;
-    cleanedString: string
-  } {
-    let expectedResult: string | null = null;
-    let data: string | null = null;
-    let cleanedString = input;
-
-    const hasExpectedResult = input.includes('QaseExpRes:');
-    const hasData = input.includes('QaseData:');
-
-    if (hasExpectedResult || hasData) {
-      const regex = /QaseExpRes:\s*:?\s*(.*?)\s*(?=QaseData:|$)QaseData:\s*:?\s*(.*)?/;
-      const match = input.match(regex);
-
-      if (match) {
-        expectedResult = match[1]?.trim() ?? null;
-        data = match[2]?.trim() ?? null;
-
-        cleanedString = input
-          .replace(/QaseExpRes:\s*:?\s*.*?(?=QaseData:|$)/, '')
-          .replace(/QaseData:\s*:?\s*.*/, '')
-          .trim();
-      }
-    }
-
-    return { expectedResult, data, cleanedString };
-  }
 }


### PR DESCRIPTION
## Summary
- Replaces local copies of \`removeQaseIdsFromTitle\`, \`extractAndCleanStep\`, \`getFile\`, and the suite-part normalizer with imports from \`qase-javascript-commons/internal\`
- Removes the deprecated static \`qaseIdRegExp\`
- Bumps commons pin \`~2.6.0\` -> \`~2.7.0\`
- Bumps \`qase-mocha\` version \`1.3.0\` -> \`1.4.0\`
- Phase 1 of design \`docs/superpowers/specs/2026-04-27-reporters-helper-extraction-design.md\`

## Smoke test
- [x] \`npm run build/lint/test --workspace=qase-mocha\` green
- [x] \`examples/single/mocha\` runs with \`QASE_MODE=report\` and produces a report

## Behavioral note
\`removeQaseIdsFromTitle\` is now case-insensitive, requires the id segment at the end of the title, and accepts \`(Qase ID 1)\` without colon. Previously mocha used a non-anchored, case-sensitive regex.