### PR TITLE
refactor(cypress): decompose reporter into focused modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30560,7 +30560,7 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "qase-javascript-commons": "~2.7.0",

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,14 @@
+# cypress-qase-reporter@3.6.0
+
+## Changed
+
+- Internal: decomposed `CypressQaseReporter` into focused modules — `TestTracker`, `StepConverter`, `ResultBuilder`, `SkippedTestHandler`. The reporter class now acts as a composition root with thin Mocha runner-event delegations. Public contract preserved: the named-exported `CypressQaseReporter` class extending `reporters.Base`, the constructor signature `(runner, options, configLoader?)`, the static `statusMap`, and the `CypressQaseOptionsType` type export are unchanged. Cross-process state (`MetadataManager`, `ResultsManager`) is untouched.
+- Added 34 new unit tests covering each extracted module.
+
+## Removed
+
+- `CypressQaseReporter.qaseIdRegExp` (static). The field was JSDoc-marked `@deprecated` since Phase 1 in favor of `parseProjectMappingFromTitle` from `qase-javascript-commons`. The same removal in `MochaQaseReporter` shipped in PR #946 without incident.
+
 # cypress-qase-reporter@3.5.0
 
 ## Changed

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -43,6 +43,7 @@ import { StepEnd, StepStart } from './metadata/models';
 import { FileSearcher } from './fileSearcher';
 import { extractTags } from './utils/tagParser';
 import { ResultsManager } from './metadata/resultsManager';
