### PR TITLE
refactor(mocha): decompose reporter into focused modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30662,13 +30662,17 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
+        "@jest/globals": "^29.7.0",
         "@types/deasync-promise": "^1.0.2",
+        "@types/jest": "^29.5.14",
         "@types/mocha": "^10.0.10",
         "@types/request": "^2.48.13",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "eslint": "^8.57.1",
-        "prettier": "^2.8.8"
+        "jest": "^29.7.0",
+        "prettier": "^2.8.8",
+        "ts-jest": "^29.4.5"
       },
       "engines": {
         "node": ">=14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30653,7 +30653,7 @@
     },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "deasync-promise": "^1.0.1",

--- a/qase-mocha/changelog.md
+++ b/qase-mocha/changelog.md
@@ -1,3 +1,13 @@
+# mocha-qase-reporter@1.5.0
+
+## Changed
+
+- Decomposed `reporter.ts` (465 LOC) into a thin orchestrator plus 5 focused modules under `src/modules/`: `MetadataApplier`, `OutputCapture`, `StepRunner`, `ProfilerTracker`, `ResultBuilder`. Public contract preserved: `MochaQaseReporter` named export, constructor signature, `static statusMap`, all 11 user-API methods bound to test context (`qaseId`, `title`, `parameters`, `groupParameters`, `fields`, `suite`, `ignore`, `attach`, `comment`, `tags`, `step`), Mocha lifecycle hooks, and parallel mode behavior.
+
+## Internal
+
+- Added Jest + ts-jest test infrastructure; introduced 43 unit tests across the new modules.
+
 # mocha-qase-reporter@1.4.0
 
 ## Changed

--- a/qase-mocha/jest.config.js
+++ b/qase-mocha/jest.config.js
@@ -1,0 +1,16 @@
+/* eslint-disable */
+module.exports = {
+  preset: 'ts-jest',
+  roots: ['<rootDir>/test'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      tsconfig: {
+        skipLibCheck: true,
+      },
+    }],
+  },
+  testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['js', 'ts'],
+  collectCoverage: false,
+  testEnvironment: 'node',
+};

--- a/qase-mocha/jest.config.js
+++ b/qase-mocha/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     '^.+\\.ts$': ['ts-jest', {
       tsconfig: {
         skipLibCheck: true,
+        isolatedModules: true,
       },
     }],
   },

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -47,12 +47,16 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@types/deasync-promise": "^1.0.2",
+    "@types/jest": "^29.5.14",
     "@types/mocha": "^10.0.10",
     "@types/request": "^2.48.13",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^8.57.1",
-    "prettier": "^2.8.8"
+    "jest": "^29.7.0",
+    "prettier": "^2.8.8",
+    "ts-jest": "^29.4.5"
   }
 }

--- a/qase-mocha/src/modules/metadataApplier.ts
+++ b/qase-mocha/src/modules/metadataApplier.ts
@@ -1,0 +1,68 @@
+import { Metadata } from '../types';
+
+interface AttachInput {
+  name?: string;
+  paths?: string | string[];
+  content?: Buffer | string;
+  contentType?: string;
+}
+
+export class MetadataApplier {
+  private metadata: Metadata = new Metadata();
+
+  reset(): void {
+    this.metadata.clear();
+  }
+
+  get(): Metadata {
+    return this.metadata;
+  }
+
+  applyQaseId(id: number | number[]): void {
+    this.metadata.addQaseId(id);
+  }
+
+  applyTitle(title: string): void {
+    this.metadata.title = title;
+  }
+
+  applyParameters(values: Record<string, string>): void {
+    this.metadata.parameters = MetadataApplier.coerceStringRecord(values);
+  }
+
+  applyGroupParameters(values: Record<string, string>): void {
+    this.metadata.groupParameters = MetadataApplier.coerceStringRecord(values);
+  }
+
+  applyFields(values: Record<string, string>): void {
+    this.metadata.fields = MetadataApplier.coerceStringRecord(values);
+  }
+
+  applySuite(name: string): void {
+    this.metadata.suite = name;
+  }
+
+  applyIgnore(): void {
+    this.metadata.ignore = true;
+  }
+
+  applyAttach(attach: AttachInput): void {
+    this.metadata.addAttachment(attach);
+  }
+
+  applyComment(message: string): void {
+    this.metadata.addComment(message);
+  }
+
+  applyTags(values: string[]): void {
+    this.metadata.addTags(values);
+  }
+
+  private static coerceStringRecord(values: Record<string, unknown>): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(values)) {
+      result[String(key)] = String(value);
+    }
+    return result;
+  }
+}

--- a/qase-mocha/src/modules/outputCapture.ts
+++ b/qase-mocha/src/modules/outputCapture.ts
@@ -1,0 +1,60 @@
+import { StreamInterceptor } from '../interceptor';
+
+export interface CapturedOutput {
+  stdout: string;
+  stderr: string;
+}
+
+export class OutputCapture {
+  private originalStdoutWrite: typeof process.stdout.write | null = null;
+  private originalStderrWrite: typeof process.stderr.write | null = null;
+  private buffer: CapturedOutput = { stdout: '', stderr: '' };
+
+  install(): void {
+    if (this.originalStdoutWrite || this.originalStderrWrite) {
+      // Already installed; preserve existing originals.
+      return;
+    }
+
+    this.buffer = { stdout: '', stderr: '' };
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    this.originalStdoutWrite = process.stdout.write;
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    this.originalStderrWrite = process.stderr.write;
+
+    const stdoutInterceptor = new StreamInterceptor((data: string) => {
+      this.buffer.stdout += data;
+    });
+    const stderrInterceptor = new StreamInterceptor((data: string) => {
+      this.buffer.stderr += data;
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+    process.stdout.write = stdoutInterceptor.write.bind(stdoutInterceptor) as typeof process.stdout.write;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+    process.stderr.write = stderrInterceptor.write.bind(stderrInterceptor) as typeof process.stderr.write;
+  }
+
+  drain(): CapturedOutput {
+    this.restore();
+    const result = this.buffer;
+    this.buffer = { stdout: '', stderr: '' };
+    return result;
+  }
+
+  reset(): void {
+    this.restore();
+    this.buffer = { stdout: '', stderr: '' };
+  }
+
+  private restore(): void {
+    if (this.originalStdoutWrite) {
+      process.stdout.write = this.originalStdoutWrite;
+      this.originalStdoutWrite = null;
+    }
+    if (this.originalStderrWrite) {
+      process.stderr.write = this.originalStderrWrite;
+      this.originalStderrWrite = null;
+    }
+  }
+}

--- a/qase-mocha/src/modules/profilerTracker.ts
+++ b/qase-mocha/src/modules/profilerTracker.ts
@@ -1,0 +1,26 @@
+import { TestStepType } from 'qase-javascript-commons';
+import { NetworkProfiler } from 'qase-javascript-commons/profilers';
+
+export class ProfilerTracker {
+  private snapshot = 0;
+
+  constructor(private readonly profiler: NetworkProfiler | null) {}
+
+  onTestStart(): void {
+    this.snapshot = this.profiler?.getAllSteps().length ?? 0;
+  }
+
+  getEvents(): TestStepType[] {
+    if (!this.profiler) return [];
+    const all = this.profiler.getAllSteps();
+    return all.slice(this.snapshot);
+  }
+
+  reset(): void {
+    this.snapshot = 0;
+  }
+
+  restore(): void {
+    this.profiler?.restore();
+  }
+}

--- a/qase-mocha/src/modules/resultBuilder.ts
+++ b/qase-mocha/src/modules/resultBuilder.ts
@@ -1,0 +1,161 @@
+import { Suite } from 'mocha';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  TestResultType,
+  TestStepType,
+  determineTestStatus,
+  generateSignature,
+  parseProjectMappingFromTitle,
+} from 'qase-javascript-commons';
+
+import {
+  removeQaseIdsFromTitle,
+  getFile as getFileFromNode,
+  FileSuiteNode,
+  normalizeSuitePart,
+} from 'qase-javascript-commons/internal';
+import { Metadata } from '../types';
+import { CapturedOutput } from './outputCapture';
+
+export interface BuildArgs {
+  test: Mocha.Test;
+  metadata: Metadata;
+  steps: TestStepType[];
+  profilerSteps: TestStepType[];
+  output: CapturedOutput;
+  testBeginTime: number;
+  cwd: string;
+  attachLogs?: boolean;
+}
+
+const getFile = (suite: Suite): string | undefined =>
+  getFileFromNode(suite as unknown as FileSuiteNode);
+
+export class ResultBuilder {
+  static build(args: BuildArgs): TestResultType {
+    const { test, metadata, steps, profilerSteps, output, testBeginTime, cwd } = args;
+    const end_time = Date.now();
+    const duration = test.duration ?? end_time - testBeginTime;
+
+    const fromTitle = parseProjectMappingFromTitle(test.title);
+
+    const ids = ResultBuilder.getQaseId(metadata);
+    if (ids.length === 0) {
+      ids.push(...fromTitle.legacyIds);
+    }
+    const hasProjectMapping = Object.keys(fromTitle.projectMapping).length > 0;
+
+    const suites = ResultBuilder.getSuites(test, metadata);
+    let relations: Record<string, unknown> = {};
+    if (suites.length > 0) {
+      relations = {
+        suite: {
+          data: suites.map((title) => ({ title, public_id: null })),
+        },
+      };
+    }
+
+    let message = metadata.comment ?? '';
+    if (test.err?.message) {
+      message += message ? `\n\n${test.err.message}` : test.err.message;
+    }
+
+    const attachments = [...(metadata.attachments ?? [])];
+    if (args.attachLogs) {
+      if (output.stdout) {
+        attachments.push({
+          file_name: 'stdout.txt',
+          mime_type: 'text/plain',
+          content: output.stdout,
+          file_path: null,
+          size: 0,
+          id: '',
+        });
+      }
+      if (output.stderr) {
+        attachments.push({
+          file_name: 'stderr.txt',
+          mime_type: 'text/plain',
+          content: output.stderr,
+          file_path: null,
+          size: 0,
+          id: '',
+        });
+      }
+    }
+
+    return {
+      attachments,
+      author: null,
+      fields: metadata.fields ?? {},
+      tags: metadata.tags ?? [],
+      message: message ? message : null,
+      muted: false,
+      params: metadata.parameters ?? {},
+      group_params: metadata.groupParameters ?? {},
+      relations,
+      run_id: null,
+      signature: ResultBuilder.getSignature(
+        test,
+        hasProjectMapping ? [] : ids,
+        metadata.parameters ?? {},
+        cwd,
+      ),
+      steps: [...steps, ...profilerSteps],
+      id: uuidv4(),
+      execution: {
+        status: determineTestStatus(test.err ?? null, test.state ?? 'failed'),
+        start_time: testBeginTime / 1000,
+        end_time: end_time / 1000,
+        duration,
+        stacktrace: test.err?.stack ?? null,
+        thread: null,
+      },
+      testops_id: hasProjectMapping ? null : (ids.length > 0 ? ids : null),
+      testops_project_mapping: hasProjectMapping ? fromTitle.projectMapping : null,
+      title: metadata.title && metadata.title !== ''
+        ? metadata.title
+        : (fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title)),
+    } as unknown as TestResultType;
+  }
+
+  static getSignature(
+    test: Mocha.Test,
+    ids: number[],
+    params: Record<string, string>,
+    cwd: string,
+  ): string {
+    const suites: string[] = [];
+    const file = test.parent ? getFile(test.parent) : undefined;
+    if (file) {
+      const executionPath = cwd.endsWith('/') ? cwd : `${cwd}/`;
+      const path = file.replace(executionPath, '');
+      suites.push(path.split('/').join('::'));
+    }
+
+    if (test.parent) {
+      for (const suite of test.parent.titlePath()) {
+        suites.push(normalizeSuitePart(suite));
+      }
+    }
+
+    suites.push(normalizeSuitePart(test.title));
+
+    return generateSignature(ids, suites, params);
+  }
+
+  static getQaseId(metadata: Metadata): number[] {
+    if (metadata.ids) return [...metadata.ids];
+    return [];
+  }
+
+  static getSuites(test: Mocha.Test, metadata: Metadata): string[] {
+    if (metadata.suite) return [metadata.suite];
+
+    const suites: string[] = [];
+    if (test.parent) {
+      suites.push(...test.parent.titlePath().filter(Boolean));
+    }
+    return suites;
+  }
+}

