### PR TITLE
refactor(wdio): decompose reporter into focused modules

### DIFF
--- a/examples/single/wdio/test/specs/cart.spec.js
+++ b/examples/single/wdio/test/specs/cart.spec.js
@@ -54,7 +54,7 @@ describe('Cart Management', () => {
   });
 
   it(qase(9, 'User can remove product from cart'), async () => {
-    qase.fields({ severity: 'high', priority: 'high', layer: 'e2e' });
+    qase.fields({ severity: 'major', priority: 'high', layer: 'e2e' });
     qase.suite('E-commerce\tCart\tRemove Items');
 
     await qase.step('Add product to cart', async () => {
@@ -79,7 +79,7 @@ describe('Cart Management', () => {
   });
 
   it(qase(10, 'User can add multiple products to cart'), async () => {
-    qase.fields({ severity: 'medium', priority: 'medium', layer: 'e2e' });
+    qase.fields({ severity: 'normal', priority: 'medium', layer: 'e2e' });
     qase.suite('E-commerce\tCart\tMultiple Items');
 
     await qase.step('Add first product', async () => {

--- a/examples/single/wdio/test/specs/checkout.spec.js
+++ b/examples/single/wdio/test/specs/checkout.spec.js
@@ -22,7 +22,7 @@ describe('Checkout Flow', () => {
   });
 
   it(qase(11, 'User can complete checkout with valid information'), async () => {
-    qase.fields({ severity: 'critical', priority: 'critical', layer: 'e2e' });
+    qase.fields({ severity: 'critical', priority: 'high', layer: 'e2e' });
     qase.suite('E-commerce\tCheckout\tComplete Purchase');
     qase.parameters({ firstName: 'John', lastName: 'Doe', postalCode: '12345' });
 
@@ -70,7 +70,7 @@ describe('Checkout Flow', () => {
   });
 
   it(qase(12, 'Checkout fails without required information'), async () => {
-    qase.fields({ severity: 'high', priority: 'high', layer: 'e2e' });
+    qase.fields({ severity: 'major', priority: 'high', layer: 'e2e' });
     qase.suite('E-commerce\tCheckout\tValidation');
     qase.parameters({ scenario: 'missing_first_name' });
 
@@ -89,7 +89,7 @@ describe('Checkout Flow', () => {
   });
 
   it(qase(13, 'User can cancel checkout'), async () => {
-    qase.fields({ severity: 'low', priority: 'medium', layer: 'e2e' });
+    qase.fields({ severity: 'minor', priority: 'medium', layer: 'e2e' });
     qase.suite('E-commerce\tCheckout\tCancel');
 
     await qase.step('Fill partial information', async () => {

--- a/examples/single/wdio/test/specs/inventory.spec.js
+++ b/examples/single/wdio/test/specs/inventory.spec.js
@@ -50,7 +50,7 @@ describe('Product Inventory', () => {
   });
 
   it(qase(5, 'User can sort products by price'), async () => {
-    qase.fields({ severity: 'medium', priority: 'medium', layer: 'e2e' });
+    qase.fields({ severity: 'normal', priority: 'medium', layer: 'e2e' });
     qase.suite('E-commerce\tProduct Catalog\tSorting');
     qase.parameters({ sortOption: 'lohi' });
 
@@ -72,7 +72,7 @@ describe('Product Inventory', () => {
   });
 
   it(qase([6, 7], 'User can view product details'), async () => {
-    qase.fields({ severity: 'medium', priority: 'medium', layer: 'e2e' });
+    qase.fields({ severity: 'normal', priority: 'medium', layer: 'e2e' });
     qase.suite('E-commerce\tProduct Catalog\tDetails');
 
     let productName;

--- a/examples/single/wdio/test/specs/login.spec.js
+++ b/examples/single/wdio/test/specs/login.spec.js
@@ -32,7 +32,7 @@ describe('Login Scenarios', () => {
   });
 
   it(qase(2, 'User cannot login with invalid password'), async () => {
-    qase.fields({ severity: 'high', priority: 'high', layer: 'e2e' });
+    qase.fields({ severity: 'major', priority: 'high', layer: 'e2e' });
     qase.suite('E-commerce\tAuthentication\tLogin');
     qase.parameters({ username: 'standard_user', password: 'wrong_password' });
 
@@ -53,7 +53,7 @@ describe('Login Scenarios', () => {
   });
 
   it(qase(3, 'Locked user cannot login'), async () => {
-    qase.fields({ severity: 'high', priority: 'medium', layer: 'e2e' });
+    qase.fields({ severity: 'major', priority: 'medium', layer: 'e2e' });
     qase.suite('E-commerce\tAuthentication\tLogin');
     qase.parameters({ username: 'locked_out_user' });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30804,7 +30804,7 @@
     },
     "qase-wdio": {
       "name": "wdio-qase-reporter",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@wdio/reporter": "^8.43.0",

--- a/qase-wdio/changelog.md
+++ b/qase-wdio/changelog.md
@@ -1,3 +1,14 @@
+# wdio-qase-reporter@1.5.0
+
+## Changed
+
+- Internal: decomposed `WDIOQaseReporter` into focused modules — `TestLifecycle`, `MetadataApplier`, `CucumberTagAdapter`, `IpcBridge`, `CommandTracker`, `ResultFinalizer`. The reporter class now acts as a composition root with thin facades. Public contract unchanged: the default-exported `WDIOQaseReporter` class, all `WDIOReporter` lifecycle overrides, and the 11 instance methods used for `process.on` IPC bindings continue to work identically.
+- Added 50+ new unit tests covering each extracted module.
+
+## Fixed
+
+- After WebDriver commands, `Response` payloads are now correctly attached to the surrounding step and the step's `end_time` is now set. Previously `TestStepType` instances were created as object literals (cast to type), which caused `Storage.getCurrentStep()` (an `instanceof` check) to never find the step — so the `onAfterCommand` guard `!getCurrentStep()` silently early-returned and skipped both the `Response` attachment and `endStep` calls. The decomposition surfaced this latent bug; `TestLifecycle` now constructs steps via `new TestStepType(...)`, restoring the intended behavior.
+
 # wdio-qase-reporter@1.4.0
 
 ## Changed

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-wdio/src/command-tracker.ts
+++ b/qase-wdio/src/command-tracker.ts
@@ -1,0 +1,70 @@
+import { AfterCommandArgs, BeforeCommandArgs } from '@wdio/reporter';
+import { TestStepType } from 'qase-javascript-commons';
+import { NetworkProfiler } from 'qase-javascript-commons/profilers';
+import { TestLifecycle } from './lifecycle';
+import { Storage } from './storage';
+import { QaseReporterOptions } from './options';
+import { isEmpty, isScreenshotCommand } from './utils';
+
+export class CommandTracker {
+  private isMultiremote = false;
+  private profilerStepSnapshot = 0;
+
+  constructor(
+    private readonly lifecycle: TestLifecycle,
+    private readonly storage: Storage,
+    private readonly options: QaseReporterOptions,
+    private readonly profiler: NetworkProfiler | null,
+  ) {}
+
+  setMultiremote(value: boolean): void {
+    this.isMultiremote = value;
+  }
+
+  onBeforeCommand(command: BeforeCommandArgs): void {
+    if (!this.storage.getLastItem()) {
+      return;
+    }
+    if (this.options.disableWebdriverStepsReporting || this.isMultiremote) {
+      return;
+    }
+    const { method, endpoint } = command;
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    const stepName = command.command ? command.command : `${method} ${endpoint}`;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const payload = command.body || command.params;
+    this.lifecycle.startStep(stepName);
+    if (!isEmpty(payload)) {
+      this.lifecycle.attachJSON('Request', payload);
+    }
+  }
+
+  onAfterCommand(command: AfterCommandArgs): void {
+    const { disableWebdriverStepsReporting, disableWebdriverScreenshotsReporting } = this.options;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const commandResult: string | undefined = command.result.value || undefined;
+    const isScreenshot = isScreenshotCommand(command);
+    if (!disableWebdriverScreenshotsReporting && isScreenshot && commandResult) {
+      this.lifecycle.attachFile('Screenshot.png', Buffer.from(commandResult, 'base64'), 'image/png');
+    }
+    if (disableWebdriverStepsReporting || this.isMultiremote || !this.storage.getCurrentStep()) {
+      return;
+    }
+    this.lifecycle.attachJSON('Response', commandResult);
+    this.lifecycle.endStep();
+  }
+
+  takeProfilerSnapshot(): void {
+    this.profilerStepSnapshot = this.profiler?.getAllSteps().length ?? 0;
+  }
+
+  drainNewProfilerSteps(): TestStepType[] {
+    if (!this.profiler) {
+      return [];
+    }
+    const all = this.profiler.getAllSteps();
+    const slice = all.slice(this.profilerStepSnapshot);
+    this.profilerStepSnapshot = 0;
+    return slice;
+  }
+}

--- a/qase-wdio/src/cucumber-tags.ts
+++ b/qase-wdio/src/cucumber-tags.ts
@@ -1,0 +1,44 @@
+import { parseQaseIdsFromString } from 'qase-javascript-commons/internal';
+import { MetadataApplier } from './metadata';
+
+interface TagLike {
+  name: string;
+}
+
+export class CucumberTagAdapter {
+  constructor(private readonly metadata: MetadataApplier) {}
+
+  applyTags(tags: readonly TagLike[]): void {
+    for (const tag of tags) {
+      if (!tag.name.includes('=')) {
+        continue;
+      }
+      const parsed = parseTag(tag.name);
+      if (parsed === null) {
+        continue;
+      }
+      switch (parsed.key.toLowerCase()) {
+        case '@qaseid':
+          this.metadata.addQaseId({ ids: parseQaseIdsFromString(parsed.value) });
+          break;
+        case '@title':
+          this.metadata.addTitle({ title: parsed.value });
+          break;
+        case '@suite':
+          this.metadata.addSuite({ suite: parsed.value });
+          break;
+        case '@tags':
+          this.metadata.addTags({ tags: parsed.value.split(',').map((t) => t.trim()) });
+          break;
+      }
+    }
+  }
+}
+
+function parseTag(tag: string): { key: string; value: string } | null {
+  const [key, value] = tag.split('=');
+  if (!key || !value) {
+    return null;
+  }
+  return { key, value };
+}

--- a/qase-wdio/src/finalizer.ts
+++ b/qase-wdio/src/finalizer.ts
@@ -1,0 +1,108 @@
+import {
+  CompoundError,
+  Relation,
+  ReporterInterface,
+  TestStatusEnum,
+  determineTestStatus,
+  generateSignature,
+  parseProjectMappingFromTitle,
+} from 'qase-javascript-commons';
+import { removeQaseIdsFromTitle } from 'qase-javascript-commons/internal';
+import { Storage } from './storage';
+import { CommandTracker } from './command-tracker';
+import { IpcBridge } from './ipc';
+
+export class ResultFinalizer {
+  constructor(
+    private readonly storage: Storage,
+    private readonly upstream: ReporterInterface,
+    private readonly commandTracker: CommandTracker,
+    private readonly ipc: IpcBridge,
+  ) {}
+
+  async finalize(
+    status: TestStatusEnum,
+    err: CompoundError | null,
+    endTime: number = Date.now() / 1000,
+  ): Promise<void> {
+    const testResult = this.storage.getCurrentTest();
+    if (testResult === undefined || this.storage.ignore) {
+      return;
+    }
+
+    if (testResult.relations === null) {
+      const relations: Relation = {};
+      if (this.storage.suites.length > 0) {
+        relations.suite = {
+          data: this.storage.suites.map((suite) => ({ title: suite, public_id: null })),
+        };
+      }
+      testResult.relations = relations;
+    }
+
+    testResult.execution.duration = testResult.execution.start_time
+      ? Math.round(endTime - testResult.execution.start_time)
+      : 0;
+
+    let error: Error | null = null;
+    if (err) {
+      error = new Error(err.message || 'Test failed');
+      if (err.stacktrace) {
+        error.stack = err.stacktrace;
+      }
+    }
+    testResult.execution.status = determineTestStatus(error, status);
+
+    testResult.execution.stacktrace = err === null
+      ? null
+      : err.stacktrace === undefined
+        ? null
+        : err.stacktrace;
+
+    const errorMessage = err === null
+      ? null
+      : err.message === undefined
+        ? null
+        : err.message;
+
+    if (this.storage.comment) {
+      testResult.message = errorMessage
+        ? `${this.storage.comment}\n\n${errorMessage}`
+        : this.storage.comment;
+    } else {
+      testResult.message = errorMessage;
+    }
+
+    testResult.signature = generateSignature(
+      Array.isArray(testResult.testops_id)
+        ? testResult.testops_id
+        : testResult.testops_id
+          ? [testResult.testops_id]
+          : null,
+      [...this.storage.suites, testResult.title],
+      testResult.params,
+    );
+
+    const parsed = parseProjectMappingFromTitle(testResult.title);
+    const hasProjectMapping = Object.keys(parsed.projectMapping).length > 0;
+    if (hasProjectMapping) {
+      testResult.testops_project_mapping = parsed.projectMapping;
+      testResult.testops_id = null;
+    } else if (parsed.legacyIds.length > 0) {
+      testResult.testops_id = parsed.legacyIds.length === 1 ? parsed.legacyIds[0]! : parsed.legacyIds;
+    }
+    testResult.title = parsed.cleanedTitle || removeQaseIdsFromTitle(testResult.title);
+
+    const inProcessSteps = this.commandTracker.drainNewProfilerSteps();
+    if (inProcessSteps.length > 0) {
+      testResult.steps = [...testResult.steps, ...inProcessSteps];
+    }
+
+    const ipcSteps = this.ipc.drainProfilerSteps();
+    if (ipcSteps.length > 0) {
+      testResult.steps = [...testResult.steps, ...ipcSteps];
+    }
+
+    await this.upstream.addTestResult(testResult);
+  }
+}

--- a/qase-wdio/src/ipc.ts
+++ b/qase-wdio/src/ipc.ts
@@ -1,0 +1,47 @@
+import { TestStepType } from 'qase-javascript-commons';
+import { events } from './events';
+import { MetadataApplier } from './metadata';
+import {
+  AddAttachmentEventArgs,
+  AddCommentEventArgs,
+  AddQaseIdEventArgs,
+  AddRecordsEventArgs,
+  AddSuiteEventArgs,
+  AddTagsEventArgs,
+  AddTitleEventArgs,
+} from './models';
+
+export class IpcBridge {
+  private pendingProfilerSteps: TestStepType[] = [];
+
+  constructor(private readonly metadata: MetadataApplier) {}
+
+  registerListeners(): void {
+    process.on(events.addQaseID, (args: AddQaseIdEventArgs) => this.metadata.addQaseId(args));
+    process.on(events.addTitle, (args: AddTitleEventArgs) => this.metadata.addTitle(args));
+    process.on(events.addFields, (args: AddRecordsEventArgs) => this.metadata.addFields(args));
+    process.on(events.addSuite, (args: AddSuiteEventArgs) => this.metadata.addSuite(args));
+    process.on(events.addParameters, (args: AddRecordsEventArgs) => this.metadata.addParameters(args));
+    process.on(events.addGroupParameters, (args: AddRecordsEventArgs) => this.metadata.addGroupParameters(args));
+    process.on(events.addComment, (args: AddCommentEventArgs) => this.metadata.addComment(args));
+    process.on(events.addAttachment, (args: AddAttachmentEventArgs) => this.metadata.addAttachment(args));
+    process.on(events.addIgnore, () => this.metadata.ignore());
+    process.on(events.addStep, (step: TestStepType) => this.metadata.addStep(step));
+    process.on(events.addTags, (args: AddTagsEventArgs) => this.metadata.addTags(args));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    process.on(events.addProfilerSteps as any, (data: string) => {
+      try {
+        const steps = JSON.parse(data) as TestStepType[];
+        this.pendingProfilerSteps.push(...steps);
+      } catch {
+        // Corrupted profiler data must not affect test results.
+      }
+    });
+  }
+
+  drainProfilerSteps(): TestStepType[] {
+    const drained = this.pendingProfilerSteps;
+    this.pendingProfilerSteps = [];
+    return drained;
+  }
+}

--- a/qase-wdio/src/lifecycle.ts
+++ b/qase-wdio/src/lifecycle.ts
@@ -1,0 +1,73 @@
+import {
+  Attachment,
+  StepStatusEnum,
+  StepType,
+  TestResultType,
+  TestStatusEnum,
+  TestStepType,
+} from 'qase-javascript-commons';
+import { v4 as uuidv4 } from 'uuid';
+import { Storage } from './storage';
+
+export class TestLifecycle {
+  constructor(private readonly storage: Storage) {}
+
+  startTest(title: string, cid: string, startTime: number = Date.now() / 1000): void {
+    const result = new TestResultType(title);
+    result.execution.thread = cid;
+    result.execution.start_time = startTime;
+    result.id = uuidv4();
+    this.storage.push(result);
+  }
+
+  startStep(title: string): void {
+    const step = new TestStepType(StepType.TEXT);
+    step.id = uuidv4();
+    step.data = {
+      action: title,
+      expected_result: null,
+      data: null,
+    };
+    step.parent_id = this.storage.getLastItem()?.id ?? null;
+    step.execution.start_time = Date.now() / 1000;
+    step.execution.end_time = null;
+    step.execution.status = StepStatusEnum.passed;
+    step.execution.duration = null;
+
+    this.storage.getLastItem()?.steps.push(step);
+    this.storage.push(step);
+  }
+
+  endStep(status: TestStatusEnum = TestStatusEnum.passed): void {
+    if (!this.storage.getLastItem()) {
+      return;
+    }
+    const step = this.storage.pop();
+    if (!step) {
+      return;
+    }
+    step.execution.end_time = Date.now() / 1000;
+    step.execution.status = status;
+  }
+
+  attachJSON(name: string, json: unknown): void {
+    const isStr = typeof json === 'string';
+    const content = isStr ? json : JSON.stringify(json, null, 2);
+    this.attachFile(name, String(content), isStr ? 'application/json' : 'text/plain');
+  }
+
+  attachFile(name: string, content: string | Buffer, contentType: string): void {
+    if (!this.storage.getLastItem()) {
+      throw new Error("There isn't any active test!");
+    }
+    const attach: Attachment = {
+      file_path: null,
+      size: content.length,
+      id: uuidv4(),
+      file_name: name,
+      mime_type: contentType,
+      content,
+    };
+    this.storage.getLastItem()?.attachments.push(attach);
+  }
+}

--- a/qase-wdio/src/metadata.ts
+++ b/qase-wdio/src/metadata.ts
@@ -1,0 +1,119 @@
+import { Attachment, getMimeTypes, TestStepType } from 'qase-javascript-commons';
+import { v4 as uuidv4 } from 'uuid';
+import path from 'path';
+import { Storage } from './storage';
+import {
+  AddAttachmentEventArgs,
+  AddCommentEventArgs,
+  AddQaseIdEventArgs,
+  AddRecordsEventArgs,
+  AddSuiteEventArgs,
+  AddTagsEventArgs,
+  AddTitleEventArgs,
+} from './models';
+
+export class MetadataApplier {
+  constructor(private readonly storage: Storage) {}
+
+  addQaseId({ ids }: AddQaseIdEventArgs): void {
+    const cur = this.storage.getCurrentTest();
+    if (!cur) return;
+    cur.testops_id = ids;
+  }
+
+  addTitle({ title }: AddTitleEventArgs): void {
+    const cur = this.storage.getCurrentTest();
+    if (!cur) return;
+    cur.title = title;
+  }
+
+  addComment({ comment }: AddCommentEventArgs): void {
+    this.storage.comment = comment;
+  }
+
+  addSuite({ suite }: AddSuiteEventArgs): void {
+    const cur = this.storage.getCurrentTest();
+    if (!cur) return;
+    cur.relations = {
+      suite: {
+        data: [{ title: suite, public_id: null }],
+      },
+    };
+  }
+
+  addParameters({ records }: AddRecordsEventArgs): void {
+    const cur = this.storage.getCurrentTest();
+    if (!cur) return;
+    const stringRecord: Record<string, string> = {};
+    for (const [k, v] of Object.entries(records)) {
+      stringRecord[String(k)] = String(v);
+    }
+    cur.params = stringRecord;
+  }
+
+  addGroupParameters({ records }: AddRecordsEventArgs): void {
+    const cur = this.storage.getCurrentTest();
+    if (!cur) return;
+    const stringRecord: Record<string, string> = {};
+    for (const [k, v] of Object.entries(records)) {
+      stringRecord[String(k)] = String(v);
+    }
+    cur.group_params = stringRecord;
+  }
+
+  addFields({ records }: AddRecordsEventArgs): void {
+    const cur = this.storage.getCurrentTest();
+    if (!cur) return;
+    cur.fields = records;
+  }
+
+  addTags({ tags }: AddTagsEventArgs): void {
+    const cur = this.storage.getCurrentTest();
+    if (!cur) return;
+    cur.tags = [...cur.tags, ...tags];
+  }
+
+  addAttachment({ name, type, content, paths }: AddAttachmentEventArgs): void {
+    const cur = this.storage.getCurrentTest();
+    if (!cur) return;
+
+    if (paths) {
+      for (const file of paths) {
+        const attach: Attachment = {
+          file_path: file,
+          size: 0,
+          id: uuidv4(),
+          file_name: path.basename(file),
+          mime_type: getMimeTypes(file),
+          content: '',
+        };
+        cur.attachments.push(attach);
+      }
+      return;
+    }
+
+    if (content) {
+      const attach: Attachment = {
+        file_path: null,
+        size: content.length,
+        id: uuidv4(),
+        file_name: name ?? 'attachment',
+        mime_type: type ?? 'application/octet-stream',
+        content,
+      };
+      cur.attachments.push(attach);
+    }
+  }
+
+  ignore(): void {
+    const cur = this.storage.getCurrentTest();
+    if (!cur) return;
+    this.storage.ignore = true;
+  }
+
+  addStep(step: TestStepType): void {
+    const cur = this.storage.getLastItem();
+    if (!cur) return;
+    cur.steps.push(step);
+  }
+}

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -7,12 +7,10 @@ import WDIOReporter, {
   Tag,
 } from '@wdio/reporter';
 import {
-  Attachment,
   composeOptions,
   CompoundError,
   ConfigLoader,
   generateSignature,
-  getMimeTypes,
   QaseReporter,
   Relation,
   ReporterInterface,
@@ -27,9 +25,9 @@ import {
   parseQaseIdsFromString,
 } from 'qase-javascript-commons/internal';
 
-import { v4 as uuidv4 } from 'uuid';
 import { Storage } from './storage';
 import { TestLifecycle } from './lifecycle';
+import { MetadataApplier } from './metadata';
 import { QaseReporterOptions } from './options';
 import { isEmpty, isScreenshotCommand } from './utils';
 import {
@@ -41,7 +39,6 @@ import {
   AddTagsEventArgs,
   AddTitleEventArgs,
 } from './models';
-import path from 'path';
 import { events } from './events';
 
 export default class WDIOQaseReporter extends WDIOReporter {
@@ -64,6 +61,8 @@ export default class WDIOQaseReporter extends WDIOReporter {
   private storage: Storage;
 
   private lifecycle: TestLifecycle;
+
+  private metadata: MetadataApplier;
 
   /**
    * @type {boolean}
@@ -124,6 +123,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
     this.isSync = true;
     this.storage = new Storage();
     this.lifecycle = new TestLifecycle(this.storage);
+    this.metadata = new MetadataApplier(this.storage);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this._options = Object.assign(new QaseReporterOptions(), options);
 
@@ -473,155 +473,48 @@ export default class WDIOQaseReporter extends WDIOReporter {
     });
   }
 
-  addQaseId({ ids }: AddQaseIdEventArgs) {
-    const curTest = this.storage.getCurrentTest();
-    if (!curTest) {
-      return;
-    }
-
-    curTest.testops_id = ids;
+  addQaseId(args: AddQaseIdEventArgs) {
+    this.metadata.addQaseId(args);
   }
 
-  addTitle({ title }: AddTitleEventArgs) {
-    const curTest = this.storage.getCurrentTest();
-    if (!curTest) {
-      return;
-    }
-
-    curTest.title = title;
+  addTitle(args: AddTitleEventArgs) {
+    this.metadata.addTitle(args);
   }
 
-  addComment({ comment }: AddCommentEventArgs) {
-    this.storage.comment = comment;
+  addComment(args: AddCommentEventArgs) {
+    this.metadata.addComment(args);
   }
 
-  addSuite({ suite }: AddSuiteEventArgs) {
-    const curTest = this.storage.getCurrentTest();
-    if (!curTest) {
-      return;
-    }
-
-    curTest.relations = {
-      suite: {
-        data: [
-          {
-            title: suite,
-            public_id: null,
-          },
-        ],
-      },
-    };
+  addSuite(args: AddSuiteEventArgs) {
+    this.metadata.addSuite(args);
   }
 
-  addParameters({ records }: AddRecordsEventArgs) {
-    const curTest = this.storage.getCurrentTest();
-    if (!curTest) {
-      return;
-    }
-
-    const stringRecord: Record<string, string> = {};
-    for (const [key, value] of Object.entries(records)) {
-      stringRecord[String(key)] = String(value);
-    }
-
-    curTest.params = stringRecord;
+  addParameters(args: AddRecordsEventArgs) {
+    this.metadata.addParameters(args);
   }
 
-  addGroupParameters({ records }: AddRecordsEventArgs) {
-    const curTest = this.storage.getCurrentTest();
-    if (!curTest) {
-      return;
-    }
-
-    const stringRecord: Record<string, string> = {};
-    for (const [key, value] of Object.entries(records)) {
-      stringRecord[String(key)] = String(value);
-    }
-
-    curTest.group_params = stringRecord;
+  addGroupParameters(args: AddRecordsEventArgs) {
+    this.metadata.addGroupParameters(args);
   }
 
-  addFields({ records }: AddRecordsEventArgs) {
-    const curTest = this.storage.getCurrentTest();
-    if (!curTest) {
-      return;
-    }
-
-    const stringRecord: Record<string, string> = {};
-    for (const [key, value] of Object.entries(records)) {
-      stringRecord[String(key)] = String(value);
-    }
-
-    curTest.fields = records;
+  addFields(args: AddRecordsEventArgs) {
+    this.metadata.addFields(args);
   }
 
-  addTags({ tags }: AddTagsEventArgs) {
-    const curTest = this.storage.getCurrentTest();
-    if (!curTest) {
-      return;
-    }
-
-    curTest.tags = [...curTest.tags, ...tags];
+  addTags(args: AddTagsEventArgs) {
+    this.metadata.addTags(args);
   }
 
-  addAttachment({ name, type, content, paths }: AddAttachmentEventArgs) {
-    const curTest = this.storage.getCurrentTest();
-    if (!curTest) {
-      return;
-    }
-
-    if (paths) {
-      for (const file of paths) {
-        const attachmentName = path.basename(file);
-        const contentType: string = getMimeTypes(file);
-
-        const attach: Attachment = {
-          file_path: file,
-          size: 0,
-          id: uuidv4(),
-          file_name: attachmentName,
-          mime_type: contentType,
-          content: '',
-        };
-
-        curTest.attachments.push(attach);
-      }
-      return;
-    }
-
-    if (content) {
-      const attachmentName = name ?? 'attachment';
-      const contentType = type ?? 'application/octet-stream';
-
-      const attach: Attachment = {
-        file_path: null,
-        size: content.length,
-        id: uuidv4(),
-        file_name: attachmentName,
-        mime_type: contentType,
-        content: content,
-      };
-
-      curTest.attachments.push(attach);
-    }
+  addAttachment(args: AddAttachmentEventArgs) {
+    this.metadata.addAttachment(args);
   }
 
   ignore() {
-    const curTest = this.storage.getCurrentTest();
-    if (!curTest) {
-      return;
-    }
-
-    this.storage.ignore = true;
+    this.metadata.ignore();
   }
 
   addStep(step: TestStepType) {
-    const curItem = this.storage.getLastItem();
-    if (!curItem) {
-      return;
-    }
-
-    curItem.steps.push(step);
+    this.metadata.addStep(step);
   }
 
   private _startTest(title: string, cid: string, start_time: number = Date.now().valueOf() / 1000) {

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -10,19 +10,12 @@ import {
   composeOptions,
   CompoundError,
   ConfigLoader,
-  generateSignature,
   QaseReporter,
-  Relation,
   ReporterInterface,
   TestStatusEnum,
   TestStepType,
-  determineTestStatus,
-  parseProjectMappingFromTitle,
 } from 'qase-javascript-commons';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
-import {
-  removeQaseIdsFromTitle,
-} from 'qase-javascript-commons/internal';
 
 import { Storage } from './storage';
 import { TestLifecycle } from './lifecycle';
@@ -30,6 +23,7 @@ import { MetadataApplier } from './metadata';
 import { CucumberTagAdapter } from './cucumber-tags';
 import { IpcBridge } from './ipc';
 import { CommandTracker } from './command-tracker';
+import { ResultFinalizer } from './finalizer';
 import { QaseReporterOptions } from './options';
 import {
   AddAttachmentEventArgs,
@@ -69,6 +63,8 @@ export default class WDIOQaseReporter extends WDIOReporter {
   private ipc: IpcBridge;
 
   private commandTracker: CommandTracker;
+
+  private finalizer: ResultFinalizer;
 
   /**
    * @type {boolean}
@@ -124,6 +120,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this._options = Object.assign(new QaseReporterOptions(), options);
     this.commandTracker = new CommandTracker(this.lifecycle, this.storage, this._options, this.profiler);
+    this.finalizer = new ResultFinalizer(this.storage, this.reporter, this.commandTracker, this.ipc);
 
     this.registerListeners();
   }
@@ -288,86 +285,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
   }
 
   private async _endTest(status: TestStatusEnum, err: CompoundError | null, end_time: number = Date.now().valueOf() / 1000) {
-    const testResult = this.storage.getCurrentTest();
-    if (testResult === undefined || this.storage.ignore) {
-      return;
-    }
-
-    if (testResult.relations === null) {
-      const relations: Relation = {};
-      if (this.storage.suites.length > 0) {
-        relations.suite = {
-          data: this.storage.suites.map((suite) => {
-            return {
-              title: suite,
-              public_id: null,
-            };
-          }),
-        };
-      }
-
-      testResult.relations = relations;
-    }
-
-    testResult.execution.duration = testResult.execution.start_time ? Math.round(end_time - testResult.execution.start_time) : 0;
-    
-    // Convert CompoundError to regular Error for status determination
-    let error: Error | null = null;
-    if (err) {
-      error = new Error(err.message || 'Test failed');
-      if (err.stacktrace) {
-        error.stack = err.stacktrace;
-      }
-    }
-    
-    // Determine status based on error type
-    testResult.execution.status = determineTestStatus(error, status);
-    
-    testResult.execution.stacktrace = err === null ?
-      null : err.stacktrace === undefined ?
-        null : err.stacktrace;
-
-    const errorMessage = err === null ?
-      null : err.message === undefined ?
-        null : err.message;
-
-    if (this.storage.comment) {
-      testResult.message = errorMessage
-        ? `${this.storage.comment}\n\n${errorMessage}`
-        : this.storage.comment;
-    } else {
-      testResult.message = errorMessage;
-    }
-
-    testResult.signature = generateSignature(
-      Array.isArray(testResult.testops_id) ? testResult.testops_id : testResult.testops_id ? [testResult.testops_id] : null,
-      [...this.storage.suites, testResult.title],
-      testResult.params
-    );
-
-    const parsed = parseProjectMappingFromTitle(testResult.title);
-    const hasProjectMapping = Object.keys(parsed.projectMapping).length > 0;
-    if (hasProjectMapping) {
-      testResult.testops_project_mapping = parsed.projectMapping;
-      testResult.testops_id = null;
-    } else if (parsed.legacyIds.length > 0) {
-      testResult.testops_id = parsed.legacyIds.length === 1 ? parsed.legacyIds[0]! : parsed.legacyIds;
-    }
-    testResult.title = parsed.cleanedTitle || removeQaseIdsFromTitle(testResult.title);
-
-    // Merge profiler steps from direct fallback accumulator (same-process mode only)
-    const newProfilerSteps = this.commandTracker.drainNewProfilerSteps();
-    if (newProfilerSteps.length > 0) {
-      testResult.steps = [...testResult.steps, ...newProfilerSteps];
-    }
-
-    // Merge profiler steps received from QaseWdioService via process.emit IPC (same-process mode only)
-    const pendingFromIpc = this.ipc.drainProfilerSteps();
-    if (pendingFromIpc.length > 0) {
-      testResult.steps = [...testResult.steps, ...pendingFromIpc];
-    }
-
-    await this.reporter.addTestResult(testResult);
+    await this.finalizer.finalize(status, err, end_time);
   }
 
   override onBeforeCommand(command: BeforeCommandArgs) {

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -29,8 +29,8 @@ import { TestLifecycle } from './lifecycle';
 import { MetadataApplier } from './metadata';
 import { CucumberTagAdapter } from './cucumber-tags';
 import { IpcBridge } from './ipc';
+import { CommandTracker } from './command-tracker';
 import { QaseReporterOptions } from './options';
-import { isEmpty, isScreenshotCommand } from './utils';
 import {
   AddAttachmentEventArgs,
   AddCommentEventArgs,
@@ -68,6 +68,8 @@ export default class WDIOQaseReporter extends WDIOReporter {
 
   private ipc: IpcBridge;
 
+  private commandTracker: CommandTracker;
+
   /**
    * @type {boolean}
    * @private
@@ -75,6 +77,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
   private isSync: boolean;
 
   private _options: QaseReporterOptions;
+  // @ts-expect-error retained for backward compatibility; CommandTracker owns the live state. Task 8 will remove.
   private _isMultiremote?: boolean;
 
   /**
@@ -82,12 +85,6 @@ export default class WDIOQaseReporter extends WDIOReporter {
    * @private
    */
   private profiler: NetworkProfiler | null = null;
-
-  /**
-   * Snapshot of fallback accumulator length for per-test delta (same-process mode).
-   * @private
-   */
-  private _profilerStepSnapshot = 0;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(options: any) {
@@ -126,6 +123,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
     this.ipc = new IpcBridge(this.metadata);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this._options = Object.assign(new QaseReporterOptions(), options);
+    this.commandTracker = new CommandTracker(this.lifecycle, this.storage, this._options, this.profiler);
 
     this.registerListeners();
   }
@@ -140,6 +138,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
 
   override onRunnerStart(runner: RunnerStats) {
     this._isMultiremote = runner.isMultiremote;
+    this.commandTracker.setMultiremote(runner.isMultiremote);
     this.isSync = false;
   }
 
@@ -210,7 +209,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
       return;
     }
 
-    this._profilerStepSnapshot = this.profiler?.getAllSteps().length ?? 0;
+    this.commandTracker.takeProfilerSnapshot();
     this._startTest(test.title, test.cid, test.start.valueOf() / 1000);
   }
 
@@ -357,13 +356,9 @@ export default class WDIOQaseReporter extends WDIOReporter {
     testResult.title = parsed.cleanedTitle || removeQaseIdsFromTitle(testResult.title);
 
     // Merge profiler steps from direct fallback accumulator (same-process mode only)
-    if (this.profiler) {
-      const allSteps = this.profiler.getAllSteps();
-      const newSteps = allSteps.slice(this._profilerStepSnapshot);
-      this._profilerStepSnapshot = 0;
-      if (newSteps.length > 0) {
-        testResult.steps = [...testResult.steps, ...newSteps];
-      }
+    const newProfilerSteps = this.commandTracker.drainNewProfilerSteps();
+    if (newProfilerSteps.length > 0) {
+      testResult.steps = [...testResult.steps, ...newProfilerSteps];
     }
 
     // Merge profiler steps received from QaseWdioService via process.emit IPC (same-process mode only)
@@ -376,46 +371,11 @@ export default class WDIOQaseReporter extends WDIOReporter {
   }
 
   override onBeforeCommand(command: BeforeCommandArgs) {
-    if (!this.storage.getLastItem()) {
-      return;
-    }
-
-    const { disableWebdriverStepsReporting } = this._options;
-
-    if (disableWebdriverStepsReporting || this._isMultiremote) {
-      return;
-    }
-
-    const { method, endpoint } = command;
-
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    const stepName = command.command ? command.command : `${method} ${endpoint}`;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const payload = command.body || command.params;
-
-    this._startStep(stepName);
-
-    if (!isEmpty(payload)) {
-      this.attachJSON('Request', payload);
-    }
+    this.commandTracker.onBeforeCommand(command);
   }
 
   override onAfterCommand(command: AfterCommandArgs) {
-    const { disableWebdriverStepsReporting, disableWebdriverScreenshotsReporting } = this._options;
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-    const commandResult: string | undefined = command.result.value || undefined;
-    const isScreenshot = isScreenshotCommand(command);
-    if (!disableWebdriverScreenshotsReporting && isScreenshot && commandResult) {
-      this.attachFile('Screenshot.png', Buffer.from(commandResult, 'base64'), 'image/png');
-    }
-
-    if (disableWebdriverStepsReporting || this._isMultiremote || !this.storage.getCurrentStep()) {
-      return;
-    }
-
-    this.attachJSON('Response', commandResult);
-    this._endStep();
+    this.commandTracker.onAfterCommand(command);
   }
 
   registerListeners() {
@@ -476,13 +436,5 @@ export default class WDIOQaseReporter extends WDIOReporter {
 
   private _endStep(status: TestStatusEnum = TestStatusEnum.passed) {
     this.lifecycle.endStep(status);
-  }
-
-  private attachJSON(name: string, json: unknown) {
-    this.lifecycle.attachJSON(name, json);
-  }
-
-  private attachFile(name: string, content: string | Buffer, contentType: string) {
-    this.lifecycle.attachFile(name, content, contentType);
   }
 }

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -28,6 +28,7 @@ import { Storage } from './storage';
 import { TestLifecycle } from './lifecycle';
 import { MetadataApplier } from './metadata';
 import { CucumberTagAdapter } from './cucumber-tags';
+import { IpcBridge } from './ipc';
 import { QaseReporterOptions } from './options';
 import { isEmpty, isScreenshotCommand } from './utils';
 import {
@@ -39,7 +40,6 @@ import {
   AddTagsEventArgs,
   AddTitleEventArgs,
 } from './models';
-import { events } from './events';
 
 export default class WDIOQaseReporter extends WDIOReporter {
   /**
@@ -66,6 +66,8 @@ export default class WDIOQaseReporter extends WDIOReporter {
 
   private cucumberTags: CucumberTagAdapter;
 
+  private ipc: IpcBridge;
+
   /**
    * @type {boolean}
    * @private
@@ -86,12 +88,6 @@ export default class WDIOQaseReporter extends WDIOReporter {
    * @private
    */
   private _profilerStepSnapshot = 0;
-
-  /**
-   * Steps received from QaseWdioService via process.emit IPC.
-   * @private
-   */
-  private _pendingProfilerSteps: TestStepType[] = [];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(options: any) {
@@ -127,6 +123,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
     this.lifecycle = new TestLifecycle(this.storage);
     this.metadata = new MetadataApplier(this.storage);
     this.cucumberTags = new CucumberTagAdapter(this.metadata);
+    this.ipc = new IpcBridge(this.metadata);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this._options = Object.assign(new QaseReporterOptions(), options);
 
@@ -370,9 +367,9 @@ export default class WDIOQaseReporter extends WDIOReporter {
     }
 
     // Merge profiler steps received from QaseWdioService via process.emit IPC (same-process mode only)
-    if (this._pendingProfilerSteps.length > 0) {
-      testResult.steps = [...testResult.steps, ...this._pendingProfilerSteps];
-      this._pendingProfilerSteps = [];
+    const pendingFromIpc = this.ipc.drainProfilerSteps();
+    if (pendingFromIpc.length > 0) {
+      testResult.steps = [...testResult.steps, ...pendingFromIpc];
     }
 
     await this.reporter.addTestResult(testResult);
@@ -422,26 +419,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
   }
 
   registerListeners() {
-    process.on(events.addQaseID, this.addQaseId.bind(this));
-    process.on(events.addTitle, this.addTitle.bind(this));
-    process.on(events.addFields, this.addFields.bind(this));
-    process.on(events.addSuite, this.addSuite.bind(this));
-    process.on(events.addParameters, this.addParameters.bind(this));
-    process.on(events.addGroupParameters, this.addGroupParameters.bind(this));
-    process.on(events.addComment, this.addComment.bind(this));
-    process.on(events.addAttachment, this.addAttachment.bind(this));
-    process.on(events.addIgnore, this.ignore.bind(this));
-    process.on(events.addStep, this.addStep.bind(this));
-    process.on(events.addTags, this.addTags.bind(this));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-    process.on(events.addProfilerSteps as any, (data: string) => {
-      try {
-        const steps = JSON.parse(data) as TestStepType[];
-        this._pendingProfilerSteps.push(...steps);
-      } catch {
-        // Silent failure — corrupted profiler data should not affect test results
-      }
-    });
+    this.ipc.registerListeners();
   }
 
   addQaseId(args: AddQaseIdEventArgs) {

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -16,9 +16,6 @@ import {
   QaseReporter,
   Relation,
   ReporterInterface,
-  StepStatusEnum,
-  StepType,
-  TestResultType,
   TestStatusEnum,
   TestStepType,
   determineTestStatus,
@@ -32,6 +29,7 @@ import {
 
 import { v4 as uuidv4 } from 'uuid';
 import { Storage } from './storage';
+import { TestLifecycle } from './lifecycle';
 import { QaseReporterOptions } from './options';
 import { isEmpty, isScreenshotCommand } from './utils';
 import {
@@ -64,6 +62,8 @@ export default class WDIOQaseReporter extends WDIOReporter {
   private reporter: ReporterInterface;
 
   private storage: Storage;
+
+  private lifecycle: TestLifecycle;
 
   /**
    * @type {boolean}
@@ -123,6 +123,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
 
     this.isSync = true;
     this.storage = new Storage();
+    this.lifecycle = new TestLifecycle(this.storage);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this._options = Object.assign(new QaseReporterOptions(), options);
 
@@ -624,74 +625,23 @@ export default class WDIOQaseReporter extends WDIOReporter {
   }
 
   private _startTest(title: string, cid: string, start_time: number = Date.now().valueOf() / 1000) {
-    const result = new TestResultType(title);
-    result.execution.thread = cid;
-    result.execution.start_time = start_time;
-    result.id = uuidv4();
-
-    this.storage.push(result);
+    this.lifecycle.startTest(title, cid, start_time);
   }
 
   private _startStep(title: string) {
-    const step: TestStepType = {
-      id: uuidv4(),
-      step_type: StepType.TEXT,
-      data: {
-        action: title,
-        expected_result: null,
-        data: null,
-      },
-      parent_id: this.storage.getLastItem()?.id ?? null,
-      execution: {
-        start_time: Date.now().valueOf() / 1000,
-        end_time: null,
-        status: StepStatusEnum.passed,
-        duration: null,
-      },
-      steps: [],
-      attachments: [],
-    };
-
-    this.storage.getLastItem()?.steps.push(step);
-    this.storage.push(step);
-  }
-
-  private attachJSON(name: string, json: unknown) {
-    const isStr = typeof json === 'string';
-    const content = isStr ? json : JSON.stringify(json, null, 2);
-
-    this.attachFile(name, String(content), isStr ? 'application/json' : 'text/plain');
-  }
-
-  private attachFile(name: string, content: string | Buffer, contentType: string) {
-    if (!this.storage.getLastItem()) {
-      throw new Error('There isn\'t any active test!');
-    }
-
-    const attach: Attachment = {
-      file_path: null,
-      size: content.length,
-      id: uuidv4(),
-      file_name: name,
-      mime_type: contentType,
-      content: content,
-    };
-
-    this.storage.getLastItem()?.attachments.push(attach);
+    this.lifecycle.startStep(title);
   }
 
   private _endStep(status: TestStatusEnum = TestStatusEnum.passed) {
-    if (!this.storage.getLastItem()) {
-      return;
-    }
+    this.lifecycle.endStep(status);
+  }
 
-    const step = this.storage.pop();
-    if (!step) {
-      return;
-    }
+  private attachJSON(name: string, json: unknown) {
+    this.lifecycle.attachJSON(name, json);
+  }
 
-    step.execution.end_time = Date.now().valueOf() / 1000;
-    step.execution.status = status;
+  private attachFile(name: string, content: string | Buffer, contentType: string) {
+    this.lifecycle.attachFile(name, content, contentType);
   }
 
   private parseTag(tag: string): { key: string, value: string } | null {

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -22,12 +22,12 @@ import {
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
 import {
   removeQaseIdsFromTitle,
-  parseQaseIdsFromString,
 } from 'qase-javascript-commons/internal';
 
 import { Storage } from './storage';
 import { TestLifecycle } from './lifecycle';
 import { MetadataApplier } from './metadata';
+import { CucumberTagAdapter } from './cucumber-tags';
 import { QaseReporterOptions } from './options';
 import { isEmpty, isScreenshotCommand } from './utils';
 import {
@@ -63,6 +63,8 @@ export default class WDIOQaseReporter extends WDIOReporter {
   private lifecycle: TestLifecycle;
 
   private metadata: MetadataApplier;
+
+  private cucumberTags: CucumberTagAdapter;
 
   /**
    * @type {boolean}
@@ -124,6 +126,7 @@ export default class WDIOQaseReporter extends WDIOReporter {
     this.storage = new Storage();
     this.lifecycle = new TestLifecycle(this.storage);
     this.metadata = new MetadataApplier(this.storage);
+    this.cucumberTags = new CucumberTagAdapter(this.metadata);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     this._options = Object.assign(new QaseReporterOptions(), options);
 
@@ -148,41 +151,9 @@ export default class WDIOQaseReporter extends WDIOReporter {
 
     if (this._options.useCucumber && suite.type === 'scenario') {
       this._startTest(suite.title, suite.cid ?? '');
-
-      if (suite.tags === undefined) {
-        return;
+      if (suite.tags) {
+        this.cucumberTags.applyTags(suite.tags as Tag[]);
       }
-
-      const tags = (suite.tags as Tag[]).map((tag) => {
-        return tag.name;
-      });
-
-      for (const tag of tags) {
-        if (!tag.includes('=')) {
-          continue;
-        }
-
-        const tagData = this.parseTag(tag);
-        if (tagData === null) {
-          continue;
-        }
-
-        switch (tagData.key.toLowerCase()) {
-          case '@qaseid':
-            this.addQaseId({ ids: parseQaseIdsFromString(tagData.value) });
-            break;
-          case '@title':
-            this.addTitle({ title: tagData.value });
-            break;
-          case '@suite':
-            this.addSuite({ suite: tagData.value });
-            break;
-          case '@tags':
-            this.addTags({ tags: tagData.value.split(',').map((t) => t.trim()) });
-            break;
-        }
-      }
-
       return;
     }
 
@@ -535,14 +506,5 @@ export default class WDIOQaseReporter extends WDIOReporter {
 
   private attachFile(name: string, content: string | Buffer, contentType: string) {
     this.lifecycle.attachFile(name, content, contentType);
-  }
-
-  private parseTag(tag: string): { key: string, value: string } | null {
-    const [key, value] = tag.split('=');
-    if (!key || !value) {
-      return null;
-    }
-
-    return { key, value };
   }
 }

--- a/qase-wdio/src/reporter.ts
+++ b/qase-wdio/src/reporter.ts
@@ -73,8 +73,6 @@ export default class WDIOQaseReporter extends WDIOReporter {
   private isSync: boolean;
 
   private _options: QaseReporterOptions;
-  // @ts-expect-error retained for backward compatibility; CommandTracker owns the live state. Task 8 will remove.
-  private _isMultiremote?: boolean;
 
   /**
    * @type {NetworkProfiler | null}
@@ -134,7 +132,6 @@ export default class WDIOQaseReporter extends WDIOReporter {
   }
 
   override onRunnerStart(runner: RunnerStats) {
-    this._isMultiremote = runner.isMultiremote;
     this.commandTracker.setMultiremote(runner.isMultiremote);
     this.isSync = false;
   }

--- a/qase-wdio/test/command-tracker.test.ts
+++ b/qase-wdio/test/command-tracker.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { TestResultType } from 'qase-javascript-commons';
+import { CommandTracker } from '../src/command-tracker';
+import { TestLifecycle } from '../src/lifecycle';
+import { Storage } from '../src/storage';
+import { QaseReporterOptions } from '../src/options';
+
+function makeProfiler(initialStepCount = 0) {
+  let allSteps: object[] = Array.from({ length: initialStepCount }, (_, i) => ({ id: `init-${i}` }));
+  return {
+    getAllSteps: jest.fn(() => allSteps),
+    appendStep: (s: object) => { allSteps = [...allSteps, s]; },
+    restore: jest.fn(),
+  };
+}
+
+describe('CommandTracker', () => {
+  let storage: Storage;
+  let lifecycle: TestLifecycle;
+  let options: QaseReporterOptions;
+  let tracker: CommandTracker;
+
+  beforeEach(() => {
+    storage = new Storage();
+    lifecycle = new TestLifecycle(storage);
+    options = new QaseReporterOptions();
+    tracker = new CommandTracker(lifecycle, storage, options, null);
+  });
+
+  it('onBeforeCommand is no-op when there is no active item', () => {
+    const startStep = jest.spyOn(lifecycle, 'startStep');
+    tracker.onBeforeCommand({ method: 'GET', endpoint: '/x', command: 'getUrl' } as any);
+    expect(startStep).not.toHaveBeenCalled();
+  });
+
+  it('onBeforeCommand is no-op when disableWebdriverStepsReporting is true', () => {
+    storage.push(new TestResultType('t'));
+    options.disableWebdriverStepsReporting = true;
+    const startStep = jest.spyOn(lifecycle, 'startStep');
+    tracker.onBeforeCommand({ method: 'GET', endpoint: '/x' } as any);
+    expect(startStep).not.toHaveBeenCalled();
+  });
+
+  it('onBeforeCommand is no-op when isMultiremote', () => {
+    storage.push(new TestResultType('t'));
+    tracker.setMultiremote(true);
+    const startStep = jest.spyOn(lifecycle, 'startStep');
+    tracker.onBeforeCommand({ method: 'GET', endpoint: '/x' } as any);
+    expect(startStep).not.toHaveBeenCalled();
+  });
+
+  it('onBeforeCommand starts a step with command name and attaches payload as JSON', () => {
+    storage.push(new TestResultType('t'));
+    const attach = jest.spyOn(lifecycle, 'attachJSON');
+    tracker.onBeforeCommand({ method: 'POST', endpoint: '/x', command: 'click', body: { selector: '#go' } } as any);
+    expect(storage.getCurrentStep()?.data.action).toBe('click');
+    expect(attach).toHaveBeenCalledWith('Request', { selector: '#go' });
+  });
+
+  it('onBeforeCommand falls back to "{method} {endpoint}" when command is missing', () => {
+    storage.push(new TestResultType('t'));
+    tracker.onBeforeCommand({ method: 'GET', endpoint: '/users' } as any);
+    expect(storage.getCurrentStep()?.data.action).toBe('GET /users');
+  });
+
+  it('onAfterCommand attaches screenshot when isScreenshotCommand and command result present', () => {
+    storage.push(new TestResultType('t'));
+    lifecycle.startStep('takeScreenshot');
+    const attachFile = jest.spyOn(lifecycle, 'attachFile');
+    tracker.onAfterCommand({
+      method: 'GET',
+      endpoint: '/screenshot',
+      command: 'takeScreenshot',
+      result: { value: 'aGVsbG8=' },
+    } as any);
+    const calls = attachFile.mock.calls;
+    expect(calls.find((c) => c[0] === 'Screenshot.png' && c[2] === 'image/png')).toBeDefined();
+  });
+
+  it('drainNewProfilerSteps returns slice since last takeProfilerSnapshot', () => {
+    const profiler = makeProfiler(2) as any;
+    tracker = new CommandTracker(lifecycle, storage, options, profiler);
+    tracker.takeProfilerSnapshot();
+    profiler.appendStep({ id: 'new-1' });
+    profiler.appendStep({ id: 'new-2' });
+    expect(tracker.drainNewProfilerSteps()).toEqual([{ id: 'new-1' }, { id: 'new-2' }]);
+  });
+
+  it('drainNewProfilerSteps resets the snapshot to 0', () => {
+    const profiler = makeProfiler(2) as any;
+    tracker = new CommandTracker(lifecycle, storage, options, profiler);
+    tracker.takeProfilerSnapshot();
+    profiler.appendStep({ id: 'x' });
+    tracker.drainNewProfilerSteps();
+    expect(tracker.drainNewProfilerSteps()).toEqual([{ id: 'init-0' }, { id: 'init-1' }, { id: 'x' }]);
+  });
+});

--- a/qase-wdio/test/cucumber-tags.test.ts
+++ b/qase-wdio/test/cucumber-tags.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { CucumberTagAdapter } from '../src/cucumber-tags';
+import { MetadataApplier } from '../src/metadata';
+import { Storage } from '../src/storage';
+
+describe('CucumberTagAdapter', () => {
+  let metadata: MetadataApplier;
+  let adapter: CucumberTagAdapter;
+  let addQaseId: ReturnType<typeof jest.spyOn>;
+  let addTitle: ReturnType<typeof jest.spyOn>;
+  let addSuite: ReturnType<typeof jest.spyOn>;
+  let addTags: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    metadata = new MetadataApplier(new Storage());
+    adapter = new CucumberTagAdapter(metadata);
+    addQaseId = jest.spyOn(metadata, 'addQaseId');
+    addTitle = jest.spyOn(metadata, 'addTitle');
+    addSuite = jest.spyOn(metadata, 'addSuite');
+    addTags = jest.spyOn(metadata, 'addTags');
+  });
+
+  it('skips tags without "="', () => {
+    adapter.applyTags([{ name: '@noequals' }]);
+    expect(addQaseId).not.toHaveBeenCalled();
+    expect(addTitle).not.toHaveBeenCalled();
+  });
+
+  it('parses @qaseid=1,2,3 into number array via parseQaseIdsFromString', () => {
+    adapter.applyTags([{ name: '@qaseid=1,2,3' }]);
+    expect(addQaseId).toHaveBeenCalledWith({ ids: [1, 2, 3] });
+  });
+
+  it('is case-insensitive on the tag key', () => {
+    adapter.applyTags([{ name: '@QASEID=42' }]);
+    expect(addQaseId).toHaveBeenCalledWith({ ids: [42] });
+  });
+
+  it('parses @title=...', () => {
+    adapter.applyTags([{ name: '@title=Login flow' }]);
+    expect(addTitle).toHaveBeenCalledWith({ title: 'Login flow' });
+  });
+
+  it('parses @suite=...', () => {
+    adapter.applyTags([{ name: '@suite=Smoke' }]);
+    expect(addSuite).toHaveBeenCalledWith({ suite: 'Smoke' });
+  });
+
+  it('parses @tags=a, b , c with whitespace trim', () => {
+    adapter.applyTags([{ name: '@tags=a, b , c' }]);
+    expect(addTags).toHaveBeenCalledWith({ tags: ['a', 'b', 'c'] });
+  });
+});

--- a/qase-wdio/test/finalizer.test.ts
+++ b/qase-wdio/test/finalizer.test.ts
@@ -1,0 +1,133 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import {
+  CompoundError,
+  ReporterInterface,
+  TestResultType,
+  TestStatusEnum,
+  TestStepType,
+} from 'qase-javascript-commons';
+import { ResultFinalizer } from '../src/finalizer';
+import { CommandTracker } from '../src/command-tracker';
+import { IpcBridge } from '../src/ipc';
+import { TestLifecycle } from '../src/lifecycle';
+import { MetadataApplier } from '../src/metadata';
+import { Storage } from '../src/storage';
+import { QaseReporterOptions } from '../src/options';
+
+function makeUpstream(): jest.Mocked<ReporterInterface> {
+  return {
+    addTestResult: jest.fn(async () => undefined),
+    sendResults: jest.fn(async () => undefined),
+  } as any;
+}
+
+describe('ResultFinalizer', () => {
+  let storage: Storage;
+  let upstream: jest.Mocked<ReporterInterface>;
+  let metadata: MetadataApplier;
+  let lifecycle: TestLifecycle;
+  let commandTracker: CommandTracker;
+  let ipc: IpcBridge;
+  let finalizer: ResultFinalizer;
+
+  beforeEach(() => {
+    storage = new Storage();
+    upstream = makeUpstream();
+    metadata = new MetadataApplier(storage);
+    lifecycle = new TestLifecycle(storage);
+    commandTracker = new CommandTracker(lifecycle, storage, new QaseReporterOptions(), null);
+    ipc = new IpcBridge(metadata);
+    finalizer = new ResultFinalizer(storage, upstream, commandTracker, ipc);
+  });
+
+  function startTest(title: string, startTime = 1700000000): TestResultType {
+    lifecycle.startTest(title, 'cid', startTime);
+    return storage.getCurrentTest()!;
+  }
+
+  it('is a no-op when there is no current test', async () => {
+    await finalizer.finalize(TestStatusEnum.passed, null);
+    expect(upstream.addTestResult).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when storage.ignore is true', async () => {
+    startTest('t');
+    storage.ignore = true;
+    await finalizer.finalize(TestStatusEnum.passed, null);
+    expect(upstream.addTestResult).not.toHaveBeenCalled();
+  });
+
+  it('builds relations from storage.suites when relations is null', async () => {
+    const t = startTest('t');
+    storage.suites.push('Outer');
+    storage.suites.push('Inner');
+    await finalizer.finalize(TestStatusEnum.passed, null, 1700000010);
+    expect(t.relations?.suite?.data).toEqual([
+      { title: 'Outer', public_id: null },
+      { title: 'Inner', public_id: null },
+    ]);
+  });
+
+  it('keeps an existing relations object untouched', async () => {
+    const t = startTest('t');
+    t.relations = { suite: { data: [{ title: 'Pre', public_id: null }] } };
+    storage.suites.push('Should not appear');
+    await finalizer.finalize(TestStatusEnum.passed, null);
+    expect(t.relations.suite?.data).toEqual([{ title: 'Pre', public_id: null }]);
+  });
+
+  it('computes duration from start_time and endTime (rounded seconds)', async () => {
+    const t = startTest('t', 100);
+    await finalizer.finalize(TestStatusEnum.passed, null, 100.7);
+    expect(t.execution.duration).toBe(1);
+  });
+
+  it('forwards stacktrace from CompoundError', async () => {
+    const t = startTest('t');
+    const err = new CompoundError();
+    err.addStacktrace('Error: boom\n  at x');
+    await finalizer.finalize(TestStatusEnum.failed, err);
+    expect(t.execution.stacktrace).toContain('Error: boom');
+  });
+
+  it('combines storage.comment with error message into testResult.message', async () => {
+    const t = startTest('t');
+    storage.comment = 'note';
+    const err = new CompoundError();
+    err.addMessage('boom');
+    await finalizer.finalize(TestStatusEnum.failed, err);
+    expect(t.message).toMatch(/^note\n\n/);
+    expect(t.message).toContain('boom');
+  });
+
+  it('uses storage.comment alone when there is no error', async () => {
+    const t = startTest('t');
+    storage.comment = 'note only';
+    await finalizer.finalize(TestStatusEnum.passed, null);
+    expect(t.message).toBe('note only');
+  });
+
+  it('cleans (Qase ID: …) from title via removeQaseIdsFromTitle', async () => {
+    const t = startTest('login (Qase ID: 1)');
+    await finalizer.finalize(TestStatusEnum.passed, null);
+    expect(t.title).toBe('login');
+  });
+
+  it('merges profiler steps in order: in-process first, IPC after', async () => {
+    const t = startTest('t');
+    const inProc: TestStepType = { id: 'in-1' } as unknown as TestStepType;
+    const ipcStep: TestStepType = { id: 'ipc-1' } as unknown as TestStepType;
+    jest.spyOn(commandTracker, 'drainNewProfilerSteps').mockReturnValue([inProc]);
+    jest.spyOn(ipc, 'drainProfilerSteps').mockReturnValue([ipcStep]);
+    await finalizer.finalize(TestStatusEnum.passed, null);
+    expect(t.steps[t.steps.length - 2]).toBe(inProc);
+    expect(t.steps[t.steps.length - 1]).toBe(ipcStep);
+  });
+
+  it('publishes via upstream.addTestResult', async () => {
+    const t = startTest('t');
+    await finalizer.finalize(TestStatusEnum.passed, null);
+    expect(upstream.addTestResult).toHaveBeenCalledWith(t);
+  });
+});

--- a/qase-wdio/test/ipc.test.ts
+++ b/qase-wdio/test/ipc.test.ts
@@ -1,0 +1,57 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
+import { TestStepType } from 'qase-javascript-commons';
+import { IpcBridge } from '../src/ipc';
+import { MetadataApplier } from '../src/metadata';
+import { Storage } from '../src/storage';
+import { events } from '../src/events';
+
+describe('IpcBridge', () => {
+  let metadata: MetadataApplier;
+  let bridge: IpcBridge;
+
+  beforeEach(() => {
+    metadata = new MetadataApplier(new Storage());
+    bridge = new IpcBridge(metadata);
+    bridge.registerListeners();
+  });
+
+  afterEach(() => {
+    process.removeAllListeners(events.addQaseID);
+    process.removeAllListeners(events.addTitle);
+    process.removeAllListeners(events.addFields);
+    process.removeAllListeners(events.addSuite);
+    process.removeAllListeners(events.addParameters);
+    process.removeAllListeners(events.addGroupParameters);
+    process.removeAllListeners(events.addComment);
+    process.removeAllListeners(events.addAttachment);
+    process.removeAllListeners(events.addIgnore);
+    process.removeAllListeners(events.addStep);
+    process.removeAllListeners(events.addTags);
+    process.removeAllListeners(events.addProfilerSteps);
+  });
+
+  it('routes addQaseID events to MetadataApplier.addQaseId', () => {
+    const spy = jest.spyOn(metadata, 'addQaseId');
+    process.emit(events.addQaseID as any, { ids: [7] } as any);
+    expect(spy).toHaveBeenCalledWith({ ids: [7] });
+  });
+
+  it('buffers addProfilerSteps payloads (valid JSON of TestStepType[])', () => {
+    const step = { id: 's' } as unknown as TestStepType;
+    process.emit(events.addProfilerSteps as any, JSON.stringify([step]) as any);
+    expect(bridge.drainProfilerSteps()).toEqual([step]);
+  });
+
+  it('silently ignores corrupted addProfilerSteps payloads', () => {
+    process.emit(events.addProfilerSteps as any, 'not json' as any);
+    expect(bridge.drainProfilerSteps()).toEqual([]);
+  });
+
+  it('drainProfilerSteps clears the buffer', () => {
+    const step = { id: 's' } as unknown as TestStepType;
+    process.emit(events.addProfilerSteps as any, JSON.stringify([step]) as any);
+    bridge.drainProfilerSteps();
+    expect(bridge.drainProfilerSteps()).toEqual([]);
+  });
+});

--- a/qase-wdio/test/lifecycle.test.ts
+++ b/qase-wdio/test/lifecycle.test.ts
@@ -1,0 +1,133 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import {
+  StepStatusEnum,
+  TestResultType,
+  TestStatusEnum,
+} from 'qase-javascript-commons';
+import { Storage } from '../src/storage';
+import { TestLifecycle } from '../src/lifecycle';
+
+describe('TestLifecycle', () => {
+  let storage: Storage;
+  let lifecycle: TestLifecycle;
+
+  beforeEach(() => {
+    storage = new Storage();
+    lifecycle = new TestLifecycle(storage);
+  });
+
+  describe('startTest', () => {
+    it('pushes a TestResultType with a uuid id and the supplied thread', () => {
+      lifecycle.startTest('login flow', 'cid-1', 1700000000);
+      const test = storage.getCurrentTest();
+      expect(test).toBeInstanceOf(TestResultType);
+      expect(test?.title).toBe('login flow');
+      expect(test?.execution.thread).toBe('cid-1');
+      expect(test?.execution.start_time).toBe(1700000000);
+      expect(typeof test?.id).toBe('string');
+      expect(test?.id).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it('defaults start_time to now (in seconds) when not supplied', () => {
+      const before = Date.now() / 1000;
+      lifecycle.startTest('t', 'cid');
+      const after = Date.now() / 1000;
+      expect(storage.getCurrentTest()?.execution.start_time).toBeGreaterThanOrEqual(before - 1);
+      expect(storage.getCurrentTest()?.execution.start_time).toBeLessThanOrEqual(after + 1);
+    });
+  });
+
+  describe('startStep', () => {
+    it('does not throw when no item is on the stack and still records the step in the storage stack', () => {
+      lifecycle.startStep('step-without-parent');
+      const step = storage.getCurrentStep();
+      expect(step).toBeDefined();
+      expect(step?.data.action).toBe('step-without-parent');
+    });
+
+    it('pushes a step under the current test and into the stack', () => {
+      lifecycle.startTest('t', 'cid');
+      lifecycle.startStep('click button');
+      const test = storage.getCurrentTest()!;
+      expect(test.steps).toHaveLength(1);
+      expect(test.steps[0]?.data.action).toBe('click button');
+      expect(test.steps[0]?.parent_id).toBe(test.id);
+      expect(test.steps[0]?.execution.status).toBe(StepStatusEnum.passed);
+      expect(storage.getCurrentStep()).toBe(test.steps[0]);
+    });
+
+    it('nests a child step under the parent step', () => {
+      lifecycle.startTest('t', 'cid');
+      lifecycle.startStep('outer');
+      const outer = storage.getCurrentStep()!;
+      lifecycle.startStep('inner');
+      const inner = storage.getCurrentStep()!;
+      expect(inner.parent_id).toBe(outer.id);
+    });
+  });
+
+  describe('endStep', () => {
+    it('pops the top step and marks it passed by default', () => {
+      lifecycle.startTest('t', 'cid');
+      lifecycle.startStep('s');
+      const before = Date.now() / 1000;
+      lifecycle.endStep();
+      const after = Date.now() / 1000;
+      const test = storage.getCurrentTest()!;
+      expect(test.steps[0]?.execution.status).toBe(StepStatusEnum.passed);
+      expect(test.steps[0]?.execution.end_time).toBeGreaterThanOrEqual(before - 1);
+      expect(test.steps[0]?.execution.end_time).toBeLessThanOrEqual(after + 1);
+      expect(storage.getCurrentStep()).toBeUndefined();
+    });
+
+    it('records the supplied status', () => {
+      lifecycle.startTest('t', 'cid');
+      lifecycle.startStep('s');
+      lifecycle.endStep(TestStatusEnum.failed);
+      const test = storage.getCurrentTest()!;
+      expect(test.steps[0]?.execution.status).toBe(TestStatusEnum.failed);
+    });
+
+    it('is a no-op when stack is empty', () => {
+      expect(() => lifecycle.endStep()).not.toThrow();
+    });
+  });
+
+  describe('attachFile', () => {
+    it('throws when there is no active item', () => {
+      expect(() => lifecycle.attachFile('a.txt', 'x', 'text/plain')).toThrow(
+        "There isn't any active test!",
+      );
+    });
+
+    it('attaches to the last item on the stack', () => {
+      lifecycle.startTest('t', 'cid');
+      lifecycle.attachFile('a.txt', 'hello', 'text/plain');
+      const test = storage.getCurrentTest()!;
+      expect(test.attachments).toHaveLength(1);
+      expect(test.attachments[0]?.file_name).toBe('a.txt');
+      expect(test.attachments[0]?.mime_type).toBe('text/plain');
+      expect(test.attachments[0]?.content).toBe('hello');
+      expect(test.attachments[0]?.size).toBe(5);
+    });
+  });
+
+  describe('attachJSON', () => {
+    it('serializes objects with 2-space indent and labels them text/plain', () => {
+      lifecycle.startTest('t', 'cid');
+      lifecycle.attachJSON('payload', { a: 1 });
+      const test = storage.getCurrentTest()!;
+      expect(test.attachments[0]?.content).toBe('{\n  "a": 1\n}');
+      expect(test.attachments[0]?.mime_type).toBe('text/plain');
+    });
+
+    it('passes through strings as application/json', () => {
+      lifecycle.startTest('t', 'cid');
+      lifecycle.attachJSON('payload', '{"already":"json"}');
+      const test = storage.getCurrentTest()!;
+      expect(test.attachments[0]?.content).toBe('{"already":"json"}');
+      expect(test.attachments[0]?.mime_type).toBe('application/json');
+    });
+  });
+});

--- a/qase-wdio/test/metadata.test.ts
+++ b/qase-wdio/test/metadata.test.ts
@@ -1,0 +1,140 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { TestResultType } from 'qase-javascript-commons';
+import { Storage } from '../src/storage';
+import { MetadataApplier } from '../src/metadata';
+
+describe('MetadataApplier', () => {
+  let storage: Storage;
+  let metadata: MetadataApplier;
+
+  beforeEach(() => {
+    storage = new Storage();
+    metadata = new MetadataApplier(storage);
+  });
+
+  function withTest(): TestResultType {
+    const t = new TestResultType('t');
+    t.id = 'test-id';
+    storage.push(t);
+    return t;
+  }
+
+  describe('addQaseId', () => {
+    it('is a no-op when there is no current test', () => {
+      expect(() => metadata.addQaseId({ ids: [1] })).not.toThrow();
+    });
+
+    it('sets testops_id on the current test', () => {
+      const t = withTest();
+      metadata.addQaseId({ ids: [1, 2] });
+      expect(t.testops_id).toEqual([1, 2]);
+    });
+  });
+
+  describe('addTitle', () => {
+    it('is a no-op when there is no current test', () => {
+      expect(() => metadata.addTitle({ title: 'x' })).not.toThrow();
+    });
+
+    it('overwrites the title of the current test', () => {
+      const t = withTest();
+      metadata.addTitle({ title: 'new title' });
+      expect(t.title).toBe('new title');
+    });
+  });
+
+  describe('addComment', () => {
+    it('writes to storage.comment regardless of active test', () => {
+      metadata.addComment({ comment: 'hi' });
+      expect(storage.comment).toBe('hi');
+    });
+  });
+
+  describe('addSuite', () => {
+    it('is a no-op when there is no current test', () => {
+      expect(() => metadata.addSuite({ suite: 'S' })).not.toThrow();
+    });
+
+    it('sets relations.suite on the current test', () => {
+      const t = withTest();
+      metadata.addSuite({ suite: 'My Suite' });
+      expect(t.relations).toEqual({
+        suite: { data: [{ title: 'My Suite', public_id: null }] },
+      });
+    });
+  });
+
+  describe('addParameters', () => {
+    it('coerces values to string and assigns to params', () => {
+      const t = withTest();
+      metadata.addParameters({ records: { browser: 'chrome', count: 3 as unknown as string } });
+      expect(t.params).toEqual({ browser: 'chrome', count: '3' });
+    });
+  });
+
+  describe('addGroupParameters', () => {
+    it('coerces values to string and assigns to group_params', () => {
+      const t = withTest();
+      metadata.addGroupParameters({ records: { region: 'eu' } });
+      expect(t.group_params).toEqual({ region: 'eu' });
+    });
+  });
+
+  describe('addFields', () => {
+    it('assigns records to fields (raw, not coerced — matches original behavior)', () => {
+      const t = withTest();
+      metadata.addFields({ records: { layer: 'api' } });
+      expect(t.fields).toEqual({ layer: 'api' });
+    });
+  });
+
+  describe('addTags', () => {
+    it('appends to existing tags', () => {
+      const t = withTest();
+      t.tags = ['existing'];
+      metadata.addTags({ tags: ['a', 'b'] });
+      expect(t.tags).toEqual(['existing', 'a', 'b']);
+    });
+  });
+
+  describe('addAttachment', () => {
+    it('attaches each path with derived mime type', () => {
+      const t = withTest();
+      metadata.addAttachment({ paths: ['/tmp/screenshot.png'] });
+      expect(t.attachments).toHaveLength(1);
+      expect(t.attachments[0]?.file_name).toBe('screenshot.png');
+      expect(t.attachments[0]?.file_path).toBe('/tmp/screenshot.png');
+    });
+
+    it('attaches inline content with default mime type', () => {
+      const t = withTest();
+      metadata.addAttachment({ content: 'data', name: 'inline.txt' });
+      expect(t.attachments[0]?.file_name).toBe('inline.txt');
+      expect(t.attachments[0]?.mime_type).toBe('application/octet-stream');
+      expect(t.attachments[0]?.content).toBe('data');
+    });
+  });
+
+  describe('ignore', () => {
+    it('flips storage.ignore when there is a current test', () => {
+      withTest();
+      metadata.ignore();
+      expect(storage.ignore).toBe(true);
+    });
+
+    it('does nothing without a current test', () => {
+      metadata.ignore();
+      expect(storage.ignore).toBe(false);
+    });
+  });
+
+  describe('addStep', () => {
+    it('appends step to the last item (a test, when no step is active)', () => {
+      const t = withTest();
+      const step = { id: 's', step_type: 'text', data: { action: 'do', expected_result: null, data: null }, parent_id: null, execution: { start_time: 0, end_time: 0, status: 'passed', duration: null }, steps: [], attachments: [] };
+      metadata.addStep(step as any);
+      expect(t.steps).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Decomposes `WDIOQaseReporter` (705 LOC) into 7 focused modules:
- `TestLifecycle` (lifecycle.ts) — test/step-stack primitives.
- `MetadataApplier` (metadata.ts) — 11 user-facing handlers (`addQaseId/.../addStep`).
- `CucumberTagAdapter` (cucumber-tags.ts) — `@qaseid=`/`@title=`/`@suite=`/`@tags=` tag parsing.
- `IpcBridge` (ipc.ts) — `process.on(events.*)` listener registration + IPC profiler-step buffer.
- `CommandTracker` (command-tracker.ts) — `onBeforeCommand`/`onAfterCommand` + NetworkProfiler snapshot/drain.
- `ResultFinalizer` (finalizer.ts) — the ~85-line `_endTest` body (relations, duration, status, signature, project-mapping, profiler-step merge, upstream publish).

Reporter is now a composition root with thin facades for the 11 instance methods used by `process.on` IPC bindings.

- 705 LOC → 355 LOC in `reporter.ts`.
- +57 unit tests (38 → 95 across 9 suites).
- Bumps `qase-wdio` version `1.4.0` → `1.5.0`.
- Phase 2 pilot — design at `docs/superpowers/specs/2026-04-28-wdio-decomposition-design.md`.

## Public contract
Unchanged. `WDIOQaseReporter` is still default-exported and extends `WDIOReporter`. All `WDIOReporter` lifecycle overrides remain. All 11 instance methods remain public for `process.on(events.X, this.X.bind(this))` IPC bindings.

## Bug fix surfaced by decomposition
After WebDriver commands, `Response` payloads are now correctly attached to the surrounding step and the step's `end_time` is now set. Previously `TestStepType` instances were created as object literals (cast to type), causing `Storage.getCurrentStep()` (an `instanceof` check) to never find the step — so `onAfterCommand`'s guard `!getCurrentStep()` silently early-returned. `TestLifecycle` now constructs steps via `new TestStepType(...)`, restoring intended behavior. Documented in the v1.5.0 CHANGELOG entry.

## Test plan
- [x] `npm run build/lint/test --workspace=qase-wdio` green (95 tests, 9 suites).
- [x] `examples/single/wdio` runs with `QASE_MODE=report` and produces `build/qase-report/run.json`.
- [x] Step end_time correctly populated in the smoke-test report (validates the bug fix).

## Review
Each commit is one module extraction following the TDD pattern (red test → green module → reporter delegation → import cleanup → commit). Reviewing commit-by-commit shows the decomposition as it lands.