### PR TITLE
refactor(wdio): use shared helpers from commons/internal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30804,13 +30804,13 @@
     },
     "qase-wdio": {
       "name": "wdio-qase-reporter",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@wdio/reporter": "^8.43.0",
         "@wdio/types": "^8.41.0",
         "csv-stringify": "^6.6.0",
-        "qase-javascript-commons": "~2.6.0",
+        "qase-javascript-commons": "~2.7.0",
         "strip-ansi": "^7.1.2",
         "uuid": "^9.0.1"
       },
@@ -30886,51 +30886,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "qase-wdio/node_modules/qase-javascript-commons": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.6.6.tgz",
-      "integrity": "sha512-Dw+L8s7L0p+kcAbHsUghhwcjRlU7+c2hCExz3hwlO2af9HeyahmkgRqGATGxDUMMF9iQJDM4DaM15JVpKo2QZg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "^8.18.0",
-        "async-mutex": "~0.5.0",
-        "chalk": "^4.1.2",
-        "env-schema": "^5.2.1",
-        "form-data": "^4.0.5",
-        "lodash.get": "^4.4.2",
-        "lodash.merge": "^4.6.2",
-        "lodash.mergewith": "^4.6.2",
-        "mime-types": "^2.1.35",
-        "qase-api-client": "~1.1.1",
-        "qase-api-v2-client": "~1.0.4",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "qase-wdio/node_modules/qase-javascript-commons/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "qase-wdio/node_modules/qase-javascript-commons/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "qase-wdio/node_modules/strip-ansi": {

--- a/qase-wdio/changelog.md
+++ b/qase-wdio/changelog.md
@@ -1,3 +1,11 @@
+# wdio-qase-reporter@1.4.0
+
+## Changed
+
+- Bumped `qase-javascript-commons` to `~2.7.0`.
+- Internal: replaced the local copy of `removeQaseIdsFromTitle` with the import from `qase-javascript-commons/internal`. Note: `removeQaseIdsFromTitle` is now case-insensitive, requires the id segment at the end of the title (anchored), and accepts `(Qase ID 1)` without colon.
+- Internal: `@qaseid` tag handling now delegates id-string parsing to `parseQaseIdsFromString` (tolerates whitespace; non-numeric entries are skipped).
+
 # wdio-qase-reporter@1.3.0
 
 ## What's new

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -35,7 +35,7 @@
     "@wdio/reporter": "^8.43.0",
     "@wdio/types": "^8.41.0",
     "csv-stringify": "^6.6.0",
-    "qase-javascript-commons": "~2.6.0",
+    "qase-javascript-commons": "~2.7.0",
     "strip-ansi": "^7.1.2",
     "uuid": "^9.0.1"
   }

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -25,6 +25,10 @@ import {
   parseProjectMappingFromTitle,
 } from 'qase-javascript-commons';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
+import {
+  removeQaseIdsFromTitle,
+  parseQaseIdsFromString,
+} from 'qase-javascript-commons/internal';
 
 import { v4 as uuidv4 } from 'uuid';
 import { Storage } from './storage';
@@ -43,11 +47,6 @@ import path from 'path';
 import { events } from './events';
 
 export default class WDIOQaseReporter extends WDIOReporter {
-    /**
-   * @type {RegExp}
-   */
-    static qaseIdRegExp = /\(Qase ID:? ([\d,]+)\)/;
-
   /**
    * @type {Record<string, TestStatusEnum>}
    */
@@ -169,7 +168,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
 
         switch (tagData.key.toLowerCase()) {
           case '@qaseid':
-            this.addQaseId({ ids: tagData.value.split(',').map((id) => parseInt(id)) });
+            this.addQaseId({ ids: parseQaseIdsFromString(tagData.value) });
             break;
           case '@title':
             this.addTitle({ title: tagData.value });
@@ -386,7 +385,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
     } else if (parsed.legacyIds.length > 0) {
       testResult.testops_id = parsed.legacyIds.length === 1 ? parsed.legacyIds[0]! : parsed.legacyIds;
     }
-    testResult.title = parsed.cleanedTitle || this.removeQaseIdsFromTitle(testResult.title);
+    testResult.title = parsed.cleanedTitle || removeQaseIdsFromTitle(testResult.title);
 
     // Merge profiler steps from direct fallback accumulator (same-process mode only)
     if (this.profiler) {
@@ -703,17 +702,4 @@ export default class WDIOQaseReporter extends WDIOReporter {
 
     return { key, value };
   }
-
-    /**
-   * @param {string} title
-   * @returns {string}
-   * @private
-   */
-    private removeQaseIdsFromTitle(title: string): string {
-      const matches = title.match(WDIOQaseReporter.qaseIdRegExp);
-      if (matches) {
-        return title.replace(matches[0], '').trimEnd();
-      }
-      return title;
-    }
 }


### PR DESCRIPTION
## Summary
- Replaces the local copy of `removeQaseIdsFromTitle` with the import from `qase-javascript-commons/internal`
- Removes the deprecated static `qaseIdRegExp`
- `@qaseid` tag handling now delegates id-string parsing to `parseQaseIdsFromString`
- Bumps commons pin `~2.6.0` -> `~2.7.0`
- Bumps `qase-wdio` version `1.3.0` -> `1.4.0`
- Phase 1 of design `docs/superpowers/specs/2026-04-27-reporters-helper-extraction-design.md` (final reporter migration)

## Smoke test
- [x] `npm run build/lint/test --workspace=qase-wdio` green

## Behavioral note
`removeQaseIdsFromTitle` is now case-insensitive, requires the id segment at the end of the title, and accepts `(Qase ID 1)` without colon. Previously wdio used a non-anchored, case-sensitive regex.