--- a/qase-mocha/src/modules/statusMap.ts
+++ b/qase-mocha/src/modules/statusMap.ts
@@ -1,0 +1,9 @@
+import { TestStatusEnum } from 'qase-javascript-commons';
+
+export type MochaState = 'failed' | 'passed' | 'pending';
+
+export const STATUS_MAP: Record<MochaState, TestStatusEnum> = {
+  failed: TestStatusEnum.failed,
+  passed: TestStatusEnum.passed,
+  pending: TestStatusEnum.skipped,
+};

--- a/qase-mocha/src/modules/stepRunner.ts
+++ b/qase-mocha/src/modules/stepRunner.ts
@@ -1,0 +1,57 @@
+import { StepStatusEnum, StepType, TestStepType } from 'qase-javascript-commons';
+import { extractAndCleanStep } from 'qase-javascript-commons/internal';
+
+export class StepRunner {
+  private steps: TestStepType[] = [];
+  private failureFlag = false;
+
+  reset(): void {
+    this.steps = [];
+    this.failureFlag = false;
+  }
+
+  getSteps(): TestStepType[] {
+    return this.steps;
+  }
+
+  hasFailure(): boolean {
+    return this.failureFlag;
+  }
+
+  run(title: string, func: () => void, expectedResult?: string, data?: string): void {
+    const stepTitle = expectedResult || data
+      ? `${title} QaseExpRes:${expectedResult ? `: ${expectedResult}` : ''} QaseData:${data ? `: ${data}` : ''}`
+      : title;
+
+    const stepData = extractAndCleanStep(stepTitle);
+
+    const step: TestStepType = {
+      step_type: StepType.TEXT,
+      data: {
+        action: stepData.cleanedString,
+        expected_result: stepData.expectedResult,
+        data: stepData.data,
+      },
+      execution: {
+        start_time: Date.now(),
+        status: StepStatusEnum.passed,
+        end_time: null,
+        duration: null,
+      },
+      id: '',
+      parent_id: null,
+      attachments: [],
+      steps: [],
+    };
+
+    try {
+      func();
+    } catch {
+      step.execution.status = StepStatusEnum.failed;
+      this.failureFlag = true;
+    }
+
+    step.execution.end_time = Date.now();
+    this.steps.push(step);
+  }
+}

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -1,5 +1,6 @@
 import { Context, MochaOptions, reporters, Runner, Suite } from 'mocha';
-import { Hook, Metadata, Test } from './types';
+import { Hook, Test } from './types';
+import { MetadataApplier } from './modules/metadataApplier';
 import {
   Attachment,
   composeOptions,
@@ -71,11 +72,7 @@ export class MochaQaseReporter extends reporters.Base {
    */
   private reporter: ReporterInterface;
 
-  /**
-   * @type {Metadata}
-   * @private
-   */
-  private readonly metadata: Metadata = new Metadata();
+  private readonly metadataApplier: MetadataApplier = new MetadataApplier();
 
   private currentTest: currentTest = new currentTest();
   private testBeginTime: number = Date.now();
@@ -228,8 +225,10 @@ export class MochaQaseReporter extends reporters.Base {
       }
     }
 
-    if (this.metadata.ignore) {
-      this.metadata.clear();
+    const metadata = this.metadataApplier.get();
+
+    if (metadata.ignore) {
+      this.metadataApplier.reset();
       this.currentTest = new currentTest();
       return;
     }
@@ -258,7 +257,7 @@ export class MochaQaseReporter extends reporters.Base {
       };
     }
 
-    let message = this.metadata.comment;
+    let message = metadata.comment;
     if (test.err?.message) {
       message += message ? `\n\n${test.err.message}` : test.err.message;
     }
@@ -271,17 +270,17 @@ export class MochaQaseReporter extends reporters.Base {
     }
 
     const result: TestResultType = {
-      attachments: this.metadata.attachments ?? [],
+      attachments: metadata.attachments ?? [],
       author: null,
-      fields: this.metadata.fields ?? {},
-      tags: this.metadata.tags ?? [],
+      fields: metadata.fields ?? {},
+      tags: metadata.tags ?? [],
       message: message ?? null,
       muted: false,
-      params: this.metadata.parameters ?? {},
-      group_params: this.metadata.groupParameters ?? {},
+      params: metadata.parameters ?? {},
+      group_params: metadata.groupParameters ?? {},
       relations: relations,
       run_id: null,
-      signature: this.getSignature(test, hasProjectMapping ? [] : ids, this.metadata.parameters ?? {}),
+      signature: this.getSignature(test, hasProjectMapping ? [] : ids, metadata.parameters ?? {}),
       steps: [...this.currentTest.steps, ...profilerSteps],
       id: uuidv4(),
       execution: {
@@ -294,12 +293,12 @@ export class MochaQaseReporter extends reporters.Base {
       },
       testops_id: hasProjectMapping ? null : (ids.length > 0 ? ids : null),
       testops_project_mapping: hasProjectMapping ? fromTitle.projectMapping : null,
-      title: this.metadata.title && this.metadata.title != '' ? this.metadata.title : (fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title)),
+      title: metadata.title && metadata.title != '' ? metadata.title : (fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title)),
     } as TestResultType;
 
     void this.reporter.addTestResult(result);
 
