### PR TITLE
refactor(testcafe): use normalizeSuitePart from commons/internal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30760,10 +30760,10 @@
     },
     "qase-testcafe": {
       "name": "testcafe-reporter-qase",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.6.0",
+        "qase-javascript-commons": "~2.7.0",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -30778,30 +30778,6 @@
       },
       "peerDependencies": {
         "testcafe": ">=2.0.0"
-      }
-    },
-    "qase-testcafe/node_modules/qase-javascript-commons": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
-      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "^8.18.0",
-        "async-mutex": "~0.5.0",
-        "chalk": "^4.1.2",
-        "env-schema": "^5.2.1",
-        "form-data": "^4.0.5",
-        "lodash.get": "^4.4.2",
-        "lodash.merge": "^4.6.2",
-        "lodash.mergewith": "^4.6.2",
-        "mime-types": "^2.1.35",
-        "qase-api-client": "~1.1.1",
-        "qase-api-v2-client": "~1.0.4",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "qase-vitest": {

--- a/qase-testcafe/changelog.md
+++ b/qase-testcafe/changelog.md
@@ -1,3 +1,10 @@
+# testcafe-reporter-qase@2.5.0
+
+## Changed
+
+- Bumped `qase-javascript-commons` to `~2.7.0`.
+- Internal: replaced inline suite-part normalization with `normalizeSuitePart` from `qase-javascript-commons/internal`.
+
 # testcafe-reporter-qase@2.4.0
 
 ## What's new

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-qase",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Qase TMS TestCafe Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -40,7 +40,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.6.0",
+    "qase-javascript-commons": "~2.7.0",
     "uuid": "^9.0.1"
   },
   "peerDependencies": {

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -14,6 +14,7 @@ import {
   TestResultType,
 } from 'qase-javascript-commons';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
+import { normalizeSuitePart } from 'qase-javascript-commons/internal';
 import { Qase } from './global';
 import { configSchema } from './configSchema';
 import { ReporterOptionsType } from './options';
@@ -398,8 +399,8 @@ export class TestcafeQaseReporter {
       suites.push(...path.split('/'));
     }
 
-    suites.push(fixture.name.toLowerCase().replace(/\s/g, '_'));
-    suites.push(title.toLowerCase().replace(/\s/g, '_'));
+    suites.push(normalizeSuitePart(fixture.name));
+    suites.push(normalizeSuitePart(title));
 
     return generateSignature(ids, suites, parameters);
   }


### PR DESCRIPTION
## Summary
- Replaces inline suite-part normalization with `normalizeSuitePart` from `qase-javascript-commons/internal`
- Bumps commons pin `~2.6.0` -> `~2.7.0`
- Bumps `qase-testcafe` version `2.4.0` -> `2.5.0`
- Phase 1 of design `docs/superpowers/specs/2026-04-27-reporters-helper-extraction-design.md`

## Smoke test
- [x] `npm run build/lint/test --workspace=qase-testcafe` green