### PR TITLE
refactor(vitest): use extractAndCleanStep from commons/internal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30806,10 +30806,10 @@
     },
     "qase-vitest": {
       "name": "vitest-qase-reporter",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.6.0"
+        "qase-javascript-commons": "~2.7.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -30824,30 +30824,6 @@
       },
       "peerDependencies": {
         "vitest": ">=3.0.0"
-      }
-    },
-    "qase-vitest/node_modules/qase-javascript-commons": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
-      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "^8.18.0",
-        "async-mutex": "~0.5.0",
-        "chalk": "^4.1.2",
-        "env-schema": "^5.2.1",
-        "form-data": "^4.0.5",
-        "lodash.get": "^4.4.2",
-        "lodash.merge": "^4.6.2",
-        "lodash.mergewith": "^4.6.2",
-        "mime-types": "^2.1.35",
-        "qase-api-client": "~1.1.1",
-        "qase-api-v2-client": "~1.0.4",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "qase-wdio": {

--- a/qase-vitest/changelog.md
+++ b/qase-vitest/changelog.md
@@ -1,3 +1,10 @@
+# vitest-qase-reporter@1.3.0
+
+## Changed
+
+- Bumped `qase-javascript-commons` to `~2.7.0`.
+- Internal: replaced the local copy of `extractAndCleanStep` with the import from `qase-javascript-commons/internal`.
+
 # vitest-qase-reporter@1.2.0
 
 ## What's new

--- a/qase-vitest/package.json
+++ b/qase-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-qase-reporter",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Qase TMS Vitest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -45,7 +45,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.6.0"
+    "qase-javascript-commons": "~2.7.0"
   },
   "peerDependencies": {
     "vitest": ">=3.0.0"

--- a/qase-vitest/src/index.ts
+++ b/qase-vitest/src/index.ts
@@ -18,6 +18,7 @@ import {
   ConfigLoader,
 } from 'qase-javascript-commons';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
+import { extractAndCleanStep } from 'qase-javascript-commons/internal';
 
 export type VitestQaseOptionsType = ConfigType;
 
@@ -175,7 +176,7 @@ export class VitestQaseReporter implements Reporter {
         testResult.steps = metadata.steps.map(step => {
           const stepObj = new TestStepType();
           stepObj.id = Math.random().toString(36).substr(2, 9);
-          const stepData = this.extractAndCleanStep(step.name);
+          const stepData = extractAndCleanStep(step.name);
           stepObj.data = {
             action: stepData.cleanedString,
             expected_result: stepData.expectedResult,
@@ -444,37 +445,6 @@ export class VitestQaseReporter implements Reporter {
     // The test will be assigned to the default suite
     return undefined;
   }
-
-  private extractAndCleanStep(input: string): {
-    expectedResult: string | null;
-    data: string | null;
-    cleanedString: string
-  } {
-    let expectedResult: string | null = null;
-    let data: string | null = null;
-    let cleanedString = input;
-
-    const hasExpectedResult = input.includes('QaseExpRes:');
-    const hasData = input.includes('QaseData:');
-
-    if (hasExpectedResult || hasData) {
-      const regex = /QaseExpRes:\s*:?\s*(.*?)\s*(?=QaseData:|$)QaseData:\s*:?\s*(.*)?/;
-      const match = input.match(regex);
-
-      if (match) {
-        expectedResult = match[1]?.trim() ?? null;
-        data = match[2]?.trim() ?? null;
-
-        cleanedString = input
-          .replace(/QaseExpRes:\s*:?\s*.*?(?=QaseData:|$)/, '')
-          .replace(/QaseData:\s*:?\s*.*/, '')
-          .trim();
-      }
-    }
-
-    return { expectedResult, data, cleanedString };
-  }
-
 
 }
 


### PR DESCRIPTION
## Summary
- Replaces the local copy of `extractAndCleanStep` with the import from `qase-javascript-commons/internal`
- Bumps commons pin `~2.6.0` -> `~2.7.0`
- Bumps `qase-vitest` version `1.2.0` -> `1.3.0`
- Phase 1 of design `docs/superpowers/specs/2026-04-27-reporters-helper-extraction-design.md`

## Smoke test
- [x] `npm run build/lint/test --workspace=qase-vitest` green
- [x] `examples/single/vitest` runs with `QASE_MODE=report` and produces a report