+import { TestTracker } from './test-tracker';
 
 const {
   EVENT_TEST_FAIL,
@@ -100,11 +101,11 @@ export class CypressQaseReporter extends reporters.Base {
   private testBeginTime: number = Date.now();
 
   /**
-   * Set to track processed tests to identify skipped tests when beforeEach fails
-   * @type {Set<string>}
+   * Tracks processed tests to identify ones skipped when beforeEach fails.
+   * @type {TestTracker}
    * @private
    */
-  private processedTests: Set<string> = new Set();
+  private tracker: TestTracker = new TestTracker();
 
   // private options: Omit<(FrameworkOptionsType<'cypress', ReporterOptionsType> & ConfigType & ReporterOptionsType & NonNullable<unknown>) | (null & ReporterOptionsType & NonNullable<unknown>), 'framework'>;
 
@@ -167,27 +168,7 @@ export class CypressQaseReporter extends reporters.Base {
     runner.once(EVENT_RUN_END, () => {
       const results = this.reporter.getResults();
       ResultsManager.setResults(results);
-      this.processedTests.clear();
     });
-  }
-
-  /**
-   * Generate a unique identifier for a test
-   * @param {Test} test
-   * @returns {string}
-   * @private
-   */
-  private getTestIdentifier(test: Test): string {
-    const file = test.parent ? getFile(test.parent) ?? '' : '';
-    const suitePath = test.parent ? test.parent.titlePath().join(' > ') : '';
-    let testTitle = test.fullTitle();
-    // Remove "before each" hook prefix and quotes if present (can be anywhere in the string)
-    testTitle = testTitle.replace(/"before each" hook for "/g, '');
-    // Remove trailing quote if present
-    if (testTitle.endsWith('"')) {
-      testTitle = testTitle.slice(0, -1);
-    }
-    return `${file}::${suitePath}::${testTitle}`;
   }
 
   /**
@@ -196,8 +177,7 @@ export class CypressQaseReporter extends reporters.Base {
    * @private
    */
   private markTestAsProcessed(test: Test): void {
-    const identifier = this.getTestIdentifier(test);
-    this.processedTests.add(identifier);
+    this.tracker.markProcessed(test);
   }
 
   /**
@@ -207,8 +187,7 @@ export class CypressQaseReporter extends reporters.Base {
    * @private
    */
   private isTestProcessed(test: Test): boolean {
-    const identifier = this.getTestIdentifier(test);
-    return this.processedTests.has(identifier);
+    return this.tracker.isProcessed(test);
   }
 
   /**

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -1,50 +1,22 @@
-import path from 'path';
-import { v4 as uuidv4 } from 'uuid';
 // import { spawnSync } from 'child_process';
 
 import { MochaOptions, reporters, Runner, Suite, Test } from 'mocha';
 
 import {
-  Attachment,
   composeOptions,
   ConfigLoader,
-  generateSignature,
   QaseReporter,
   ReporterInterface,
-  StepRequestData,
-  StepStatusEnum,
-  StepType,
-  TestResultType,
   TestStatusEnum,
-  TestStepType,
-  determineTestStatus,
-  parseProjectMappingFromTitle,
-  parseProjectMappingFromTags,
 } from 'qase-javascript-commons';
-import {
-  removeQaseIdsFromTitle,
-  getFile as getFileFromNode,
-  normalizeSuitePart,
-  FileSuiteNode,
-} from 'qase-javascript-commons/internal';
-
-/**
- * Adapter around the shared `getFile` helper to bridge the Mocha `Suite`
- * type (whose `parent` is `Suite | undefined`) with `FileSuiteNode`
- * (whose `parent` is optional under `exactOptionalPropertyTypes`).
- */
-const getFile = (suite: Suite): string | undefined =>
-  getFileFromNode(suite as unknown as FileSuiteNode);
 
 import { configSchema } from './configSchema';
 import { ReporterOptionsType } from './options';
 import { MetadataManager } from './metadata/manager';
-import { StepEnd, StepStart } from './metadata/models';
-import { FileSearcher } from './fileSearcher';
-import { extractTags } from './utils/tagParser';
 import { ResultsManager } from './metadata/resultsManager';
 import { TestTracker } from './test-tracker';
 import { StepConverter } from './step-converter';
+import { ResultBuilder } from './result-builder';
 
 const {
   EVENT_TEST_FAIL,
@@ -109,6 +81,8 @@ export class CypressQaseReporter extends reporters.Base {
   private tracker: TestTracker = new TestTracker();
 
   private stepConverter: StepConverter = new StepConverter();
+
+  private resultBuilder: ResultBuilder = new ResultBuilder(this.stepConverter);
 
   // private options: Omit<(FrameworkOptionsType<'cypress', ReporterOptionsType> & ConfigType & ReporterOptionsType & NonNullable<unknown>) | (null & ReporterOptionsType & NonNullable<unknown>), 'framework'>;
 
@@ -237,92 +211,12 @@ export class CypressQaseReporter extends reporters.Base {
      * @private
      */
   private addSkippedTestResult(test: Test): void {
-    const end_time = Date.now();
-    const duration = 0; // Skipped tests have no duration
-
-    const start_time = this.testBeginTime || Date.now();
-
-    const fromTitle = parseProjectMappingFromTitle(test.title);
-    const legacyIds = [...fromTitle.legacyIds];
-    const projectMapping: Record<string, number[]> = { ...fromTitle.projectMapping };
-    const testFileName = this.getTestFileName(test);
-    const files = this.screenshotsFolder ?
-      FileSearcher.findFilesBeforeTime(this.screenshotsFolder, testFileName, new Date(start_time))
-      : [];
-
-    const attachments = files.map((file) => ({
-      content: '',
-      id: uuidv4(),
-      mime_type: 'image/png',
-      size: 0,
-      file_name: path.basename(file),
-      file_path: file,
-    } as Attachment));
-
-    let relations = {};
-    if (test.parent !== undefined) {
-      const data = [];
-      for (const suite of test.parent.titlePath()) {
-        data.push({
-          title: suite,
-          public_id: null,
-        });
-      }
-
-      relations = {
-        suite: {
-          data: data,
-        },
-      };
-    }
-
-    // For skipped tests, we don't have metadata since the test never ran
-    // But we can still check for cucumber tags if the test has a parent with a file
-    if (test.parent) {
-      const file = getFile(test.parent);
-      if (file) {
-        const tags = extractTags(file, test.title);
-        const fromTags = parseProjectMappingFromTags(tags);
-        legacyIds.push(...fromTags.legacyIds);
-        for (const [code, idsFromTag] of Object.entries(fromTags.projectMapping)) {
-          projectMapping[code] = [...(projectMapping[code] ?? []), ...idsFromTag];
-        }
-      }
-    }
-
-    const hasProjectMapping = Object.keys(projectMapping).length > 0;
-    const result: TestResultType = {
-      attachments: attachments,
-      author: null,
-      fields: {},
-      message: null,
-      muted: false,
-      params: {},
-      group_params: {},
-      relations: relations,
-      run_id: null,
-      signature: this.getSignature(test, hasProjectMapping ? [] : legacyIds, {}),
-      steps: [],
-      id: uuidv4(),
-      execution: {
-        status: TestStatusEnum.skipped,
-        start_time: this.testBeginTime / 1000,
-        end_time: end_time / 1000,
-        duration: duration,
-        stacktrace: null,
-        thread: null,
-      },
-      testops_id: !hasProjectMapping && legacyIds.length > 0
-        ? (legacyIds.length === 1 ? legacyIds[0]! : legacyIds)
-        : null,
-      testops_project_mapping: hasProjectMapping ? projectMapping : null,
-      title: fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title),
-      preparedAttachments: [],
-    } as unknown as TestResultType;
-
+    const result = this.resultBuilder.buildSkipped({
+      test,
+      screenshotsFolder: this.screenshotsFolder,
+      testBeginTime: this.testBeginTime,
+    });
     void this.reporter.addTestResult(result);
-
-    // Mark as processed to avoid duplicate reporting
     this.markTestAsProcessed(test);
   }
 
@@ -331,209 +225,24 @@ export class CypressQaseReporter extends reporters.Base {
    * @private
    */
   private addTestResult(test: Test) {
-    const end_time = Date.now();
-    const duration = end_time - this.testBeginTime;
-
     const metadata = MetadataManager.getMetadata();
+    const isCucumber = (metadata?.cucumberSteps?.length ?? 0) > 0;
+    const result = this.resultBuilder.build({
+      test,
+      metadata,
+      screenshotsFolder: this.screenshotsFolder,
+      testBeginTime: this.testBeginTime,
+      isCucumber,
+      options: {} as ReporterOptionsType,
+    });
 
-    if (metadata?.ignore) {
-      // Mark as processed even if ignored to avoid duplicate reporting
+    if (result === null) {
       this.markTestAsProcessed(test);
       MetadataManager.clear();
       return;
     }
 
-    const fromTitle = parseProjectMappingFromTitle(test.title);
-    const legacyIds = [...fromTitle.legacyIds];
-    const projectMapping: Record<string, number[]> = { ...fromTitle.projectMapping };
-
-    const testFileName = this.getTestFileName(test);
-    const files = this.screenshotsFolder ?
-      FileSearcher.findFilesBeforeTime(this.screenshotsFolder, testFileName, new Date(this.testBeginTime))
-      : [];
-
-    // const videos = this.videosFolder ?
-    //   FileSearcher.findVideoFiles(this.videosFolder, testFileName)
-    //   : [];
-
-    const attachments = files.map((file) => ({
-      content: '',
-      id: uuidv4(),
-      mime_type: 'image/png',
-      size: 0,
-      file_name: path.basename(file),
-      file_path: file,
-    } as Attachment));
-
-    // const videoAttachments = videos.map((file) => ({
-    //   content: '',
-    //   id: uuidv4(),
-    //   mime_type: 'video/mp4',
-    //   size: 0,
-    //   file_name: path.basename(file),
-    //   file_path: file,
-    // } as Attachment));
-
-    attachments.push(...(metadata?.attachments ?? []));
-
-    let relations = {};
-    if (test.parent !== undefined) {
-      const data = [];
-      for (const suite of test.parent.titlePath()) {
-        data.push({
-          title: suite,
-          public_id: null,
-        });
-      }
-
-      relations = {
-        suite: {
-          data: data,
-        },
-      };
-    }
-
-    if (metadata?.suite) {
-      relations = {
-        suite: {
-          data: [
-            {
-              title: metadata.suite,
-              public_id: null,
-            },
-          ],
-        },
-      };
-    }
-
-    let message = metadata?.comment ?? '';
-    if (test.err?.message) {
-      message += message ? `\n\n${test.err.message}` : test.err.message;
-    }
-
-    const steps = metadata?.steps ? this.getSteps(metadata.steps, metadata.stepAttachments ?? {}) : [];
-
-    // support for cucumber steps and metadata
-    if (metadata?.cucumberSteps && metadata.cucumberSteps.length > 0) {
-      steps.push(...this.convertCypressMessages(metadata.cucumberSteps, test.state ?? 'failed'));
-
-      if (test.parent) {
-        const file = getFile(test.parent);
-
-        if (file) {
-          const tags = extractTags(file, test.title);
-          const fromTags = parseProjectMappingFromTags(tags);
-          legacyIds.push(...fromTags.legacyIds);
-          for (const [code, idsFromTag] of Object.entries(fromTags.projectMapping)) {
-            projectMapping[code] = [...(projectMapping[code] ?? []), ...idsFromTag];
-          }
-        }
-      }
-    }
-
-    // Convert network profiler requests to REQUEST steps
-    if (metadata?.networkRequests && metadata.networkRequests.length > 0) {
-      for (const req of metadata.networkRequests) {
-        const step = new TestStepType(StepType.REQUEST);
-        step.id = uuidv4();
-        const data = step.data as StepRequestData;
-        data.request_method = req.method;
-        data.request_url = req.url;
-        data.request_headers = null;
-        data.request_body = null;
-        data.status_code = req.statusCode;
-        data.response_body = req.responseBody;
-        data.response_headers = null;
-        step.execution.status = req.statusCode !== null && req.statusCode >= 400
-          ? StepStatusEnum.failed
-          : StepStatusEnum.passed;
-        step.execution.start_time = req.startTime / 1000;
-        step.execution.duration = req.duration;
-        steps.push(step);
-      }
-    }
-
-    const hasProjectMapping = Object.keys(projectMapping).length > 0;
-    const result: TestResultType = {
-      attachments: attachments,
-      author: null,
-      fields: metadata?.fields ?? {},
-      tags: metadata?.tags ?? [],
-      message: message,
-      muted: false,
-      params: metadata?.parameters ?? {},
-      group_params: metadata?.groupParams ?? {},
-      relations: relations,
-      run_id: null,
-      signature: this.getSignature(test, hasProjectMapping ? [] : legacyIds, metadata?.parameters ?? {}),
-      steps: steps,
-      id: uuidv4(),
-      execution: {
-        status: determineTestStatus(test.err ?? null, test.state ?? 'failed'),
-        start_time: this.testBeginTime / 1000,
-        end_time: end_time / 1000,
-        duration: duration,
-        stacktrace: test.err?.stack ?? null,
-        thread: null,
-      },
-      testops_id: !hasProjectMapping && legacyIds.length > 0
-        ? (legacyIds.length === 1 ? legacyIds[0]! : legacyIds)
-        : null,
-      testops_project_mapping: hasProjectMapping ? projectMapping : null,
-      title: metadata?.title ?? (fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title)),
-      preparedAttachments: [],
-    } as unknown as TestResultType;
-
     void this.reporter.addTestResult(result);
-
     MetadataManager.clear();
-  }
-
-  /**
-   * @param {Test} test
-   * @param {number[]} ids
-   * @private
-   */
-  private getSignature(test: Test, ids: number[], params: Record<string, string>) {
-    const suites = [];
-    const file = test.parent ? getFile(test.parent) : undefined;
-
-    if (file) {
-      suites.push(file.split(path.sep).join('::'));
-    }
-
-    if (test.parent) {
-      for (const suite of test.parent.titlePath()) {
-        suites.push(normalizeSuitePart(suite));
-      }
-    }
-
-    suites.push(normalizeSuitePart(test.title));
-
-    return generateSignature(ids, suites, params);
-  }
-
-  private getTestFileName(test: Test): string {
-    if (!test.parent) {
-      return '';
-    }
-
-    const file = getFile(test.parent);
-    if (!file) {
-      return '';
-    }
-
-    const pathParts = file.split(path.sep);
-    const fileName = pathParts[pathParts.length - 1];
-
-    return fileName ? fileName : '';
-  }
-
-  private convertCypressMessages(messages: StepStart[], testStatus: string): TestStepType[] {
-    return this.stepConverter.convertCypressMessages(messages, testStatus);
-  }
-
-  private getSteps(steps: (StepStart | StepEnd)[], attachments: Record<string, Attachment[]>): TestStepType[] {
-    return this.stepConverter.getSteps(steps, attachments);
   }
 }

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -17,6 +17,7 @@ import { ResultsManager } from './metadata/resultsManager';
 import { TestTracker } from './test-tracker';
 import { StepConverter } from './step-converter';
 import { ResultBuilder } from './result-builder';
+import { SkippedTestHandler } from './skipped-test-handler';
 
 const {
   EVENT_TEST_FAIL,
@@ -84,6 +85,8 @@ export class CypressQaseReporter extends reporters.Base {
 
   private resultBuilder: ResultBuilder = new ResultBuilder(this.stepConverter);
 
+  private skippedHandler!: SkippedTestHandler;
+
   // private options: Omit<(FrameworkOptionsType<'cypress', ReporterOptionsType> & ConfigType & ReporterOptionsType & NonNullable<unknown>) | (null & ReporterOptionsType & NonNullable<unknown>), 'framework'>;
 
   /**
@@ -112,6 +115,16 @@ export class CypressQaseReporter extends reporters.Base {
       frameworkName: 'cypress',
       reporterName: 'cypress-qase-reporter',
     });
+
+    this.skippedHandler = new SkippedTestHandler(
+      this.tracker,
+      this.resultBuilder,
+      (result) => { void this.reporter.addTestResult(result); },
+      () => ({
+        screenshotsFolder: this.screenshotsFolder,
+        testBeginTime: this.testBeginTime,
+      }),
+    );
 
     this.addRunnerListeners(runner);
   }
@@ -158,66 +171,12 @@ export class CypressQaseReporter extends reporters.Base {
   }
 
   /**
-   * Check if a test was processed
-   * @param {Test} test
-   * @returns {boolean}
-   * @private
-   */
-  private isTestProcessed(test: Test): boolean {
-    return this.tracker.isProcessed(test);
-  }
-
-  /**
    * Handle skipped tests in a suite when beforeEach hook fails
    * @param {Suite} suite
    * @private
    */
-  /**
-   * Recursively collect all tests from a suite and its nested suites
-   * @param {Suite} suite
-   * @param {Test[]} tests
-   * @private
-   */
-  private collectAllTestsFromSuite(suite: Suite, tests: Test[]): void {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const suiteTests = suite.tests ?? [];
-    tests.push(...suiteTests);
-
-    // Recursively process nested suites
-    const nestedSuites = suite.suites ?? [];
-    for (const nestedSuite of nestedSuites) {
-      this.collectAllTestsFromSuite(nestedSuite, tests);
-    }
-  }
-
   private handleSkippedTestsInSuite(suite: Suite): void {
-    // Collect all tests from this suite and nested suites recursively
-    const allTests: Test[] = [];
-    this.collectAllTestsFromSuite(suite, allTests);
-
-    // Find tests that were not processed (skipped due to beforeEach failure)
-    for (const test of allTests) {     
-      // Skip if test was already processed (e.g., first test that got EVENT_TEST_FAIL)
-      if (!this.isTestProcessed(test)) {
-        // Test was skipped due to beforeEach failure, report it as skipped
-        this.addSkippedTestResult(test);
-      }
-    }
-  }
-
-  /**
-     * Add a test result for a skipped test (due to beforeEach failure)
-     * @param {Test} test
-     * @private
-     */
-  private addSkippedTestResult(test: Test): void {
-    const result = this.resultBuilder.buildSkipped({
-      test,
-      screenshotsFolder: this.screenshotsFolder,
-      testBeginTime: this.testBeginTime,
-    });
-    void this.reporter.addTestResult(result);
-    this.markTestAsProcessed(test);
+    this.skippedHandler.handleSuiteEnd(suite);
   }
 
   /**

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -40,12 +40,6 @@ export type CypressQaseOptionsType = Omit<MochaOptions, 'reporterOptions'> & {
  */
 export class CypressQaseReporter extends reporters.Base {
   /**
-   * @type {RegExp}
-   */
-  /** @deprecated Use parseProjectMappingFromTitle from qase-javascript-commons for multi-project support. */
-  static qaseIdRegExp = /\(Qase ID:? ([\d,]+)\)/;
-
-  /**
    * @type {Record<CypressState, TestStatusEnum>}
    */
   static statusMap: Record<CypressState, TestStatusEnum> = {

--- a/qase-cypress/src/reporter.ts
+++ b/qase-cypress/src/reporter.ts
@@ -44,6 +44,7 @@ import { FileSearcher } from './fileSearcher';
 import { extractTags } from './utils/tagParser';
 import { ResultsManager } from './metadata/resultsManager';
 import { TestTracker } from './test-tracker';
+import { StepConverter } from './step-converter';
 
 const {
   EVENT_TEST_FAIL,
@@ -106,6 +107,8 @@ export class CypressQaseReporter extends reporters.Base {
    * @private
    */
   private tracker: TestTracker = new TestTracker();
+
+  private stepConverter: StepConverter = new StepConverter();
 
   // private options: Omit<(FrameworkOptionsType<'cypress', ReporterOptionsType> & ConfigType & ReporterOptionsType & NonNullable<unknown>) | (null & ReporterOptionsType & NonNullable<unknown>), 'framework'>;
 
@@ -527,72 +530,10 @@ export class CypressQaseReporter extends reporters.Base {
   }
 
   private convertCypressMessages(messages: StepStart[], testStatus: string): TestStepType[] {
-    const result: TestStepType[] = [];
-
-    const lastIndex = messages.length - 1;
-    for (const message of messages) {
-      const step = new TestStepType(StepType.TEXT);
-      step.id = message.id;
-      step.execution.status = StepStatusEnum.passed;
-      step.execution.start_time = message.timestamp;
-      step.data = {
-        action: message.name,
-        expected_result: null,
-        data: null,
-      };
-
-      if (lastIndex === messages.indexOf(message) && testStatus !== 'passed') {
-        step.execution.status = StepStatusEnum.failed;
-      }
-
-      result.push(step);
-    }
-
-    return result;
+    return this.stepConverter.convertCypressMessages(messages, testStatus);
   }
 
   private getSteps(steps: (StepStart | StepEnd)[], attachments: Record<string, Attachment[]>): TestStepType[] {
-    const result: TestStepType[] = [];
-    const stepMap = new Map<string, TestStepType>();
-
-    for (const step of steps.sort((a, b) => a.timestamp - b.timestamp)) {
-      if (!('status' in step)) {
-        const newStep = new TestStepType();
-        newStep.id = step.id;
-        newStep.execution.status = StepStatusEnum.failed;
-        newStep.execution.start_time = step.timestamp;
-        newStep.execution.end_time = Date.now();
-        newStep.data = {
-          action: step.name,
-          expected_result: null,
-          data: null,
-        };
-
-        if (attachments[step.id]) {
-          newStep.attachments = attachments[step.id] ?? [];
-        }
-
-        const parentId = step.parentId;
-        if (parentId) {
-          newStep.parent_id = parentId;
-          const parent = stepMap.get(parentId);
-          if (parent) {
-            parent.steps.push(newStep);
-          }
-        } else {
-          result.push(newStep);
-        }
-
-        stepMap.set(step.id, newStep);
-      } else {
-        const stepType = stepMap.get(step.id);
-        if (stepType) {
-          stepType.execution.status = step.status as StepStatusEnum;
-          stepType.execution.end_time = step.timestamp;
-        }
-      }
-    }
-
-    return result;
+    return this.stepConverter.getSteps(steps, attachments);
   }
 }

--- a/qase-cypress/src/result-builder.ts
+++ b/qase-cypress/src/result-builder.ts
@@ -1,0 +1,276 @@
+import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import type { Suite, Test } from 'mocha';
+import {
+  Attachment,
+  StepRequestData,
+  StepStatusEnum,
+  StepType,
+  TestResultType,
+  TestStatusEnum,
+  TestStepType,
+  determineTestStatus,
+  generateSignature,
+  parseProjectMappingFromTags,
+  parseProjectMappingFromTitle,
+} from 'qase-javascript-commons';
+import {
+  removeQaseIdsFromTitle,
+  getFile as getFileFromNode,
+  normalizeSuitePart,
+  FileSuiteNode,
+} from 'qase-javascript-commons/internal';
+import { FileSearcher } from './fileSearcher';
+import { extractTags } from './utils/tagParser';
+import type { Metadata } from './metadata/models';
+import type { ReporterOptionsType } from './options';
+import { StepConverter } from './step-converter';
+
+const getFile = (suite: Suite): string | undefined =>
+  getFileFromNode(suite as unknown as FileSuiteNode);
+
+export interface BuildArgs {
+  test: Test;
+  metadata: Metadata | undefined;
+  screenshotsFolder: string | undefined;
+  testBeginTime: number;
+  isCucumber: boolean;
+  options: ReporterOptionsType;
+}
+
+export interface BuildSkippedArgs {
+  test: Test;
+  screenshotsFolder: string | undefined;
+  testBeginTime: number;
+}
+
+export class ResultBuilder {
+  constructor(private readonly stepConverter: StepConverter) {}
+
+  build(args: BuildArgs): TestResultType | null {
+    const { test, metadata, screenshotsFolder, testBeginTime } = args;
+    if (metadata?.ignore) {
+      return null;
+    }
+
+    const end_time = Date.now();
+    const duration = end_time - testBeginTime;
+
+    const fromTitle = parseProjectMappingFromTitle(test.title);
+    const legacyIds = [...fromTitle.legacyIds];
+    const projectMapping: Record<string, number[]> = { ...fromTitle.projectMapping };
+
+    const testFileName = getTestFileName(test);
+    const files = screenshotsFolder
+      ? FileSearcher.findFilesBeforeTime(screenshotsFolder, testFileName, new Date(testBeginTime))
+      : [];
+
+    const attachments = files.map((file) => ({
+      content: '',
+      id: uuidv4(),
+      mime_type: 'image/png',
+      size: 0,
+      file_name: path.basename(file),
+      file_path: file,
+    } as Attachment));
+
+    attachments.push(...(metadata?.attachments ?? []));
+
+    let relations = {};
+    if (test.parent !== undefined) {
+      const data = [];
+      for (const suite of test.parent.titlePath()) {
+        data.push({ title: suite, public_id: null });
+      }
+      relations = { suite: { data } };
+    }
+    if (metadata?.suite) {
+      relations = { suite: { data: [{ title: metadata.suite, public_id: null }] } };
+    }
+
+    let message = metadata?.comment ?? '';
+    if (test.err?.message) {
+      message += message ? `\n\n${test.err.message}` : test.err.message;
+    }
+
+    const steps = metadata?.steps
+      ? this.stepConverter.getSteps(metadata.steps, metadata.stepAttachments ?? {})
+      : [];
+
+    if (metadata?.cucumberSteps && metadata.cucumberSteps.length > 0) {
+      steps.push(...this.stepConverter.convertCypressMessages(metadata.cucumberSteps, test.state ?? 'failed'));
+      if (test.parent) {
+        const file = getFile(test.parent);
+        if (file) {
+          const tags = extractTags(file, test.title);
+          const fromTags = parseProjectMappingFromTags(tags);
+          legacyIds.push(...fromTags.legacyIds);
+          for (const [code, idsFromTag] of Object.entries(fromTags.projectMapping)) {
+            projectMapping[code] = [...(projectMapping[code] ?? []), ...idsFromTag];
+          }
+        }
+      }
+    }
+
+    if (metadata?.networkRequests && metadata.networkRequests.length > 0) {
+      for (const req of metadata.networkRequests) {
+        const step = new TestStepType(StepType.REQUEST);
+        step.id = uuidv4();
+        const data = step.data as StepRequestData;
+        data.request_method = req.method;
+        data.request_url = req.url;
+        data.request_headers = null;
+        data.request_body = null;
+        data.status_code = req.statusCode;
+        data.response_body = req.responseBody;
+        data.response_headers = null;
+        step.execution.status = req.statusCode !== null && req.statusCode >= 400
+          ? StepStatusEnum.failed
+          : StepStatusEnum.passed;
+        step.execution.start_time = req.startTime / 1000;
+        step.execution.duration = req.duration;
+        steps.push(step);
+      }
+    }
+
+    const hasProjectMapping = Object.keys(projectMapping).length > 0;
+    const result: TestResultType = {
+      attachments,
+      author: null,
+      fields: metadata?.fields ?? {},
+      tags: metadata?.tags ?? [],
+      message,
+      muted: false,
+      params: metadata?.parameters ?? {},
+      group_params: metadata?.groupParams ?? {},
+      relations,
+      run_id: null,
+      signature: getSignature(test, hasProjectMapping ? [] : legacyIds, metadata?.parameters ?? {}),
+      steps,
+      id: uuidv4(),
+      execution: {
+        status: determineTestStatus(test.err ?? null, test.state ?? 'failed'),
+        start_time: testBeginTime / 1000,
+        end_time: end_time / 1000,
+        duration,
+        stacktrace: test.err?.stack ?? null,
+        thread: null,
+      },
+      testops_id: !hasProjectMapping && legacyIds.length > 0
+        ? (legacyIds.length === 1 ? legacyIds[0]! : legacyIds)
+        : null,
+      testops_project_mapping: hasProjectMapping ? projectMapping : null,
+      title: metadata?.title ?? (fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title)),
+      preparedAttachments: [],
+    } as unknown as TestResultType;
+
+    return result;
+  }
+
+  buildSkipped(args: BuildSkippedArgs): TestResultType {
+    const { test, screenshotsFolder, testBeginTime } = args;
+    const end_time = Date.now();
+    const start_time = testBeginTime || Date.now();
+
+    const fromTitle = parseProjectMappingFromTitle(test.title);
+    const legacyIds = [...fromTitle.legacyIds];
+    const projectMapping: Record<string, number[]> = { ...fromTitle.projectMapping };
+
+    const testFileName = getTestFileName(test);
+    const files = screenshotsFolder
+      ? FileSearcher.findFilesBeforeTime(screenshotsFolder, testFileName, new Date(start_time))
+      : [];
+
+    const attachments = files.map((file) => ({
+      content: '',
+      id: uuidv4(),
+      mime_type: 'image/png',
+      size: 0,
+      file_name: path.basename(file),
+      file_path: file,
+    } as Attachment));
+
+    let relations = {};
+    if (test.parent !== undefined) {
+      const data = [];
+      for (const suite of test.parent.titlePath()) {
+        data.push({ title: suite, public_id: null });
+      }
+      relations = { suite: { data } };
+    }
+
+    if (test.parent) {
+      const file = getFile(test.parent);
+      if (file) {
+        const tags = extractTags(file, test.title);
+        const fromTags = parseProjectMappingFromTags(tags);
+        legacyIds.push(...fromTags.legacyIds);
+        for (const [code, idsFromTag] of Object.entries(fromTags.projectMapping)) {
+          projectMapping[code] = [...(projectMapping[code] ?? []), ...idsFromTag];
+        }
+      }
+    }
+
+    const hasProjectMapping = Object.keys(projectMapping).length > 0;
+    const result: TestResultType = {
+      attachments,
+      author: null,
+      fields: {},
+      message: null,
+      muted: false,
+      params: {},
+      group_params: {},
+      relations,
+      run_id: null,
+      signature: getSignature(test, hasProjectMapping ? [] : legacyIds, {}),
+      steps: [],
+      id: uuidv4(),
+      execution: {
+        status: TestStatusEnum.skipped,
+        start_time: testBeginTime / 1000,
+        end_time: end_time / 1000,
+        duration: 0,
+        stacktrace: null,
+        thread: null,
+      },
+      testops_id: !hasProjectMapping && legacyIds.length > 0
+        ? (legacyIds.length === 1 ? legacyIds[0]! : legacyIds)
+        : null,
+      testops_project_mapping: hasProjectMapping ? projectMapping : null,
+      title: fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title),
+      preparedAttachments: [],
+    } as unknown as TestResultType;
+
+    return result;
+  }
+}
+
+function getSignature(test: Test, ids: number[], params: Record<string, string>): string {
+  const suites: string[] = [];
+  const file = test.parent ? getFile(test.parent) : undefined;
+
+  if (file) {
+    suites.push(file.split(path.sep).join('::'));
+  }
+  if (test.parent) {
+    for (const suite of test.parent.titlePath()) {
+      suites.push(normalizeSuitePart(suite));
+    }
+  }
+  suites.push(normalizeSuitePart(test.title));
+
+  return generateSignature(ids, suites, params);
+}
+
+function getTestFileName(test: Test): string {
+  if (!test.parent) {
+    return '';
+  }
+  const file = getFile(test.parent);
+  if (!file) {
+    return '';
+  }
+  const pathParts = file.split(path.sep);
+  const fileName = pathParts[pathParts.length - 1];
+  return fileName ? fileName : '';
+}

--- a/qase-cypress/src/skipped-test-handler.ts
+++ b/qase-cypress/src/skipped-test-handler.ts
@@ -1,0 +1,44 @@
+import type { Suite, Test } from 'mocha';
+import type { TestResultType } from 'qase-javascript-commons';
+import type { ResultBuilder, BuildSkippedArgs } from './result-builder';
+import type { TestTracker } from './test-tracker';
+
+export type PublishFn = (result: TestResultType) => void;
+export type BuildArgsFactory = (test: Test) => Omit<BuildSkippedArgs, 'test'>;
+
+/**
+ * Detects tests skipped due to a beforeEach failure (which never emit
+ * TEST_PASS/PENDING/FAIL events) by walking the suite tree at SUITE_END
+ * and synthesizing a skipped TestResult for each unprocessed test.
+ */
+export class SkippedTestHandler {
+  constructor(
+    private readonly tracker: TestTracker,
+    private readonly resultBuilder: ResultBuilder,
+    private readonly publish: PublishFn,
+    private readonly buildArgsFor: BuildArgsFactory,
+  ) {}
+
+  handleSuiteEnd(suite: Suite): void {
+    const allTests: Test[] = [];
+    this.collectAllTestsFromSuite(suite, allTests);
+
+    for (const test of allTests) {
+      if (!this.tracker.isProcessed(test)) {
+        const opts = this.buildArgsFor(test);
+        const result = this.resultBuilder.buildSkipped({ test, ...opts });
+        this.publish(result);
+        this.tracker.markProcessed(test);
+      }
+    }
+  }
+
+  private collectAllTestsFromSuite(suite: Suite, tests: Test[]): void {
+    const suiteTests = suite.tests ?? [];
+    tests.push(...suiteTests);
+    const nestedSuites = suite.suites ?? [];
+    for (const nestedSuite of nestedSuites) {
+      this.collectAllTestsFromSuite(nestedSuite, tests);
+    }
+  }
+}

--- a/qase-cypress/src/step-converter.ts
+++ b/qase-cypress/src/step-converter.ts
@@ -1,0 +1,81 @@
+import {
+  Attachment,
+  StepStatusEnum,
+  StepType,
+  TestStepType,
+} from 'qase-javascript-commons';
+import type { StepEnd, StepStart } from './metadata/models';
+
+export class StepConverter {
+  convertCypressMessages(messages: StepStart[], testStatus: string): TestStepType[] {
+    const result: TestStepType[] = [];
+
+    const lastIndex = messages.length - 1;
+    for (const message of messages) {
+      const step = new TestStepType(StepType.TEXT);
+      step.id = message.id;
+      step.execution.status = StepStatusEnum.passed;
+      step.execution.start_time = message.timestamp;
+      step.data = {
+        action: message.name,
+        expected_result: null,
+        data: null,
+      };
+
+      if (lastIndex === messages.indexOf(message) && testStatus !== 'passed') {
+        step.execution.status = StepStatusEnum.failed;
+      }
+
+      result.push(step);
+    }
+
+    return result;
+  }
+
+  getSteps(steps: (StepStart | StepEnd)[], attachments: Record<string, Attachment[]>): TestStepType[] {
+    const result: TestStepType[] = [];
+    const stepMap = new Map<string, TestStepType>();
+
+    for (const step of steps.sort((a, b) => a.timestamp - b.timestamp)) {
+      if (!('status' in step)) {
+        const newStep = new TestStepType();
+        newStep.id = step.id;
+        newStep.execution.status = StepStatusEnum.failed;
+        newStep.execution.start_time = step.timestamp;
+        newStep.execution.end_time = Date.now();
+        newStep.data = {
+          action: step.name,
+          expected_result: null,
+          data: null,
+        };
+
+        if (attachments[step.id]) {
+          newStep.attachments = attachments[step.id] ?? [];
+        }
+
+        const parentId = step.parentId;
+        if (parentId) {
+          newStep.parent_id = parentId;
+          const parent = stepMap.get(parentId);
+          if (parent) {
+            parent.steps.push(newStep);
+          } else {
+            result.push(newStep);
+          }
+        } else {
+          result.push(newStep);
+        }
+
+        stepMap.set(step.id, newStep);
+      } else {
+        const stepType = stepMap.get(step.id);
+        if (stepType) {
+          stepType.execution.status = step.status as StepStatusEnum;
+          stepType.execution.end_time = step.timestamp;
+        }
+      }
+    }
+
+    return result;
+  }
+}

--- a/qase-cypress/src/test-tracker.ts
+++ b/qase-cypress/src/test-tracker.ts
@@ -1,0 +1,36 @@
+import type { Test } from 'mocha';
+import {
+  getFile as getFileFromNode,
+  FileSuiteNode,
+} from 'qase-javascript-commons/internal';
+
+const getFile = (suite: { parent?: unknown; file?: string }): string | undefined =>
+  getFileFromNode(suite as unknown as FileSuiteNode);
+
+/**
+ * Tracks which tests the reporter has already produced a result for.
+ * Used to detect tests skipped due to a `beforeEach` failure (those never
+ * fire a `TEST_PASS`/`PENDING`/`FAIL` event).
+ */
+export class TestTracker {
+  private readonly processed = new Set<string>();
+
+  getTestIdentifier(test: Test): string {
+    const file = test.parent ? getFile(test.parent) ?? '' : '';
+    const suitePath = test.parent ? test.parent.titlePath().join(' > ') : '';
+    let testTitle = test.fullTitle();
+    testTitle = testTitle.replace(/"before each" hook for "/g, '');
+    if (testTitle.endsWith('"')) {
+      testTitle = testTitle.slice(0, -1);
+    }
+    return `${file}::${suitePath}::${testTitle}`;
+  }
+
+  markProcessed(test: Test): void {
+    this.processed.add(this.getTestIdentifier(test));
+  }
+
+  isProcessed(test: Test): boolean {
+    return this.processed.has(this.getTestIdentifier(test));
+  }
+}

--- a/qase-cypress/test/result-builder.test.ts
+++ b/qase-cypress/test/result-builder.test.ts
@@ -1,0 +1,191 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import type { Suite, Test } from 'mocha';
+import {
+  StepStatusEnum,
+  TestStatusEnum,
+} from 'qase-javascript-commons';
+import { ResultBuilder, BuildArgs, BuildSkippedArgs } from '../src/result-builder';
+import { StepConverter } from '../src/step-converter';
+import type { Metadata } from '../src/metadata/models';
+import type { ReporterOptionsType } from '../src/options';
+
+function makeTest(opts: { title: string; state?: string; err?: { message: string; stack?: string }; suiteTitlePath?: string[]; file?: string }): Test {
+  const parent = opts.suiteTitlePath
+    ? ({
+        titlePath: () => opts.suiteTitlePath!,
+        file: opts.file,
+        parent: undefined,
+      } as unknown as Suite)
+    : undefined;
+  return {
+    title: opts.title,
+    state: opts.state,
+    err: opts.err,
+    parent,
+  } as unknown as Test;
+}
+
+function emptyMetadata(): Metadata {
+  return {
+    title: undefined,
+    fields: {},
+    parameters: {},
+    groupParams: {},
+    ignore: false,
+    suite: undefined,
+    comment: undefined,
+    steps: [],
+    cucumberSteps: [],
+    currentStepId: undefined,
+    firstStepName: undefined,
+    attachments: [],
+    stepAttachments: {},
+  } as unknown as Metadata;
+}
+
+function defaultArgs(over: Partial<BuildArgs> = {}): BuildArgs {
+  return {
+    test: makeTest({ title: 'login', state: 'passed', suiteTitlePath: ['Auth', 'login'], file: '/tests/auth.spec.ts' }),
+    metadata: emptyMetadata(),
+    screenshotsFolder: undefined,
+    testBeginTime: 1000,
+    isCucumber: false,
+    options: {} as ReporterOptionsType,
+    ...over,
+  };
+}
+
+describe('ResultBuilder.build', () => {
+  let builder: ResultBuilder;
+
+  beforeEach(() => {
+    builder = new ResultBuilder(new StepConverter());
+  });
+
+  it('returns null when metadata.ignore is true', () => {
+    const args = defaultArgs({ metadata: { ...emptyMetadata(), ignore: true } });
+    expect(builder.build(args)).toBeNull();
+  });
+
+  it('uses metadata.title when present, otherwise removes Qase IDs from test.title', () => {
+    const args1 = defaultArgs({ metadata: { ...emptyMetadata(), title: 'override' } });
+    expect(builder.build(args1)?.title).toBe('override');
+
+    const args2 = defaultArgs({ test: makeTest({ title: 'login (Qase ID: 1)' }) });
+    expect(builder.build(args2)?.title).toBe('login');
+  });
+
+  it('extracts testops_id from a (Qase ID: 1,2) title when no metadata or annotations', () => {
+    const args = defaultArgs({ test: makeTest({ title: 'login (Qase ID: 1,2)' }) });
+    const r = builder.build(args)!;
+    expect(r.testops_id).toEqual([1, 2]);
+  });
+
+  it('combines metadata.comment with test.err.message into the message field', () => {
+    const args = defaultArgs({
+      test: makeTest({ title: 't', state: 'failed', err: { message: 'boom' } }),
+      metadata: { ...emptyMetadata(), comment: 'note' },
+    });
+    const r = builder.build(args)!;
+    expect(r.message).toContain('note');
+    expect(r.message).toContain('boom');
+  });
+
+  it('uses metadata.suite as a single-element relations.suite when present', () => {
+    const args = defaultArgs({ metadata: { ...emptyMetadata(), suite: 'Custom' } });
+    const r = builder.build(args)!;
+    expect((r.relations as any).suite.data).toEqual([{ title: 'Custom', public_id: null }]);
+  });
+
+  it('falls back to test.parent.titlePath() for relations.suite when metadata.suite is empty', () => {
+    const args = defaultArgs({ test: makeTest({ title: 't', suiteTitlePath: ['A', 'B'] }) });
+    const r = builder.build(args)!;
+    expect((r.relations as any).suite.data).toEqual([
+      { title: 'A', public_id: null },
+      { title: 'B', public_id: null },
+    ]);
+  });
+
+  it('produces steps from metadata.steps via StepConverter.getSteps', () => {
+    const args = defaultArgs({
+      metadata: {
+        ...emptyMetadata(),
+        steps: [{ id: 's1', name: 'click', timestamp: 100 } as any],
+        stepAttachments: {},
+      },
+    });
+    const r = builder.build(args)!;
+    expect(r.steps).toHaveLength(1);
+    expect(r.steps[0]?.id).toBe('s1');
+  });
+
+  it('appends cucumber steps when isCucumber is true and metadata.cucumberSteps is non-empty', () => {
+    const args = defaultArgs({
+      test: makeTest({ title: 'login', state: 'passed', suiteTitlePath: ['Auth', 'login'] }),
+      isCucumber: true,
+      metadata: {
+        ...emptyMetadata(),
+        cucumberSteps: [{ id: 'c1', name: 'Given x', timestamp: 50 } as any],
+      },
+    });
+    const r = builder.build(args)!;
+    expect(r.steps.find((s: any) => s.id === 'c1')).toBeDefined();
+  });
+
+  it('maps test.state via determineTestStatus', () => {
+    const passedArgs = defaultArgs({ test: makeTest({ title: 't', state: 'passed' }) });
+    expect(builder.build(passedArgs)?.execution.status).toBe(TestStatusEnum.passed);
+    const failedArgs = defaultArgs({ test: makeTest({ title: 't', state: 'failed', err: { message: 'expected x to equal y' } }) });
+    expect(builder.build(failedArgs)?.execution.status).toBe(TestStatusEnum.failed);
+  });
+
+  it('computes signature with normalized suites and parameters', () => {
+    const args = defaultArgs({
+      test: makeTest({ title: 'login', suiteTitlePath: ['Auth Suite'], file: '/x/y.spec.ts' }),
+      metadata: { ...emptyMetadata(), parameters: { user: 'admin' } },
+    });
+    const r = builder.build(args)!;
+    expect(typeof r.signature).toBe('string');
+    expect(r.signature.length).toBeGreaterThan(0);
+  });
+});
+
+describe('ResultBuilder.buildSkipped', () => {
+  let builder: ResultBuilder;
+
+  beforeEach(() => {
+    builder = new ResultBuilder(new StepConverter());
+  });
+
+  it('returns a skipped status result', () => {
+    const test = makeTest({ title: 't', suiteTitlePath: ['Auth', 't'] });
+    const opts: BuildSkippedArgs = { test, screenshotsFolder: undefined, testBeginTime: 1000 };
+    const r = builder.buildSkipped(opts);
+    expect(r.execution.status).toBe(TestStatusEnum.skipped);
+    expect(r.execution.duration).toBe(0);
+  });
+
+  it('extracts ids from a (Qase ID: 5) title even without metadata', () => {
+    const test = makeTest({ title: 'foo (Qase ID: 5)' });
+    const r = builder.buildSkipped({ test, screenshotsFolder: undefined, testBeginTime: 1000 });
+    expect(r.testops_id).toBe(5);
+  });
+
+  it('builds relations.suite from test.parent.titlePath() when present', () => {
+    const test = makeTest({ title: 't', suiteTitlePath: ['Outer', 'Inner', 't'] });
+    const r = builder.buildSkipped({ test, screenshotsFolder: undefined, testBeginTime: 1000 });
+    expect((r.relations as any).suite.data).toEqual([
+      { title: 'Outer', public_id: null },
+      { title: 'Inner', public_id: null },
+      { title: 't', public_id: null },
+    ]);
+  });
+
+  it('produces no steps and no attachments when screenshotsFolder is undefined', () => {
+    const test = makeTest({ title: 't' });
+    const r = builder.buildSkipped({ test, screenshotsFolder: undefined, testBeginTime: 1000 });
+    expect(r.steps).toEqual([]);
+    expect(r.attachments).toEqual([]);
+  });
+});

--- a/qase-cypress/test/skipped-test-handler.test.ts
+++ b/qase-cypress/test/skipped-test-handler.test.ts
@@ -1,0 +1,101 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import type { Suite, Test } from 'mocha';
+import { TestStatusEnum, TestResultType } from 'qase-javascript-commons';
+import { SkippedTestHandler } from '../src/skipped-test-handler';
+import { TestTracker } from '../src/test-tracker';
+import { ResultBuilder } from '../src/result-builder';
+import { StepConverter } from '../src/step-converter';
+
+function makeTest(title: string): Test {
+  return {
+    title,
+    fullTitle: () => title,
+    parent: undefined,
+  } as unknown as Test;
+}
+
+function makeSuite(tests: Test[], nested: Suite[] = []): Suite {
+  return { tests, suites: nested } as unknown as Suite;
+}
+
+function makeFakeResult(title: string): TestResultType {
+  return { title, execution: { status: TestStatusEnum.skipped } } as unknown as TestResultType;
+}
+
+describe('SkippedTestHandler', () => {
+  let tracker: TestTracker;
+  let resultBuilder: ResultBuilder;
+  let publish: jest.Mock<(r: TestResultType) => void>;
+  let handler: SkippedTestHandler;
+
+  beforeEach(() => {
+    tracker = new TestTracker();
+    resultBuilder = new ResultBuilder(new StepConverter());
+    publish = jest.fn() as any;
+    handler = new SkippedTestHandler(
+      tracker,
+      resultBuilder,
+      publish,
+      () => ({ screenshotsFolder: undefined, testBeginTime: 1000 }),
+    );
+  });
+
+  it('does nothing for an empty suite', () => {
+    handler.handleSuiteEnd(makeSuite([]));
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('does not publish anything when every test is already processed', () => {
+    const t1 = makeTest('a');
+    const t2 = makeTest('b');
+    tracker.markProcessed(t1);
+    tracker.markProcessed(t2);
+    handler.handleSuiteEnd(makeSuite([t1, t2]));
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('publishes a skipped result for each unprocessed test', () => {
+    jest.spyOn(resultBuilder, 'buildSkipped').mockImplementation(({ test }) => makeFakeResult(test.title));
+    const t1 = makeTest('a');
+    const t2 = makeTest('b');
+    tracker.markProcessed(t1); // t1 already done; t2 should be marked skipped
+    handler.handleSuiteEnd(makeSuite([t1, t2]));
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect((publish.mock.calls[0]![0] as any).title).toBe('b');
+  });
+
+  it('marks the test as processed after publishing the skipped result', () => {
+    jest.spyOn(resultBuilder, 'buildSkipped').mockImplementation(({ test }) => makeFakeResult(test.title));
+    const t = makeTest('only');
+    handler.handleSuiteEnd(makeSuite([t]));
+    expect(tracker.isProcessed(t)).toBe(true);
+  });
+
+  it('walks nested suites recursively', () => {
+    jest.spyOn(resultBuilder, 'buildSkipped').mockImplementation(({ test }) => makeFakeResult(test.title));
+    const inner1 = makeTest('x');
+    const inner2 = makeTest('y');
+    const inner = makeSuite([inner1]);
+    const middle = makeSuite([inner2], [inner]);
+    handler.handleSuiteEnd(middle);
+    expect(publish).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the buildArgsFor factory to obtain screenshotsFolder/testBeginTime per test', () => {
+    const factory = jest.fn(() => ({ screenshotsFolder: '/s', testBeginTime: 42 }));
+    const h = new SkippedTestHandler(tracker, resultBuilder, publish, factory as any);
+    jest.spyOn(resultBuilder, 'buildSkipped').mockImplementation(({ test }) => makeFakeResult(test.title));
+    h.handleSuiteEnd(makeSuite([makeTest('a')]));
+    expect(factory).toHaveBeenCalled();
+  });
+
+  it('does not double-publish if the same test exists in multiple suites', () => {
+    jest.spyOn(resultBuilder, 'buildSkipped').mockImplementation(({ test }) => makeFakeResult(test.title));
+    const t = makeTest('shared');
+    const inner = makeSuite([t]);
+    const outer = makeSuite([t], [inner]);
+    handler.handleSuiteEnd(outer);
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/qase-cypress/test/step-converter.test.ts
+++ b/qase-cypress/test/step-converter.test.ts
@@ -1,0 +1,114 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { StepConverter } from '../src/step-converter';
+import { StepStatusEnum } from 'qase-javascript-commons';
+import type { StepEnd, StepStart } from '../src/metadata/models';
+
+describe('StepConverter', () => {
+  let converter: StepConverter;
+
+  beforeEach(() => {
+    converter = new StepConverter();
+  });
+
+  describe('convertCypressMessages', () => {
+    it('returns an empty array for empty input', () => {
+      expect(converter.convertCypressMessages([], 'passed')).toEqual([]);
+    });
+
+    it('maps each StepStart to a passed TextStep with id, action, start_time', () => {
+      const messages: StepStart[] = [
+        { id: 's1', name: 'click', timestamp: 100 } as StepStart,
+        { id: 's2', name: 'verify', timestamp: 200 } as StepStart,
+      ];
+      const result = converter.convertCypressMessages(messages, 'passed');
+      expect(result).toHaveLength(2);
+      expect(result[0]?.id).toBe('s1');
+      expect(result[0]?.data.action).toBe('click');
+      expect(result[0]?.execution.status).toBe(StepStatusEnum.passed);
+      expect(result[0]?.execution.start_time).toBe(100);
+    });
+
+    it('marks the LAST step failed when test status is not passed', () => {
+      const messages: StepStart[] = [
+        { id: 's1', name: 'a', timestamp: 100 } as StepStart,
+        { id: 's2', name: 'b', timestamp: 200 } as StepStart,
+      ];
+      const result = converter.convertCypressMessages(messages, 'failed');
+      expect(result[0]?.execution.status).toBe(StepStatusEnum.passed);
+      expect(result[1]?.execution.status).toBe(StepStatusEnum.failed);
+    });
+  });
+
+  describe('getSteps', () => {
+    it('returns an empty array when no messages are provided', () => {
+      expect(converter.getSteps([], {})).toEqual([]);
+    });
+
+    it('builds a flat list when no parent_id is set', () => {
+      const messages: (StepStart | StepEnd)[] = [
+        { id: 's1', name: 'a', timestamp: 100 } as StepStart,
+        { id: 's1', timestamp: 200, status: 'passed' } as StepEnd,
+      ];
+      const result = converter.getSteps(messages, {});
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe('s1');
+      expect(result[0]?.execution.status).toBe(StepStatusEnum.passed);
+      expect(result[0]?.execution.end_time).toBe(200);
+    });
+
+    it('nests a child under its parent via parentId', () => {
+      const messages: (StepStart | StepEnd)[] = [
+        { id: 'p', name: 'parent', timestamp: 100 } as StepStart,
+        { id: 'c', name: 'child', timestamp: 110, parentId: 'p' } as StepStart,
+        { id: 'c', timestamp: 120, status: 'passed' } as StepEnd,
+        { id: 'p', timestamp: 130, status: 'passed' } as StepEnd,
+      ];
+      const result = converter.getSteps(messages, {});
+      expect(result).toHaveLength(1);
+      expect(result[0]?.steps).toHaveLength(1);
+      expect(result[0]?.steps[0]?.id).toBe('c');
+      expect(result[0]?.steps[0]?.parent_id).toBe('p');
+    });
+
+    it('starts every step as failed; StepEnd updates status', () => {
+      const messages: (StepStart | StepEnd)[] = [
+        { id: 's', name: 'a', timestamp: 100 } as StepStart,
+        { id: 's', timestamp: 200, status: 'failed' } as StepEnd,
+      ];
+      const result = converter.getSteps(messages, {});
+      expect(result[0]?.execution.status).toBe(StepStatusEnum.failed);
+    });
+
+    it('attaches per-step attachments by step id', () => {
+      const messages: (StepStart | StepEnd)[] = [
+        { id: 's1', name: 'a', timestamp: 100 } as StepStart,
+      ];
+      const attachments = {
+        s1: [{ file_name: 'x.png', mime_type: 'image/png', content: '', file_path: null, size: 0, id: 'a1' } as any],
+      };
+      const result = converter.getSteps(messages, attachments);
+      expect(result[0]?.attachments).toHaveLength(1);
+      expect(result[0]?.attachments[0]?.file_name).toBe('x.png');
+    });
+
+    it('sorts messages by timestamp before processing', () => {
+      const messages: (StepStart | StepEnd)[] = [
+        { id: 'b', name: 'second', timestamp: 200 } as StepStart,
+        { id: 'a', name: 'first', timestamp: 100 } as StepStart,
+      ];
+      const result = converter.getSteps(messages, {});
+      expect(result[0]?.id).toBe('a');
+      expect(result[1]?.id).toBe('b');
+    });
+
+    it('keeps a child as a top-level step when parent is missing from the message stream', () => {
+      const messages: (StepStart | StepEnd)[] = [
+        { id: 'orphan', name: 'lonely', timestamp: 100, parentId: 'missing-parent' } as StepStart,
+      ];
+      const result = converter.getSteps(messages, {});
+      expect(result).toHaveLength(1);
+      expect(result[0]?.parent_id).toBe('missing-parent');
+    });
+  });
+});

--- a/qase-cypress/test/test-tracker.test.ts
+++ b/qase-cypress/test/test-tracker.test.ts
@@ -1,0 +1,58 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import type { Suite, Test } from 'mocha';
+import { TestTracker } from '../src/test-tracker';
+
+function makeTest(opts: { fullTitle: string; parentSuites?: string[]; file?: string }): Test {
+  const parent = opts.parentSuites
+    ? ({
+        titlePath: () => opts.parentSuites!,
+        file: opts.file,
+        parent: undefined,
+      } as unknown as Suite)
+    : undefined;
+  return {
+    fullTitle: () => opts.fullTitle,
+    parent,
+  } as unknown as Test;
+}
+
+describe('TestTracker', () => {
+  let tracker: TestTracker;
+
+  beforeEach(() => {
+    tracker = new TestTracker();
+  });
+
+  it('starts with no processed tests', () => {
+    const t = makeTest({ fullTitle: 'login flow' });
+    expect(tracker.isProcessed(t)).toBe(false);
+  });
+
+  it('marks a test processed and reports it', () => {
+    const t = makeTest({ fullTitle: 'login flow' });
+    tracker.markProcessed(t);
+    expect(tracker.isProcessed(t)).toBe(true);
+  });
+
+  it('strips "before each" hook prefix from full title in identifier', () => {
+    const t = makeTest({ fullTitle: '"before each" hook for "click button"' });
+    expect(tracker.getTestIdentifier(t)).toContain('click button');
+    expect(tracker.getTestIdentifier(t)).not.toContain('before each');
+  });
+
+  it('marking is idempotent — second call does not change state', () => {
+    const t = makeTest({ fullTitle: 'login flow' });
+    tracker.markProcessed(t);
+    tracker.markProcessed(t);
+    expect(tracker.isProcessed(t)).toBe(true);
+  });
+
+  it('two trackers do not share state', () => {
+    const a = new TestTracker();
+    const b = new TestTracker();
+    const t = makeTest({ fullTitle: 'login flow' });
+    a.markProcessed(t);
+    expect(b.isProcessed(t)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Decomposes \`CypressQaseReporter\` (619 LOC) into 4 focused modules:
- \`TestTracker\` (test-tracker.ts) — encapsulates the processedTests Set with explicit accessors.
- \`StepConverter\` (step-converter.ts) — Cypress StepStart/StepEnd → TestStepType (recursive parent_id resolution).
- \`ResultBuilder\` (result-builder.ts) — \`build(args)\` for normal tests + \`buildSkipped(args)\` for tests skipped by beforeEach failure. Helpers \`getSignature\`/\`getTestFileName\` become free functions inside the module.
- \`SkippedTestHandler\` (skipped-test-handler.ts) — SUITE_END suite walk + beforeEach-failure detection; calls \`buildSkipped\` and publishes via callback.

Reporter is now an orchestrator wiring these modules and dispatching Mocha runner events. Cross-process state (\`MetadataManager\`, \`ResultsManager\`) is intentionally not touched — out of scope.

- 619 LOC → **201 LOC** in \`reporter.ts\` (-67%).
- +36 unit tests on the new modules. Net 50 → 86 tests across 10 suites.
- Bumps \`qase-cypress\` version \`3.5.0\` → \`3.6.0\`.
- Phase 2 third decomposition (after wdio PR #950, playwright PR #951) — design at \`docs/superpowers/specs/2026-04-28-cypress-decomposition-design.md\`.

## Removed
- Deprecated \`static qaseIdRegExp\` removed from \`CypressQaseReporter\`. The field was JSDoc-marked \`@deprecated\` since Phase 1 in favor of \`parseProjectMappingFromTitle\` from \`qase-javascript-commons\`. Same precedent as \`MochaQaseReporter\` in PR #946.

## Behavior fix surfaced by decomposition
- In \`StepConverter.getSteps\`, orphan child steps with \`parentId\` set but missing parent now surface as top-level steps instead of being silently dropped. Documented in CHANGELOG.

## Public contract
Unchanged otherwise. \`CypressQaseReporter\` class extends \`reporters.Base\`, ctor signature \`(runner, options, configLoader?)\`, \`static statusMap\`, and \`CypressQaseOptionsType\` type export are preserved.

## Smoke tests
- [x] \`npm run build/lint/test --workspace=qase-cypress\` green (86 tests, 10 suites).
- [x] \`examples/single/cypress\` runs with \`QASE_MODE=report\` and produces a report — all 13 specs passed.
- [x] \`examples/single/cypress\` with \`QASE_MODE=testops\` against DEVX — run #664 created and completed without errors; all 13 results uploaded.

## Review
Each commit corresponds to one module extraction (TDD red → green → reporter delegation). Reviewing commit-by-commit shows the decomposition as it lands.