-    this.metadata.clear();
+    this.metadataApplier.reset();
     this.currentTest = new currentTest();
   }
 
@@ -334,8 +333,8 @@ export class MochaQaseReporter extends reporters.Base {
    * @private
    */
   private getQaseId(): number[] {
-    if (this.metadata.ids) {
-      return this.metadata.ids;
+    if (this.metadataApplier.get().ids) {
+      return this.metadataApplier.get().ids ?? [];
     }
 
     return [];
@@ -347,8 +346,8 @@ export class MochaQaseReporter extends reporters.Base {
    * @private
    */
   private getSuites(test: Mocha.Test): string[] {
-    if (this.metadata.suite) {
-      return [this.metadata.suite];
+    if (this.metadataApplier.get().suite) {
+      return [this.metadataApplier.get().suite ?? ''];
     }
 
     const suites = [];
@@ -360,55 +359,43 @@ export class MochaQaseReporter extends reporters.Base {
   }
 
   qaseId = (id: number | number[]) => {
-    this.metadata.addQaseId(id);
+    this.metadataApplier.applyQaseId(id);
   };
 
   title = (title: string) => {
-    this.metadata.title = title;
+    this.metadataApplier.applyTitle(title);
   };
 
   parameters = (values: Record<string, string>) => {
-    const stringRecord: Record<string, string> = {};
-    for (const [key, value] of Object.entries(values)) {
-      stringRecord[String(key)] = String(value);
-    }
-    this.metadata.parameters = stringRecord;
+    this.metadataApplier.applyParameters(values);
   };
 
   groupParameters = (values: Record<string, string>) => {
-    const stringRecord: Record<string, string> = {};
-    for (const [key, value] of Object.entries(values)) {
-      stringRecord[String(key)] = String(value);
-    }
-    this.metadata.groupParameters = stringRecord;
+    this.metadataApplier.applyGroupParameters(values);
   };
 
   fields = (values: Record<string, string>) => {
-    const stringRecord: Record<string, string> = {};
-    for (const [key, value] of Object.entries(values)) {
-      stringRecord[String(key)] = String(value);
-    }
-    this.metadata.fields = stringRecord;
+    this.metadataApplier.applyFields(values);
   };
 
   suite = (name: string) => {
-    this.metadata.suite = name;
+    this.metadataApplier.applySuite(name);
   };
 
   ignore = () => {
-    this.metadata.ignore = true;
+    this.metadataApplier.applyIgnore();
   };
 
   attach = (attach: { name?: string, paths?: string | string[], content?: Buffer | string, contentType?: string }) => {
-    this.metadata.addAttachment(attach);
+    this.metadataApplier.applyAttach(attach);
   };
 
   comment = (message: string) => {
-    this.metadata.addComment(message);
+    this.metadataApplier.applyComment(message);
   };
 
   tags = (...values: string[]) => {
-    this.metadata.addTags(values);
+    this.metadataApplier.applyTags(values);
   };
 
   step = (title: string, func: () => void, expectedResult?: string, data?: string) => {

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -1,29 +1,19 @@
-import { Context, MochaOptions, reporters, Runner, Suite } from 'mocha';
+import { Context, MochaOptions, reporters, Runner } from 'mocha';
 import { Hook, Metadata, Test } from './types';
 import {
   composeOptions,
   ConfigLoader,
-  generateSignature,
   QaseReporter,
   ReporterInterface,
-  TestResultType,
   TestStatusEnum,
-  determineTestStatus,
-  parseProjectMappingFromTitle,
 } from 'qase-javascript-commons';
-import {
-  removeQaseIdsFromTitle,
-  getFile as getFileFromNode,
-  FileSuiteNode,
-  normalizeSuitePart,
-} from 'qase-javascript-commons/internal';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
 import deasyncPromise from 'deasync-promise';
 import { extname, join } from 'node:path';
-import { v4 as uuidv4 } from 'uuid';
 import { OutputCapture } from './modules/outputCapture';
 import { StepRunner } from './modules/stepRunner';
 import { ProfilerTracker } from './modules/profilerTracker';
+import { ResultBuilder } from './modules/resultBuilder';
 import {
   parseExtraReporters,
   createExtraReporters,
@@ -36,14 +26,6 @@ const Events = Runner.constants;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return,@typescript-eslint/restrict-template-expressions
 const resolveParallelModeSetupFile = () => join(__dirname, `parallel${extname(__filename)}`);
-
-/**
- * Adapter around the shared `getFile` helper to bridge the Mocha `Suite`
- * type (whose `parent` is `Suite | undefined`) with `FileSuiteNode`
- * (whose `parent` is optional under `exactOptionalPropertyTypes`).
- */
-const getFile = (suite: Suite): string | undefined =>
-  getFileFromNode(suite as unknown as FileSuiteNode);
 
 export class MochaQaseReporter extends reporters.Base {
 
@@ -181,145 +163,32 @@ export class MochaQaseReporter extends reporters.Base {
   }
 
   private onEndTest(test: Mocha.Test) {
-    const end_time = Date.now();
-    const duration = test.duration ?? end_time - this.testBeginTime;
-
     const output = this.outputCapture.drain();
+    const metadata = this.metadata;
 
-    if (this.reporter.isCaptureLogs()) {
-      if (output.stdout) {
-        this.attach({ name: 'stdout.txt', content: output.stdout, contentType: 'text/plain' });
-      }
-      if (output.stderr) {
-        this.attach({ name: 'stderr.txt', content: output.stderr, contentType: 'text/plain' });
-      }
-    }
-
-    if (this.metadata.ignore) {
+    if (metadata.ignore) {
       this.metadata.clear();
       this.stepRunner.reset();
+      this.profilerTracker.reset();
       return;
     }
 
-    const fromTitle = parseProjectMappingFromTitle(test.title);
-    const ids = this.getQaseId();
-    if (ids.length === 0) {
-      ids.push(...fromTitle.legacyIds);
-    }
-    const hasProjectMapping = Object.keys(fromTitle.projectMapping).length > 0;
-    const suites = this.getSuites(test);
-    let relations = {};
-    if (suites.length > 0) {
-      const data = [];
-      for (const suite of suites) {
-        data.push({
-          title: suite,
-          public_id: null,
-        });
-      }
-
-      relations = {
-        suite: {
-          data: data,
-        },
-      };
-    }
-
-    let message = this.metadata.comment;
-    if (test.err?.message) {
-      message += message ? `\n\n${test.err.message}` : test.err.message;
-    }
-
-    const profilerSteps = this.profilerTracker.getEvents();
-    this.profilerTracker.reset();
-
-    const result: TestResultType = {
-      attachments: this.metadata.attachments ?? [],
-      author: null,
-      fields: this.metadata.fields ?? {},
-      tags: this.metadata.tags ?? [],
-      message: message ?? null,
-      muted: false,
-      params: this.metadata.parameters ?? {},
-      group_params: this.metadata.groupParameters ?? {},
-      relations: relations,
-      run_id: null,
-      signature: this.getSignature(test, hasProjectMapping ? [] : ids, this.metadata.parameters ?? {}),
-      steps: [...this.stepRunner.getSteps(), ...profilerSteps],
-      id: uuidv4(),
-      execution: {
-        status: determineTestStatus(test.err ?? null, test.state ?? 'failed'),
-        start_time: this.testBeginTime / 1000,
-        end_time: end_time / 1000,
-        duration: duration,
-        stacktrace: test.err?.stack ?? null,
-        thread: null,
-      },
-      testops_id: hasProjectMapping ? null : (ids.length > 0 ? ids : null),
-      testops_project_mapping: hasProjectMapping ? fromTitle.projectMapping : null,
-      title: this.metadata.title && this.metadata.title != '' ? this.metadata.title : (fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title)),
-    } as TestResultType;
+    const result = ResultBuilder.build({
+      test,
+      metadata,
+      steps: this.stepRunner.getSteps(),
+      profilerSteps: this.profilerTracker.getEvents(),
+      output,
+      testBeginTime: this.testBeginTime,
+      cwd: process.cwd(),
+      attachLogs: this.reporter.isCaptureLogs(),
+    });
 
     void this.reporter.addTestResult(result);
 
     this.metadata.clear();
     this.stepRunner.reset();
-  }
-
-  /**
-   * @param {Test} test
-   * @param {number[]} ids
-   * @private
-   */
-  private getSignature(test: Mocha.Test, ids: number[], params: Record<string, string>) {
-    const suites = [];
-    const file = test.parent ? getFile(test.parent) : undefined;
-
-    if (file) {
-      const executionPath = process.cwd() + '/';
-      const path = file.replace(executionPath, '');
-      suites.push(path.split('/').join('::'));
-    }
-
-    if (test.parent) {
-      for (const suite of test.parent.titlePath()) {
-        suites.push(normalizeSuitePart(suite));
-      }
-    }
-
-    suites.push(normalizeSuitePart(test.title));
-
-    return generateSignature(ids, suites, params);
-  }
-
-  /**
-   * @returns {number[]}
-   * @private
-   */
-  private getQaseId(): number[] {
-    if (this.metadata.ids) {
-      return this.metadata.ids;
-    }
-
-    return [];
-  }
-
-  /**
-   * @param {Mocha.Test} test
-   * @returns {string[]}
-   * @private
-   */
-  private getSuites(test: Mocha.Test): string[] {
-    if (this.metadata.suite) {
-      return [this.metadata.suite];
-    }
-
-    const suites = [];
-    if (test.parent) {
-      suites.push(...test.parent.titlePath().filter(Boolean));
-    }
-
-    return suites;
+    this.profilerTracker.reset();
   }
 
   qaseId = (id: number | number[]) => {

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -27,16 +27,15 @@ import deasyncPromise from 'deasync-promise';
 import { extname, join } from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
 import { StreamInterceptor, TestOutput } from './interceptor';
-import { 
-  parseExtraReporters, 
-  createExtraReporters, 
-  validateExtraReportersForParallel 
+import {
+  parseExtraReporters,
+  createExtraReporters,
+  validateExtraReportersForParallel
 } from './extraReporters';
+import { STATUS_MAP, MochaState } from './modules/statusMap';
 
 
 const Events = Runner.constants;
-
-type MochaState = 'failed' | 'passed' | 'pending';
 
 class currentTest {
   steps: TestStepType[] = [];
@@ -64,14 +63,7 @@ export class MochaQaseReporter extends reporters.Base {
   private profiler: NetworkProfiler | null = null;
   private _profilerStepSnapshot = 0;
 
-  /**
-   * @type {Record<CypressState, TestStatusEnum>}
-   */
-  static statusMap: Record<MochaState, TestStatusEnum> = {
-    failed: TestStatusEnum.failed,
-    passed: TestStatusEnum.passed,
-    pending: TestStatusEnum.skipped,
-  };
+  static statusMap: Record<MochaState, TestStatusEnum> = STATUS_MAP;
 
   /**
    * @type {ReporterInterface}

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -1,5 +1,6 @@
 import { Context, MochaOptions, reporters, Runner } from 'mocha';
-import { Hook, Metadata, Test } from './types';
+import { Hook, Test } from './types';
+import { MetadataApplier } from './modules/metadataApplier';
 import {
   composeOptions,
   ConfigLoader,
@@ -30,22 +31,13 @@ const resolveParallelModeSetupFile = () => join(__dirname, `parallel${extname(__
 export class MochaQaseReporter extends reporters.Base {
 
   private readonly outputCapture: OutputCapture = new OutputCapture();
-  // readonly #extraReporters: reporters.Base[] = [];
   private profilerTracker: ProfilerTracker;
 
   static statusMap: Record<MochaState, TestStatusEnum> = STATUS_MAP;
 
-  /**
-   * @type {ReporterInterface}
-   * @private
-   */
   private reporter: ReporterInterface;
 
-  /**
-   * @type {Metadata}
-   * @private
-   */
-  private readonly metadata: Metadata = new Metadata();
+  private readonly metadataApplier: MetadataApplier = new MetadataApplier();
 
   private readonly stepRunner: StepRunner = new StepRunner();
   private testBeginTime: number = Date.now();
@@ -164,10 +156,10 @@ export class MochaQaseReporter extends reporters.Base {
 
   private onEndTest(test: Mocha.Test) {
     const output = this.outputCapture.drain();
-    const metadata = this.metadata;
+    const metadata = this.metadataApplier.get();
 
     if (metadata.ignore) {
-      this.metadata.clear();
+      this.metadataApplier.reset();
       this.stepRunner.reset();
       this.profilerTracker.reset();
       return;
@@ -186,61 +178,49 @@ export class MochaQaseReporter extends reporters.Base {
 
     void this.reporter.addTestResult(result);
 
-    this.metadata.clear();
+    this.metadataApplier.reset();
     this.stepRunner.reset();
     this.profilerTracker.reset();
   }
 
   qaseId = (id: number | number[]) => {
-    this.metadata.addQaseId(id);
+    this.metadataApplier.applyQaseId(id);
   };
 
   title = (title: string) => {
-    this.metadata.title = title;
+    this.metadataApplier.applyTitle(title);
   };
 
   parameters = (values: Record<string, string>) => {
-    const stringRecord: Record<string, string> = {};
-    for (const [key, value] of Object.entries(values)) {
-      stringRecord[String(key)] = String(value);
-    }
-    this.metadata.parameters = stringRecord;
+    this.metadataApplier.applyParameters(values);
   };
 
   groupParameters = (values: Record<string, string>) => {
-    const stringRecord: Record<string, string> = {};
-    for (const [key, value] of Object.entries(values)) {
-      stringRecord[String(key)] = String(value);
-    }
-    this.metadata.groupParameters = stringRecord;
+    this.metadataApplier.applyGroupParameters(values);
   };
 
   fields = (values: Record<string, string>) => {
-    const stringRecord: Record<string, string> = {};
-    for (const [key, value] of Object.entries(values)) {
-      stringRecord[String(key)] = String(value);
-    }
-    this.metadata.fields = stringRecord;
+    this.metadataApplier.applyFields(values);
   };
 
   suite = (name: string) => {
-    this.metadata.suite = name;
+    this.metadataApplier.applySuite(name);
   };
 
   ignore = () => {
-    this.metadata.ignore = true;
+    this.metadataApplier.applyIgnore();
   };
 
   attach = (attach: { name?: string, paths?: string | string[], content?: Buffer | string, contentType?: string }) => {
-    this.metadata.addAttachment(attach);
+    this.metadataApplier.applyAttach(attach);
   };
 
   comment = (message: string) => {
-    this.metadata.addComment(message);
+    this.metadataApplier.applyComment(message);
   };
 
   tags = (...values: string[]) => {
-    this.metadata.addTags(values);
+    this.metadataApplier.applyTags(values);
   };
 
   step = (title: string, func: () => void, expectedResult?: string, data?: string) => {

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -1,14 +1,11 @@
 import { Context, MochaOptions, reporters, Runner, Suite } from 'mocha';
 import { Hook, Metadata, Test } from './types';
 import {
-  Attachment,
   composeOptions,
   ConfigLoader,
   generateSignature,
   QaseReporter,
   ReporterInterface,
-  StepStatusEnum,
-  StepType,
   TestResultType,
   TestStatusEnum,
   TestStepType,
@@ -17,7 +14,6 @@ import {
 } from 'qase-javascript-commons';
 import {
   removeQaseIdsFromTitle,
-  extractAndCleanStep,
   getFile as getFileFromNode,
   FileSuiteNode,
   normalizeSuitePart,
@@ -27,6 +23,7 @@ import deasyncPromise from 'deasync-promise';
 import { extname, join } from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
 import { OutputCapture } from './modules/outputCapture';
+import { StepRunner } from './modules/stepRunner';
 import {
   parseExtraReporters,
   createExtraReporters,
@@ -36,12 +33,6 @@ import { STATUS_MAP, MochaState } from './modules/statusMap';
 
 
 const Events = Runner.constants;
-
-class currentTest {
-  steps: TestStepType[] = [];
-  status: MochaState = 'passed';
-  attachments: Attachment[] = [];
-}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return,@typescript-eslint/restrict-template-expressions
 const resolveParallelModeSetupFile = () => join(__dirname, `parallel${extname(__filename)}`);
@@ -75,7 +66,7 @@ export class MochaQaseReporter extends reporters.Base {
    */
   private readonly metadata: Metadata = new Metadata();
 
-  private currentTest: currentTest = new currentTest();
+  private readonly stepRunner: StepRunner = new StepRunner();
   private testBeginTime: number = Date.now();
   private currentType: 'test' | 'step' = 'test';
 
@@ -182,6 +173,7 @@ export class MochaQaseReporter extends reporters.Base {
   private onStartTest() {
     this.outputCapture.reset();
     this.outputCapture.install();
+    this.stepRunner.reset();
     this.currentType = 'test';
     this.testBeginTime = Date.now();
     this._profilerStepSnapshot = this.profiler?.getAllSteps().length ?? 0;
@@ -204,7 +196,7 @@ export class MochaQaseReporter extends reporters.Base {
 
     if (this.metadata.ignore) {
       this.metadata.clear();
-      this.currentTest = new currentTest();
+      this.stepRunner.reset();
       return;
     }
 
@@ -256,7 +248,7 @@ export class MochaQaseReporter extends reporters.Base {
       relations: relations,
       run_id: null,
       signature: this.getSignature(test, hasProjectMapping ? [] : ids, this.metadata.parameters ?? {}),
-      steps: [...this.currentTest.steps, ...profilerSteps],
+      steps: [...this.stepRunner.getSteps(), ...profilerSteps],
       id: uuidv4(),
       execution: {
         status: determineTestStatus(test.err ?? null, test.state ?? 'failed'),
@@ -274,7 +266,7 @@ export class MochaQaseReporter extends reporters.Base {
     void this.reporter.addTestResult(result);
 
     this.metadata.clear();
-    this.currentTest = new currentTest();
+    this.stepRunner.reset();
   }
 
   /**
@@ -386,46 +378,9 @@ export class MochaQaseReporter extends reporters.Base {
   };
 
   step = (title: string, func: () => void, expectedResult?: string, data?: string) => {
-
     const previousType = this.currentType;
-
     this.currentType = 'step';
-
-    const stepTitle = expectedResult || data 
-      ? `${title} QaseExpRes:${expectedResult ? `: ${expectedResult}` : ''} QaseData:${data ? `: ${data}` : ''}` 
-      : title;
-
-    const stepData = extractAndCleanStep(stepTitle);
-
-    const step: TestStepType = {
-      step_type: StepType.TEXT,
-      data: {
-        action: stepData.cleanedString,
-        expected_result: stepData.expectedResult,
-        data: stepData.data,
-      },
-      execution: {
-        start_time: Date.now(),
-        status: StepStatusEnum.passed,
-        end_time: null,
-        duration: null,
-      },
-      id: '',
-      parent_id: null,
-      attachments: [],
-      steps: [],
-    };
-
-    try {
-      func();
-    } catch (err) {
-      step.execution.status = StepStatusEnum.failed;
-      this.currentTest.status = 'failed';
-    }
-
-    step.execution.end_time = Date.now();
-
-    this.currentTest.steps.push(step);
+    this.stepRunner.run(title, func, expectedResult, data);
     this.currentType = previousType;
   };
 }

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -8,7 +8,6 @@ import {
   ReporterInterface,
   TestResultType,
   TestStatusEnum,
-  TestStepType,
   determineTestStatus,
   parseProjectMappingFromTitle,
 } from 'qase-javascript-commons';
@@ -24,6 +23,7 @@ import { extname, join } from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
 import { OutputCapture } from './modules/outputCapture';
 import { StepRunner } from './modules/stepRunner';
+import { ProfilerTracker } from './modules/profilerTracker';
 import {
   parseExtraReporters,
   createExtraReporters,
@@ -49,8 +49,7 @@ export class MochaQaseReporter extends reporters.Base {
 
   private readonly outputCapture: OutputCapture = new OutputCapture();
   // readonly #extraReporters: reporters.Base[] = [];
-  private profiler: NetworkProfiler | null = null;
-  private _profilerStepSnapshot = 0;
+  private profilerTracker: ProfilerTracker;
 
   static statusMap: Record<MochaState, TestStatusEnum> = STATUS_MAP;
 
@@ -89,13 +88,15 @@ export class MochaQaseReporter extends reporters.Base {
       reporterName: 'mocha-qase-reporter',
     });
 
+    let profiler: NetworkProfiler | null = null;
     if (composedOptions.profilers?.includes('network')) {
-      this.profiler = new NetworkProfiler({
+      profiler = new NetworkProfiler({
         skipDomains: composedOptions.networkProfiler?.skip_domains,
         trackOnFail: composedOptions.networkProfiler?.track_on_fail,
       });
-      this.profiler.enable();
+      profiler.enable();
     }
+    this.profilerTracker = new ProfilerTracker(profiler);
 
     // Create extra reporters in both modes, but validate compatibility for parallel mode
     if (extraReportersConfig) {
@@ -145,7 +146,7 @@ export class MochaQaseReporter extends reporters.Base {
   }
 
   private onEndRun() {
-    this.profiler?.restore();
+    this.profilerTracker.restore();
     deasyncPromise(this.reporter.publish());
   }
 
@@ -176,7 +177,7 @@ export class MochaQaseReporter extends reporters.Base {
     this.stepRunner.reset();
     this.currentType = 'test';
     this.testBeginTime = Date.now();
-    this._profilerStepSnapshot = this.profiler?.getAllSteps().length ?? 0;
+    this.profilerTracker.onTestStart();
   }
 
   private onEndTest(test: Mocha.Test) {
@@ -229,12 +230,8 @@ export class MochaQaseReporter extends reporters.Base {
       message += message ? `\n\n${test.err.message}` : test.err.message;
     }
 
-    let profilerSteps: TestStepType[] = [];
-    if (this.profiler) {
-      const allSteps = this.profiler.getAllSteps();
-      profilerSteps = allSteps.slice(this._profilerStepSnapshot);
-      this._profilerStepSnapshot = 0;
-    }
+    const profilerSteps = this.profilerTracker.getEvents();
+    this.profilerTracker.reset();
 
     const result: TestResultType = {
       attachments: this.metadata.attachments ?? [],

--- a/qase-mocha/src/reporter.ts
+++ b/qase-mocha/src/reporter.ts
@@ -1,6 +1,5 @@
 import { Context, MochaOptions, reporters, Runner, Suite } from 'mocha';
-import { Hook, Test } from './types';
-import { MetadataApplier } from './modules/metadataApplier';
+import { Hook, Metadata, Test } from './types';
 import {
   Attachment,
   composeOptions,
@@ -27,7 +26,7 @@ import { NetworkProfiler } from 'qase-javascript-commons/profilers';
 import deasyncPromise from 'deasync-promise';
 import { extname, join } from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
-import { StreamInterceptor, TestOutput } from './interceptor';
+import { OutputCapture } from './modules/outputCapture';
 import {
   parseExtraReporters,
   createExtraReporters,
@@ -57,9 +56,7 @@ const getFile = (suite: Suite): string | undefined =>
 
 export class MochaQaseReporter extends reporters.Base {
 
-  private originalStdoutWrite: typeof process.stdout.write;
-  private originalStderrWrite: typeof process.stderr.write;
-  private testOutputs: Map<string, TestOutput>;
+  private readonly outputCapture: OutputCapture = new OutputCapture();
   // readonly #extraReporters: reporters.Base[] = [];
   private profiler: NetworkProfiler | null = null;
   private _profilerStepSnapshot = 0;
@@ -72,7 +69,11 @@ export class MochaQaseReporter extends reporters.Base {
    */
   private reporter: ReporterInterface;
 
-  private readonly metadataApplier: MetadataApplier = new MetadataApplier();
+  /**
+   * @type {Metadata}
+   * @private
+   */
+  private readonly metadata: Metadata = new Metadata();
 
   private currentTest: currentTest = new currentTest();
   private testBeginTime: number = Date.now();
@@ -134,9 +135,6 @@ export class MochaQaseReporter extends reporters.Base {
       this.applyListeners();
     }
 
-    this.originalStdoutWrite = process.stdout.write.bind(process.stdout);
-    this.originalStderrWrite = process.stderr.write.bind(process.stderr);
-    this.testOutputs = new Map();
   }
 
   private applyListeners = () => {
@@ -177,30 +175,13 @@ export class MochaQaseReporter extends reporters.Base {
   }
 
   private addMethods(test: Test) {
-    const stdoutInterceptor = new StreamInterceptor((data: string) => {
-      const output = this.testOutputs.get(test.title) ?? { stdout: '', stderr: '' };
-      output.stdout += data;
-      this.testOutputs.set(test.title, output);
-    });
-
-    const stderrInterceptor = new StreamInterceptor((data: string) => {
-      const output = this.testOutputs.get(test.title) ?? { stdout: '', stderr: '' };
-      output.stderr += data;
-      this.testOutputs.set(test.title, output);
-
-    });
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
-    process.stdout.write = stdoutInterceptor.write.bind(stdoutInterceptor);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
-    process.stderr.write = stderrInterceptor.write.bind(stderrInterceptor);
-
-    this.testOutputs.set(test.title, { stdout: '', stderr: '' });
-
+    this.outputCapture.install();
     this.addMethodsToContext(test.ctx);
   }
 
   private onStartTest() {
+    this.outputCapture.reset();
+    this.outputCapture.install();
     this.currentType = 'test';
     this.testBeginTime = Date.now();
     this._profilerStepSnapshot = this.profiler?.getAllSteps().length ?? 0;
@@ -210,25 +191,19 @@ export class MochaQaseReporter extends reporters.Base {
     const end_time = Date.now();
     const duration = test.duration ?? end_time - this.testBeginTime;
 
-    process.stdout.write = this.originalStdoutWrite;
-    process.stderr.write = this.originalStderrWrite;
+    const output = this.outputCapture.drain();
 
     if (this.reporter.isCaptureLogs()) {
-      const output = this.testOutputs.get(test.title);
-
-      if (output?.stdout) {
+      if (output.stdout) {
         this.attach({ name: 'stdout.txt', content: output.stdout, contentType: 'text/plain' });
       }
-
-      if (output?.stderr) {
+      if (output.stderr) {
         this.attach({ name: 'stderr.txt', content: output.stderr, contentType: 'text/plain' });
       }
     }
 
-    const metadata = this.metadataApplier.get();
-
-    if (metadata.ignore) {
-      this.metadataApplier.reset();
+    if (this.metadata.ignore) {
+      this.metadata.clear();
       this.currentTest = new currentTest();
       return;
     }
@@ -257,7 +232,7 @@ export class MochaQaseReporter extends reporters.Base {
       };
     }
 
-    let message = metadata.comment;
+    let message = this.metadata.comment;
     if (test.err?.message) {
       message += message ? `\n\n${test.err.message}` : test.err.message;
     }
@@ -270,17 +245,17 @@ export class MochaQaseReporter extends reporters.Base {
     }
 
     const result: TestResultType = {
-      attachments: metadata.attachments ?? [],
+      attachments: this.metadata.attachments ?? [],
       author: null,
-      fields: metadata.fields ?? {},
-      tags: metadata.tags ?? [],
+      fields: this.metadata.fields ?? {},
+      tags: this.metadata.tags ?? [],
       message: message ?? null,
       muted: false,
-      params: metadata.parameters ?? {},
-      group_params: metadata.groupParameters ?? {},
+      params: this.metadata.parameters ?? {},
+      group_params: this.metadata.groupParameters ?? {},
       relations: relations,
       run_id: null,
-      signature: this.getSignature(test, hasProjectMapping ? [] : ids, metadata.parameters ?? {}),
+      signature: this.getSignature(test, hasProjectMapping ? [] : ids, this.metadata.parameters ?? {}),
       steps: [...this.currentTest.steps, ...profilerSteps],
       id: uuidv4(),
       execution: {
@@ -293,12 +268,12 @@ export class MochaQaseReporter extends reporters.Base {
       },
       testops_id: hasProjectMapping ? null : (ids.length > 0 ? ids : null),
       testops_project_mapping: hasProjectMapping ? fromTitle.projectMapping : null,
-      title: metadata.title && metadata.title != '' ? metadata.title : (fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title)),
+      title: this.metadata.title && this.metadata.title != '' ? this.metadata.title : (fromTitle.cleanedTitle || removeQaseIdsFromTitle(test.title)),
     } as TestResultType;
 
     void this.reporter.addTestResult(result);
 
-    this.metadataApplier.reset();
+    this.metadata.clear();
     this.currentTest = new currentTest();
   }
 
@@ -333,8 +308,8 @@ export class MochaQaseReporter extends reporters.Base {
    * @private
    */
   private getQaseId(): number[] {
-    if (this.metadataApplier.get().ids) {
-      return this.metadataApplier.get().ids ?? [];
+    if (this.metadata.ids) {
+      return this.metadata.ids;
     }
 
     return [];
@@ -346,8 +321,8 @@ export class MochaQaseReporter extends reporters.Base {
    * @private
    */
   private getSuites(test: Mocha.Test): string[] {
-    if (this.metadataApplier.get().suite) {
-      return [this.metadataApplier.get().suite ?? ''];
+    if (this.metadata.suite) {
+      return [this.metadata.suite];
     }
 
     const suites = [];
@@ -359,43 +334,55 @@ export class MochaQaseReporter extends reporters.Base {
   }
 
   qaseId = (id: number | number[]) => {
-    this.metadataApplier.applyQaseId(id);
+    this.metadata.addQaseId(id);
   };
 
   title = (title: string) => {
-    this.metadataApplier.applyTitle(title);
+    this.metadata.title = title;
   };
 
   parameters = (values: Record<string, string>) => {
-    this.metadataApplier.applyParameters(values);
+    const stringRecord: Record<string, string> = {};
+    for (const [key, value] of Object.entries(values)) {
+      stringRecord[String(key)] = String(value);
+    }
+    this.metadata.parameters = stringRecord;
   };
 
   groupParameters = (values: Record<string, string>) => {
-    this.metadataApplier.applyGroupParameters(values);
+    const stringRecord: Record<string, string> = {};
+    for (const [key, value] of Object.entries(values)) {
+      stringRecord[String(key)] = String(value);
+    }
+    this.metadata.groupParameters = stringRecord;
   };
 
   fields = (values: Record<string, string>) => {
-    this.metadataApplier.applyFields(values);
+    const stringRecord: Record<string, string> = {};
+    for (const [key, value] of Object.entries(values)) {
+      stringRecord[String(key)] = String(value);
+    }
+    this.metadata.fields = stringRecord;
   };
 
   suite = (name: string) => {
-    this.metadataApplier.applySuite(name);
+    this.metadata.suite = name;
   };
 
   ignore = () => {
-    this.metadataApplier.applyIgnore();
+    this.metadata.ignore = true;
   };
 
   attach = (attach: { name?: string, paths?: string | string[], content?: Buffer | string, contentType?: string }) => {
-    this.metadataApplier.applyAttach(attach);
+    this.metadata.addAttachment(attach);
   };
 
   comment = (message: string) => {
-    this.metadataApplier.applyComment(message);
+    this.metadata.addComment(message);
   };
 
   tags = (...values: string[]) => {
-    this.metadataApplier.applyTags(values);
+    this.metadata.addTags(values);
   };
 
   step = (title: string, func: () => void, expectedResult?: string, data?: string) => {

--- a/qase-mocha/test/metadataApplier.test.ts
+++ b/qase-mocha/test/metadataApplier.test.ts
@@ -1,0 +1,78 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { MetadataApplier } from '../src/modules/metadataApplier';
+
+describe('MetadataApplier', () => {
+  let applier: MetadataApplier;
+
+  beforeEach(() => {
+    applier = new MetadataApplier();
+  });
+
+  it('applyQaseId(number) sets ids to single-element array', () => {
+    applier.applyQaseId(123);
+    expect(applier.get().ids).toEqual([123]);
+  });
+
+  it('applyQaseId(array) sets ids to that array', () => {
+    applier.applyQaseId([1, 2, 3]);
+    expect(applier.get().ids).toEqual([1, 2, 3]);
+  });
+
+  it('applyTitle sets title field', () => {
+    applier.applyTitle('Custom title');
+    expect(applier.get().title).toBe('Custom title');
+  });
+
+  it('applyParameters coerces keys and values to strings', () => {
+    applier.applyParameters({ a: 1, b: true } as unknown as Record<string, string>);
+    expect(applier.get().parameters).toEqual({ a: '1', b: 'true' });
+  });
+
+  it('applyGroupParameters coerces keys and values to strings', () => {
+    applier.applyGroupParameters({ env: 'prod' });
+    expect(applier.get().groupParameters).toEqual({ env: 'prod' });
+  });
+
+  it('applyFields coerces keys and values to strings', () => {
+    applier.applyFields({ severity: 'high' });
+    expect(applier.get().fields).toEqual({ severity: 'high' });
+  });
+
+  it('applySuite sets the suite override', () => {
+    applier.applySuite('My Suite');
+    expect(applier.get().suite).toBe('My Suite');
+  });
+
+  it('applyIgnore sets the ignore flag', () => {
+    applier.applyIgnore();
+    expect(applier.get().ignore).toBe(true);
+  });
+
+  it('applyTags accumulates across calls and applyComment appends with \\n\\n', () => {
+    applier.applyTags(['smoke']);
+    applier.applyTags(['regression', 'fast']);
+    applier.applyComment('first');
+    applier.applyComment('second');
+
+    expect(applier.get().tags).toEqual(['smoke', 'regression', 'fast']);
+    expect(applier.get().comment).toBe('first\n\nsecond\n\n');
+  });
+
+  it('reset() clears all fields back to initial values', () => {
+    applier.applyQaseId(99);
+    applier.applyTitle('Custom');
+    applier.applyTags(['smoke']);
+    applier.applyIgnore();
+    applier.applyAttach({ name: 'log.txt', content: 'x', contentType: 'text/plain' });
+
+    applier.reset();
+
+    const m = applier.get();
+    expect(m.ids).toEqual([]);
+    expect(m.title).toBe('');
+    expect(m.tags).toEqual([]);
+    expect(m.ignore).toBe(false);
+    expect(m.attachments).toEqual([]);
+  });
+});

--- a/qase-mocha/test/outputCapture.test.ts
+++ b/qase-mocha/test/outputCapture.test.ts
@@ -1,0 +1,78 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
+import { OutputCapture } from '../src/modules/outputCapture';
+
+describe('OutputCapture', () => {
+  let originalStdoutWrite: typeof process.stdout.write;
+  let originalStderrWrite: typeof process.stderr.write;
+  let capture: OutputCapture;
+
+  beforeEach(() => {
+    originalStdoutWrite = process.stdout.write;
+    originalStderrWrite = process.stderr.write;
+    capture = new OutputCapture();
+  });
+
+  afterEach(() => {
+    // Safety: always restore the originals between tests.
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  });
+
+  it('install replaces process.stdout.write and process.stderr.write', () => {
+    capture.install();
+    expect(process.stdout.write).not.toBe(originalStdoutWrite);
+    expect(process.stderr.write).not.toBe(originalStderrWrite);
+  });
+
+  it('drain() restores originals and returns captured stdout/stderr', () => {
+    capture.install();
+    process.stdout.write('hello-out');
+    process.stderr.write('hello-err');
+
+    const result = capture.drain();
+
+    expect(result).toEqual({ stdout: 'hello-out', stderr: 'hello-err' });
+    expect(process.stdout.write).toBe(originalStdoutWrite);
+    expect(process.stderr.write).toBe(originalStderrWrite);
+  });
+
+  it('without install, drain returns empty strings and is a no-op on streams', () => {
+    const result = capture.drain();
+    expect(result).toEqual({ stdout: '', stderr: '' });
+    expect(process.stdout.write).toBe(originalStdoutWrite);
+    expect(process.stderr.write).toBe(originalStderrWrite);
+  });
+
+  it('reinstall after drain captures fresh data with no leakage', () => {
+    capture.install();
+    process.stdout.write('first');
+    capture.drain();
+
+    capture.install();
+    process.stdout.write('second');
+    const result = capture.drain();
+
+    expect(result.stdout).toBe('second');
+  });
+
+  it('keeps stdout and stderr separate', () => {
+    capture.install();
+    process.stdout.write('out1');
+    process.stderr.write('err1');
+    process.stdout.write('out2');
+
+    const result = capture.drain();
+
+    expect(result.stdout).toBe('out1out2');
+    expect(result.stderr).toBe('err1');
+  });
+
+  it('reset() restores originals even when drain() was not called', () => {
+    capture.install();
+    capture.reset();
+
+    expect(process.stdout.write).toBe(originalStdoutWrite);
+    expect(process.stderr.write).toBe(originalStderrWrite);
+  });
+});

--- a/qase-mocha/test/profilerTracker.test.ts
+++ b/qase-mocha/test/profilerTracker.test.ts
@@ -1,0 +1,78 @@
+/* eslint-disable */
+import { describe, expect, it } from '@jest/globals';
+import { TestStepType, StepType, StepStatusEnum } from 'qase-javascript-commons';
+import { ProfilerTracker } from '../src/modules/profilerTracker';
+
+class FakeProfiler {
+  private steps: TestStepType[] = [];
+
+  push(action: string): void {
+    this.steps.push({
+      step_type: StepType.TEXT,
+      data: { action, expected_result: null, data: null },
+      execution: { start_time: 0, status: StepStatusEnum.passed, end_time: 0, duration: 0 },
+      id: action,
+      parent_id: null,
+      attachments: [],
+      steps: [],
+    });
+  }
+
+  getAllSteps(): TestStepType[] {
+    return this.steps;
+  }
+}
+
+describe('ProfilerTracker', () => {
+  it('with a null profiler, getEvents() returns []', () => {
+    const tracker = new ProfilerTracker(null);
+    tracker.onTestStart();
+    expect(tracker.getEvents()).toEqual([]);
+  });
+
+  it('with a profiler, returns only steps recorded since onTestStart()', () => {
+    const profiler = new FakeProfiler();
+    profiler.push('before-test-1');
+    const tracker = new ProfilerTracker(profiler as any);
+    tracker.onTestStart();
+
+    profiler.push('during-test-1');
+    profiler.push('during-test-2');
+
+    const events = tracker.getEvents();
+    expect(events.map((s) => s.id)).toEqual(['during-test-1', 'during-test-2']);
+  });
+
+  it('multiple test cycles isolate events', () => {
+    const profiler = new FakeProfiler();
+    const tracker = new ProfilerTracker(profiler as any);
+
+    tracker.onTestStart();
+    profiler.push('test-1-event');
+    expect(tracker.getEvents().map((s) => s.id)).toEqual(['test-1-event']);
+
+    tracker.onTestStart();
+    profiler.push('test-2-event');
+    expect(tracker.getEvents().map((s) => s.id)).toEqual(['test-2-event']);
+  });
+
+  it('reset() returns snapshot to zero', () => {
+    const profiler = new FakeProfiler();
+    profiler.push('a');
+    profiler.push('b');
+    const tracker = new ProfilerTracker(profiler as any);
+    tracker.onTestStart();        // snapshot = 2
+
+    tracker.reset();              // snapshot = 0
+
+    expect(tracker.getEvents().map((s) => s.id)).toEqual(['a', 'b']);
+  });
+
+  it('without onTestStart(), getEvents returns all known steps from index 0', () => {
+    const profiler = new FakeProfiler();
+    profiler.push('a');
+    profiler.push('b');
+    const tracker = new ProfilerTracker(profiler as any);
+    expect(tracker.getEvents().map((s) => s.id)).toEqual(['a', 'b']);
+  });
+});

--- a/qase-mocha/test/resultBuilder.test.ts
+++ b/qase-mocha/test/resultBuilder.test.ts
@@ -1,0 +1,175 @@
+/* eslint-disable */
+import { describe, expect, it } from '@jest/globals';
+import {
+  StepStatusEnum,
+  StepType,
+  TestStatusEnum,
+  TestStepType,
+} from 'qase-javascript-commons';
+import { Metadata } from '../src/types';
+import { ResultBuilder } from '../src/modules/resultBuilder';
+
+function makeMetadata(overrides: Partial<Metadata> = {}): Metadata {
+  const m = new Metadata();
+  Object.assign(m, overrides);
+  return m;
+}
+
+function makeTest(opts: {
+  title?: string;
+  state?: 'passed' | 'failed' | 'pending';
+  err?: { message: string; stack?: string };
+  duration?: number;
+  parentTitlePath?: string[];
+  parentFile?: string;
+} = {}): any {
+  return {
+    title: opts.title ?? 'sample',
+    state: opts.state ?? 'passed',
+    err: opts.err,
+    duration: opts.duration,
+    parent: opts.parentTitlePath
+      ? {
+          titlePath: () => opts.parentTitlePath!,
+          file: opts.parentFile,
+          parent: undefined,
+        }
+      : undefined,
+  };
+}
+
+const STEP_FIXTURE: TestStepType = {
+  step_type: StepType.TEXT,
+  data: { action: 's1', expected_result: null, data: null },
+  execution: { start_time: 0, status: StepStatusEnum.passed, end_time: 1, duration: 1 },
+  id: 'step-1',
+  parent_id: null,
+  attachments: [],
+  steps: [],
+};
+
+describe('ResultBuilder', () => {
+  const baseArgs = {
+    test: makeTest({ parentTitlePath: ['Suite'], parentFile: '/repo/test/foo.spec.ts' }),
+    metadata: makeMetadata(),
+    steps: [],
+    profilerSteps: [],
+    output: { stdout: '', stderr: '' },
+    testBeginTime: 1700000000000,
+    cwd: '/repo/',
+  };
+
+  it('builds a passed result with empty metadata', () => {
+    const result = ResultBuilder.build({ ...baseArgs });
+    expect(result.execution.status).toBe(TestStatusEnum.passed);
+    expect(result.title).toBe('sample');
+    expect(result.testops_id).toBeNull();
+  });
+
+  it('marks failed when test.err present', () => {
+    const failedTest = makeTest({
+      state: 'failed',
+      err: { message: 'expected 1 to equal 2', stack: 'stack-here' },
+      parentTitlePath: ['Suite'],
+    });
+    const result = ResultBuilder.build({ ...baseArgs, test: failedTest });
+    expect(result.execution.status).toBe(TestStatusEnum.failed);
+    expect(result.execution.stacktrace).toBe('stack-here');
+    expect(result.message).toBe('expected 1 to equal 2');
+  });
+
+  it('maps pending → skipped', () => {
+    const pendingTest = makeTest({ state: 'pending', parentTitlePath: ['Suite'] });
+    const result = ResultBuilder.build({ ...baseArgs, test: pendingTest });
+    expect(result.execution.status).toBe(TestStatusEnum.skipped);
+  });
+
+  it('uses metadata.title when provided', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      metadata: makeMetadata({ title: 'overridden' }),
+    });
+    expect(result.title).toBe('overridden');
+  });
+
+  it('removes "(Qase ID: 7)" suffix from title when metadata.title not set', () => {
+    const test = makeTest({ title: 'login (Qase ID: 7)', parentTitlePath: ['Suite'] });
+    const result = ResultBuilder.build({ ...baseArgs, test });
+    expect(result.title).toBe('login');
+  });
+
+  it('sets testops_id from metadata.ids when no project mapping in title', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      metadata: makeMetadata({ ids: [42] }),
+    });
+    expect(result.testops_id).toEqual([42]);
+  });
+
+  it('falls back to legacy ids parsed from title when metadata.ids empty', () => {
+    const test = makeTest({ title: 'order (Qase ID: 9)', parentTitlePath: ['Suite'] });
+    const result = ResultBuilder.build({ ...baseArgs, test });
+    expect(result.testops_id).toEqual([9]);
+  });
+
+  it('builds suite relations from parent.titlePath() when no metadata.suite', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      test: makeTest({ parentTitlePath: ['Outer', 'Inner'] }),
+    });
+    const data = (result.relations as any).suite.data.map((d: any) => d.title);
+    expect(data).toEqual(['Outer', 'Inner']);
+  });
+
+  it('overrides suite relation with metadata.suite when set', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      metadata: makeMetadata({ suite: 'OnlyThis' }),
+    });
+    const data = (result.relations as any).suite.data.map((d: any) => d.title);
+    expect(data).toEqual(['OnlyThis']);
+  });
+
+  it('merges StepRunner steps and ProfilerTracker steps in order', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      steps: [STEP_FIXTURE],
+      profilerSteps: [{ ...STEP_FIXTURE, id: 'profiler-1' }],
+    });
+    expect(result.steps.map((s) => s.id)).toEqual(['step-1', 'profiler-1']);
+  });
+
+  it('attaches stdout.txt and stderr.txt when output non-empty', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      metadata: makeMetadata(),
+      output: { stdout: 'log-out', stderr: 'log-err' },
+      attachLogs: true,
+    });
+    const names = result.attachments.map((a) => a.file_name);
+    expect(names).toContain('stdout.txt');
+    expect(names).toContain('stderr.txt');
+  });
+
+  it('does not attach logs when attachLogs flag is false', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      output: { stdout: 'data', stderr: '' },
+      attachLogs: false,
+    });
+    expect(result.attachments).toEqual([]);
+  });
+
+  it('appends test.err.message after metadata.comment with double newline', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      metadata: makeMetadata({ comment: 'note' }),
+      test: makeTest({
+        state: 'failed',
+        err: { message: 'extra' },
+        parentTitlePath: ['Suite'],
+      }),
+    });
+    expect(result.message).toBe('note\n\nextra');
+  });
+});

--- a/qase-mocha/test/stepRunner.test.ts
+++ b/qase-mocha/test/stepRunner.test.ts
@@ -1,0 +1,73 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { StepStatusEnum, StepType } from 'qase-javascript-commons';
+import { StepRunner } from '../src/modules/stepRunner';
+
+describe('StepRunner', () => {
+  let runner: StepRunner;
+
+  beforeEach(() => {
+    runner = new StepRunner();
+  });
+
+  it('getSteps() initially returns an empty array', () => {
+    expect(runner.getSteps()).toEqual([]);
+  });
+
+  it('run() captures a passed sync step with title, status, end_time', () => {
+    runner.run('login', () => {});
+    const steps = runner.getSteps();
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.step_type).toBe(StepType.TEXT);
+    expect(steps[0]?.data.action).toBe('login');
+    expect(steps[0]?.execution.status).toBe(StepStatusEnum.passed);
+    expect(steps[0]?.execution.end_time).not.toBeNull();
+  });
+
+  it('run() with a throwing fn marks step failed, swallows the error, and exposes hasFailure()', () => {
+    expect(() => runner.run('boom', () => { throw new Error('nope'); })).not.toThrow();
+    expect(runner.getSteps()[0]?.execution.status).toBe(StepStatusEnum.failed);
+    expect(runner.hasFailure()).toBe(true);
+  });
+
+  it('run() preserves expectedResult and data via extractAndCleanStep', () => {
+    runner.run('verify total', () => {}, 'sum equals 42', 'cart=[A,B]');
+    const step = runner.getSteps()[0]!;
+
+    expect(step.data.expected_result).toBe('sum equals 42');
+    expect(step.data.data).toBe('cart=[A,B]');
+    expect(step.data.action).toBe('verify total');
+  });
+
+  it('run() without expectedResult/data leaves action equal to the title', () => {
+    runner.run('plain step', () => {});
+    expect(runner.getSteps()[0]?.data.action).toBe('plain step');
+  });
+
+  it('multiple sequential run() calls accumulate steps in order', () => {
+    runner.run('a', () => {});
+    runner.run('b', () => {});
+    runner.run('c', () => {});
+
+    const titles = runner.getSteps().map((s) => s.data.action);
+    expect(titles).toEqual(['a', 'b', 'c']);
+  });
+
+  it('reset() empties the steps buffer', () => {
+    runner.run('first', () => {});
+    runner.reset();
+    expect(runner.getSteps()).toEqual([]);
+  });
+
+  it('parent_id is null for top-level steps', () => {
+    runner.run('top', () => {});
+    expect(runner.getSteps()[0]?.parent_id).toBeNull();
+  });
+
+  it('returns the value of the wrapped fn', () => {
+    const out = runner.run('compute', () => 42 as unknown as void);
+    // run is typed as () => void in the public API, but we still propagate the return.
+    expect(out).toBeUndefined(); // the public step API discards return values.
+  });
+});


### PR DESCRIPTION
## Summary

- Decompose `qase-mocha/src/reporter.ts` (465 → 232 LOC, -50%) into orchestrator + 5 modules: `MetadataApplier`, `OutputCapture`, `StepRunner`, `ProfilerTracker`, `ResultBuilder`. Phase 2 pattern, 4th reporter after wdio (#950) / playwright (#951) / cypress (#953).
- Bring up Jest + ts-jest infrastructure (no tests existed previously); add 43 unit tests across the new modules (10+6+9+5+13).
- Bump `mocha-qase-reporter` 1.4.0 → 1.5.0; public contract preserved (named export, ctor, `static statusMap`, 11 user-API methods bound to test context, Mocha lifecycle hooks, parallel mode).

## Test plan

- [x] CI green on `refactor/mocha-decomposition`.
- [x] `cd qase-mocha && npm test` passes locally — `Tests: 43 passed, 43 total`.
- [x] Smoke `QASE_MODE=report` against `examples/single/mocha`: report file written, no errors in console.
- [x] Smoke `QASE_MODE=testops` against `examples/single/mocha` in DEVX project: run created, all results uploaded.
- [x] Smoke parallel mode `QASE_MODE=testops` with `--parallel`: main + worker reporter both function; result count matches the sequential run.