### PR TITLE
refactor(cucumberjs): decompose storage into focused modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30481,7 +30481,7 @@
     },
     "qase-cucumberjs": {
       "name": "cucumberjs-qase-reporter",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/messages": "^22.0.0",

--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,17 @@
+# cucumberjs-qase-reporter@2.4.0
+
+## Changed
+
+- Decomposed `storage.ts` (595 LOC) into a thin facade plus 6 focused modules under `src/modules/`: `TagParser`, `EventStorage`, `StatusTracker`, `StepConverter`, `ProfilerTracker`, `ResultBuilder`, plus `STATUS_MAP` / `STEP_STATUS_MAP` constants. Public contract preserved: `Storage` named export, constructor signature, all 7 instance methods, static `statusMap` and `stepStatusMap`, all 9 user-facing tag patterns.
+
+## Bug fixes
+
+- Cross-reporter consistency: `testops_id` is now `null` when project mapping (`@qaseid.PROJ(ids)` tag) is set, matching the behavior of mocha / cypress / jest reporters. Previously cucumberjs emitted both `testops_id: ids` and `testops_project_mapping: mapping`, which could lead to ambiguous results in multi-project runs.
+
+## Internal
+
+- Added 38 per-module unit tests on top of the existing 44 facade integration tests (82 total).
+
 # cucumberjs-qase-reporter@2.3.0
 
 ## What's new

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",

--- a/qase-cucumberjs/src/modules/eventStorage.ts
+++ b/qase-cucumberjs/src/modules/eventStorage.ts
@@ -103,6 +103,10 @@ export class EventStorage {
     return this.testStepFinished[id];
   }
 
+  getAllTestStepFinished(): Map<string, TestStepFinished> {
+    return new Map(Object.entries(this.testStepFinished));
+  }
+
   private appendAttachment(key: string, attachment: Attach): void {
     const list = this.attachments[key] ?? [];
     this.attachments[key] = list;

--- a/qase-cucumberjs/src/modules/eventStorage.ts
+++ b/qase-cucumberjs/src/modules/eventStorage.ts
@@ -1,0 +1,138 @@
+import {
+  Attachment as Attach,
+  GherkinDocument,
+  Pickle,
+  TestCaseStarted,
+  TestStepFinished,
+} from '@cucumber/messages';
+import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
+import { Attachment } from 'qase-javascript-commons';
+import { v4 as uuidv4 } from 'uuid';
+import { ScenarioData } from '../models';
+
+export class EventStorage {
+  private pickles: Record<string, Pickle> = {};
+  private testCaseStarts: Record<string, TestCaseStarted> = {};
+  private testStepFinished: Record<string, TestStepFinished> = {};
+  private testCases: Record<string, TestCase> = {};
+  private scenarios: Record<string, ScenarioData> = {};
+  private attachments: Record<string, Attachment[]> = {};
+
+  addPickle(pickle: Pickle): void {
+    this.pickles[pickle.id] = pickle;
+  }
+
+  addScenario(document: GherkinDocument): void {
+    if (!document.feature) return;
+
+    const { children, name } = document.feature;
+
+    for (const { scenario } of children) {
+      if (!scenario) continue;
+
+      const parameters: Record<string, Record<string, string>> = {};
+
+      scenario.examples?.forEach((example) => {
+        if (example.tableHeader) {
+          const columnNames = example.tableHeader.cells.map((cell) => cell.value);
+
+          example.tableBody.forEach((row) => {
+            const rowParams: Record<string, string> = {};
+
+            row.cells.forEach((cell, index) => {
+              const columnName = columnNames[index];
+              if (columnName) {
+                rowParams[columnName] = cell.value;
+              }
+            });
+
+            parameters[row.id] = rowParams;
+          });
+        }
+      });
+
+      this.scenarios[scenario.id] = {
+        name,
+        parameters,
+      };
+    }
+  }
+
+  addAttachment(attachment: Attach): void {
+    if (attachment.testStepId) {
+      this.appendAttachment(attachment.testStepId, attachment);
+    }
+    if (attachment.testCaseStartedId) {
+      this.appendAttachment(attachment.testCaseStartedId, attachment);
+    }
+  }
+
+  addTestCase(testCase: TestCase): void {
+    this.testCases[testCase.id] = testCase;
+  }
+
+  addTestCaseStarted(testCaseStarted: TestCaseStarted): void {
+    this.testCaseStarts[testCaseStarted.id] = testCaseStarted;
+  }
+
+  addTestStepFinished(step: TestStepFinished): void {
+    this.testStepFinished[step.testStepId] = step;
+  }
+
+  getPickle(id: string): Pickle | undefined {
+    return this.pickles[id];
+  }
+
+  getTestCase(id: string): TestCase | undefined {
+    return this.testCases[id];
+  }
+
+  getTestCaseStarted(id: string): TestCaseStarted | undefined {
+    return this.testCaseStarts[id];
+  }
+
+  getScenario(id: string): ScenarioData | undefined {
+    return this.scenarios[id];
+  }
+
+  getAttachments(key: string): Attachment[] {
+    return this.attachments[key] ?? [];
+  }
+
+  getTestStepFinished(id: string): TestStepFinished | undefined {
+    return this.testStepFinished[id];
+  }
+
+  private appendAttachment(key: string, attachment: Attach): void {
+    const list = this.attachments[key] ?? [];
+    this.attachments[key] = list;
+    list.push({
+      file_name: EventStorage.getFileNameFromMediaType(attachment.mediaType),
+      mime_type: attachment.mediaType,
+      file_path: null,
+      content: attachment.body,
+      size: 0,
+      id: uuidv4(),
+    });
+  }
+
+  static getFileNameFromMediaType(mediaType: string): string {
+    const extensions: Record<string, string> = {
+      'text/plain': 'txt',
+      'application/json': 'json',
+      'image/png': 'png',
+      'image/jpeg': 'jpg',
+      'image/gif': 'gif',
+      'text/html': 'html',
+      'application/pdf': 'pdf',
+      'application/xml': 'xml',
+      'application/zip': 'zip',
+      'application/msword': 'doc',
+      'application/vnd.ms-excel': 'xls',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+    };
+    const extension = extensions[mediaType];
+    return extension ? `file.${extension}` : 'file';
+  }
+}

--- a/qase-cucumberjs/src/modules/profilerTracker.ts
+++ b/qase-cucumberjs/src/modules/profilerTracker.ts
@@ -1,0 +1,28 @@
+import { TestStepType } from 'qase-javascript-commons';
+import { NetworkProfiler } from 'qase-javascript-commons/profilers';
+
+export class ProfilerTracker {
+  private snapshots: Record<string, number> = {};
+
+  constructor(private readonly profiler: NetworkProfiler | null) {}
+
+  onTestStart(testCaseStartedId: string): void {
+    if (this.profiler) {
+      this.snapshots[testCaseStartedId] = this.profiler.getAllSteps().length;
+    }
+  }
+
+  getEvents(testCaseStartedId: string): TestStepType[] {
+    if (!this.profiler) return [];
+    const snapshot = this.snapshots[testCaseStartedId] ?? 0;
+    return this.profiler.getAllSteps().slice(snapshot);
+  }
+
+  reset(testCaseStartedId: string): void {
+    delete this.snapshots[testCaseStartedId];
+  }
+
+  restore(): void {
+    this.profiler?.restore();
+  }
+}

--- a/qase-cucumberjs/src/modules/resultBuilder.ts
+++ b/qase-cucumberjs/src/modules/resultBuilder.ts
@@ -1,0 +1,103 @@
+import { Pickle, TestCaseFinished, TestCaseStarted } from '@cucumber/messages';
+import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
+import {
+  Attachment,
+  CompoundError,
+  generateSignature,
+  Relation,
+  TestResultType,
+  TestStatusEnum,
+  TestStepType,
+} from 'qase-javascript-commons';
+import { TestMetadata } from '../models';
+
+export interface BuildArgs {
+  testCaseFinished: TestCaseFinished;
+  testCaseStarted: TestCaseStarted;
+  testCase: TestCase;
+  pickle: Pickle;
+  metadata: TestMetadata;
+  status: TestStatusEnum;
+  error: CompoundError | undefined;
+  steps: TestStepType[];
+  profilerSteps: TestStepType[];
+  attachments: Attachment[];
+  scenarioName: string | undefined;
+  scenarioParameters: Record<string, string>;
+}
+
+export class ResultBuilder {
+  static build(args: BuildArgs): TestResultType {
+    const {
+      testCaseFinished,
+      testCaseStarted,
+      pickle,
+      metadata,
+      status,
+      error,
+      steps,
+      profilerSteps,
+      attachments,
+      scenarioName,
+      scenarioParameters,
+    } = args;
+
+    let relations: Relation | null = null;
+
+    if (metadata.suite) {
+      const suiteParts = metadata.suite.split('\t').filter((part) => part.trim().length > 0);
+      relations = {
+        suite: {
+          data: suiteParts.map((suite) => ({
+            title: suite.trim(),
+            public_id: null,
+          })),
+        },
+      };
+    } else if (scenarioName !== undefined) {
+      relations = {
+        suite: {
+          data: [
+            { title: scenarioName, public_id: null },
+          ],
+        },
+      };
+    }
+
+    // Merge scenario params with metadata parameters (metadata wins)
+    const params: Record<string, string> = { ...scenarioParameters, ...metadata.parameters };
+
+    const hasProjectMapping = Object.keys(metadata.projectMapping).length > 0;
+
+    return {
+      attachments,
+      author: null,
+      execution: {
+        status,
+        start_time: testCaseStarted.timestamp.seconds,
+        end_time: testCaseFinished.timestamp.seconds,
+        duration: Math.abs(testCaseFinished.timestamp.seconds - testCaseStarted.timestamp.seconds) * 1000,
+        stacktrace: error?.stacktrace ?? null,
+        thread: null,
+      },
+      fields: metadata.fields,
+      message: error?.message ?? null,
+      muted: false,
+      params,
+      group_params: metadata.group_params,
+      relations,
+      run_id: null,
+      signature: ResultBuilder.getSignature(pickle, metadata.ids, params),
+      steps: [...steps, ...profilerSteps],
+      testops_id: hasProjectMapping ? null : (metadata.ids.length > 0 ? metadata.ids : null),
+      testops_project_mapping: hasProjectMapping ? metadata.projectMapping : null,
+      id: testCaseStarted.id,
+      title: metadata.title ?? pickle.name,
+      tags: metadata.tags,
+    } as unknown as TestResultType;
+  }
+
+  static getSignature(pickle: Pickle, ids: number[], parameters: Record<string, string> = {}): string {
+    return generateSignature(ids, [...pickle.uri.split('/'), pickle.name], parameters);
+  }
+}

--- a/qase-cucumberjs/src/modules/statusMaps.ts
+++ b/qase-cucumberjs/src/modules/statusMaps.ts
@@ -1,0 +1,24 @@
+import { Status } from '@cucumber/cucumber';
+import { StepStatusEnum, TestStatusEnum } from 'qase-javascript-commons';
+
+export type TestStepResultStatus = (typeof Status)[keyof typeof Status];
+
+export const STATUS_MAP: Record<TestStepResultStatus, TestStatusEnum> = {
+  [Status.PASSED]: TestStatusEnum.passed,
+  [Status.FAILED]: TestStatusEnum.failed,
+  [Status.SKIPPED]: TestStatusEnum.skipped,
+  [Status.AMBIGUOUS]: TestStatusEnum.invalid,
+  [Status.PENDING]: TestStatusEnum.skipped,
+  [Status.UNDEFINED]: TestStatusEnum.skipped,
+  [Status.UNKNOWN]: TestStatusEnum.skipped,
+};
+
+export const STEP_STATUS_MAP: Record<TestStepResultStatus, StepStatusEnum> = {
+  [Status.PASSED]: StepStatusEnum.passed,
+  [Status.FAILED]: StepStatusEnum.failed,
+  [Status.SKIPPED]: StepStatusEnum.skipped,
+  [Status.AMBIGUOUS]: StepStatusEnum.failed,
+  [Status.PENDING]: StepStatusEnum.skipped,
+  [Status.UNDEFINED]: StepStatusEnum.skipped,
+  [Status.UNKNOWN]: StepStatusEnum.skipped,
+};

--- a/qase-cucumberjs/src/modules/statusTracker.ts
+++ b/qase-cucumberjs/src/modules/statusTracker.ts
@@ -1,0 +1,56 @@
+import { TestStepFinished } from '@cucumber/messages';
+import { CompoundError, TestStatusEnum, determineTestStatus } from 'qase-javascript-commons';
+import { STATUS_MAP } from './statusMaps';
+
+export class StatusTracker {
+  private results: Record<string, TestStatusEnum> = {};
+  private errors: Record<string, string[]> = {};
+
+  onTestStarted(testCaseStartedId: string): void {
+    this.results[testCaseStartedId] = TestStatusEnum.passed;
+  }
+
+  applyStep(step: TestStepFinished): void {
+    const oldStatus = this.results[step.testCaseStartedId];
+
+    let error: Error | null = null;
+    if (step.testStepResult.message) {
+      error = new Error(step.testStepResult.message);
+    }
+
+    const newStatus = determineTestStatus(error, STATUS_MAP[step.testStepResult.status]);
+
+    if (newStatus !== TestStatusEnum.passed) {
+      if (step.testStepResult.message) {
+        if (!this.errors[step.testCaseStartedId]) {
+          this.errors[step.testCaseStartedId] = [];
+        }
+        this.errors[step.testCaseStartedId]?.push(step.testStepResult.message);
+      }
+
+      if (oldStatus) {
+        if (oldStatus !== TestStatusEnum.failed && oldStatus !== TestStatusEnum.invalid) {
+          this.results[step.testCaseStartedId] = newStatus;
+        }
+      } else {
+        this.results[step.testCaseStartedId] = newStatus;
+      }
+    }
+  }
+
+  getStatus(testCaseStartedId: string): TestStatusEnum {
+    return this.results[testCaseStartedId] ?? TestStatusEnum.passed;
+  }
+
+  getErrors(testCaseStartedId: string): CompoundError | undefined {
+    const messages = this.errors[testCaseStartedId];
+    if (!messages) return undefined;
+
+    const err = new CompoundError();
+    messages.forEach((message) => {
+      err.addMessage(message);
+      err.addStacktrace(message);
+    });
+    return err;
+  }
+}

--- a/qase-cucumberjs/src/modules/stepConverter.ts
+++ b/qase-cucumberjs/src/modules/stepConverter.ts
@@ -1,0 +1,44 @@
+import { PickleStep, TestStepFinished } from '@cucumber/messages';
+import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
+import { Attachment, StepType, TestStepType } from 'qase-javascript-commons';
+import { STEP_STATUS_MAP } from './statusMaps';
+
+export class StepConverter {
+  static convert(
+    pickleSteps: readonly PickleStep[],
+    testCase: TestCase,
+    finishedSteps: Map<string, TestStepFinished>,
+    getAttachments: (stepId: string) => Attachment[],
+  ): TestStepType[] {
+    const results: TestStepType[] = [];
+
+    for (const s of testCase.testSteps) {
+      const finished = finishedSteps.get(s.id);
+      if (!finished) continue;
+
+      const step = pickleSteps.find((ps) => ps.id === s.pickleStepId);
+      if (!step) continue;
+
+      results.push({
+        id: s.id,
+        step_type: StepType.GHERKIN,
+        data: {
+          keyword: step.text,
+          name: step.text,
+          line: 0,
+        },
+        execution: {
+          status: STEP_STATUS_MAP[finished.testStepResult.status],
+          start_time: null,
+          end_time: null,
+          duration: finished.testStepResult.duration.seconds * 1000,
+        },
+        attachments: getAttachments(s.id),
+        steps: [],
+        parent_id: null,
+      } as TestStepType);
+    }
+
+    return results;
+  }
+}

--- a/qase-cucumberjs/src/modules/tagParser.ts
+++ b/qase-cucumberjs/src/modules/tagParser.ts
@@ -1,0 +1,108 @@
+import { PickleTag } from '@cucumber/messages';
+import { parseProjectMappingFromTags } from 'qase-javascript-commons';
+import { TestMetadata } from '../models';
+
+const qaseIdRegExp = /^@[Qq]-?(\d+)$/;
+const newQaseIdRegExp = /^@[Qq]ase[Ii][Dd]=(\d+(?:,\s*\d+)*)$/;
+const qaseTitleRegExp = /^@[Qq]ase[Tt]itle=(.+)$/;
+const qaseFieldsRegExp = /^@[Qq]ase[Ff]ields=(.+)$/;
+const qaseParametersRegExp = /^@[Qq]ase[Pp]arameters=(.+)$/;
+const qaseGroupParametersRegExp = /^@[Qq]ase[Gg]roup[Pp]arameters=(.+)$/;
+const qaseSuiteRegExp = /^@[Qq]ase[Ss]uite=(.+)$/;
+const qaseIgnoreRegExp = /^@[Qq]ase[Ii][Gg][Nn][Oo][Rr][Ee]$/;
+const qaseTagsRegExp = /^@[Qq]ase[Tt]ags=(.+)$/;
+
+export class TagParser {
+  static parse(tags: readonly PickleTag[]): TestMetadata {
+    const tagNames = tags.map((t) => t.name);
+    const { legacyIds, projectMapping } = parseProjectMappingFromTags(tagNames);
+
+    const metadata: TestMetadata = {
+      ids: [...legacyIds],
+      projectMapping: { ...projectMapping },
+      fields: {},
+      title: null,
+      isIgnore: false,
+      parameters: {},
+      group_params: {},
+      suite: null,
+      tags: [],
+    };
+
+    for (const tag of tags) {
+      if (qaseIdRegExp.test(tag.name)) {
+        metadata.ids.push(Number(tag.name.replace(/^@[Qq]-?/, '')));
+        continue;
+      }
+
+      if (newQaseIdRegExp.test(tag.name)) {
+        const idsStr = tag.name.replace(/^@[Qq]ase[Ii][Dd]=/, '');
+        metadata.ids.push(...idsStr.split(',').map((s) => Number(s.trim())));
+        continue;
+      }
+
+      if (qaseTitleRegExp.test(tag.name)) {
+        metadata.title = tag.name.replace(/^@[Qq]ase[Tt]itle=/, '');
+        continue;
+      }
+
+      if (qaseFieldsRegExp.test(tag.name)) {
+        const value = tag.name.replace(/^@[Qq]ase[Ff]ields=/, '');
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          const record: Record<string, string> = JSON.parse(TagParser.normalizeJsonString(value));
+          metadata.fields = { ...metadata.fields, ...record };
+        } catch {
+          // do nothing
+        }
+      }
+
+      if (qaseParametersRegExp.test(tag.name)) {
+        const value = tag.name.replace(/^@[Qq]ase[Pp]arameters=/, '');
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          const record: Record<string, string> = JSON.parse(TagParser.normalizeJsonString(value));
+          metadata.parameters = { ...metadata.parameters, ...record };
+        } catch {
+          // do nothing
+        }
+      }
+
+      if (qaseGroupParametersRegExp.test(tag.name)) {
+        const value = tag.name.replace(/^@[Qq]ase[Gg]roup[Pp]arameters=/, '');
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          const record: Record<string, string> = JSON.parse(TagParser.normalizeJsonString(value));
+          metadata.group_params = { ...metadata.group_params, ...record };
+        } catch {
+          // do nothing
+        }
+      }
+
+      if (qaseSuiteRegExp.test(tag.name)) {
+        metadata.suite = tag.name.replace(/^@[Qq]ase[Ss]uite=/, '');
+        continue;
+      }
+
+      if (qaseTagsRegExp.test(tag.name)) {
+        const value = tag.name.replace(/^@[Qq]ase[Tt]ags=/, '');
+        const parsedTags = value.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
+        metadata.tags.push(...parsedTags);
+        continue;
+      }
+
+      if (qaseIgnoreRegExp.test(tag.name)) {
+        metadata.isIgnore = true;
+      }
+    }
+
+    return metadata;
+  }
+
+  static normalizeJsonString(jsonString: string): string {
+    if (jsonString.includes("'")) {
+      return jsonString.replace(/'/g, '"');
+    }
+    return jsonString;
+  }
+}

--- a/qase-cucumberjs/src/reporter.ts
+++ b/qase-cucumberjs/src/reporter.ts
@@ -37,11 +37,6 @@ export class CucumberQaseReporter extends Formatter {
   private reporter: ReporterInterface;
 
   /**
-   * @type {NetworkProfiler | null}
-   * @private
-   */
-  private profiler: NetworkProfiler | null = null;
-  /**
    * @type {EventEmitter}
    * @private
    */
@@ -68,16 +63,17 @@ export class CucumberQaseReporter extends Formatter {
       reporterName: 'cucumberjs-qase-reporter',
     });
 
+    let profiler: NetworkProfiler | null = null;
     if (composedOptions.profilers?.includes('network')) {
-      this.profiler = new NetworkProfiler({
+      profiler = new NetworkProfiler({
         skipDomains: composedOptions.networkProfiler?.skip_domains,
         trackOnFail: composedOptions.networkProfiler?.track_on_fail,
       });
-      this.profiler.enable();
+      profiler.enable();
     }
 
     this.eventBroadcaster = formatterOptions.eventBroadcaster;
-    this.storage = new Storage(this.profiler);
+    this.storage = new Storage(profiler);
     this.bindEventListeners();
   }
 
@@ -120,7 +116,7 @@ export class CucumberQaseReporter extends Formatter {
    * @private
    */
   private async publishResults(): Promise<void> {
-    this.profiler?.restore();
+    this.storage.restore();
     await this.reporter.publish();
   }
 

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -8,7 +8,6 @@ import {
   TestStepFinished,
 } from '@cucumber/messages';
 import {
-  Attachment,
   CompoundError,
   generateSignature,
   Relation,
@@ -21,10 +20,9 @@ import {
 } from 'qase-javascript-commons';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
 import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
-import { v4 as uuidv4 } from 'uuid';
-import { ScenarioData } from './models';
 import { STATUS_MAP, STEP_STATUS_MAP, TestStepResultStatus } from './modules/statusMaps';
 import { TagParser } from './modules/tagParser';
+import { EventStorage } from './modules/eventStorage';
 
 export class Storage {
   /**
@@ -44,22 +42,10 @@ export class Storage {
   }
 
   /**
-   * @type {Record<string, Pickle>}
+   * @type {EventStorage}
    * @private
    */
-  private pickles: Record<string, Pickle> = {};
-
-  /**
-   * @type {Record<string, TestCaseStarted>}
-   * @private
-   */
-  private testCaseStarts: Record<string, TestCaseStarted> = {};
-
-  /**
-   * @type {Record<string, TestStepFinished>}
-   * @private
-   */
-  private testCaseSteps: Record<string, TestStepFinished> = {};
+  private events: EventStorage = new EventStorage();
 
   /**
    * @type {Record<string, TestStatusEnum>}
@@ -74,29 +60,11 @@ export class Storage {
   private testCaseStartedErrors: Record<string, string[]> = {};
 
   /**
-   * @type {Record<string, string>}
-   * @private
-   */
-  private testCases: Record<string, TestCase> = {};
-
-  /**
-   * @type {Record<string, string>}
-   * @private
-   */
-  private scenarios: Record<string, ScenarioData> = {};
-
-  /**
-   * @type {Record<string, string>}
-   * @private
-   */
-  private attachments: Record<string, Attachment[]> = {};
-
-  /**
    * Add pickle to storage
    * @param {Pickle} pickle
    */
   public addPickle(pickle: Pickle): void {
-    this.pickles[pickle.id] = pickle;
+    this.events.addPickle(pickle);
   }
 
   /**
@@ -104,39 +72,7 @@ export class Storage {
    * @param {GherkinDocument} document
    */
   public addScenario(document: GherkinDocument): void {
-    if (document.feature) {
-      const { children, name } = document.feature;
-
-      children.forEach(({ scenario }) => {
-        if (scenario) {
-          const parameters: Record<string, Record<string, string>> = {};
-          
-          scenario.examples?.forEach((example) => {
-            if (example.tableHeader && example.tableBody) {
-              const columnNames = example.tableHeader.cells.map(cell => cell.value);
-              
-              example.tableBody.forEach((row) => {
-                const rowParams: Record<string, string> = {};
-                
-                row.cells.forEach((cell, index) => {
-                  const columnName = columnNames[index];
-                  if (columnName) {
-                    rowParams[columnName] = cell.value;
-                  }
-                });
-                
-                parameters[row.id] = rowParams;
-              });
-            }
-          });
-
-          this.scenarios[scenario.id] = {
-            name: name,
-            parameters: parameters,
-          };
-        }
-      });
-    }
+    this.events.addScenario(document);
   }
 
   /**
@@ -144,35 +80,7 @@ export class Storage {
    * @param {Attach} attachment
    */
   public addAttachment(attachment: Attach): void {
-    if (attachment.testStepId) {
-      if (!this.attachments[attachment.testStepId]) {
-        this.attachments[attachment.testStepId] = [];
-      }
-
-      this.attachments[attachment.testStepId]?.push({
-        file_name: this.getFileNameFromMediaType(attachment.mediaType),
-        mime_type: attachment.mediaType,
-        file_path: null,
-        content: attachment.body,
-        size: 0,
-        id: uuidv4(),
-      });
-    }
-
-    if (attachment.testCaseStartedId) {
-      if (!this.attachments[attachment.testCaseStartedId]) {
-        this.attachments[attachment.testCaseStartedId] = [];
-      }
-
-      this.attachments[attachment.testCaseStartedId]?.push({
-        file_name: this.getFileNameFromMediaType(attachment.mediaType),
-        mime_type: attachment.mediaType,
-        file_path: null,
-        content: attachment.body,
-        size: 0,
-        id: uuidv4(),
-      });
-    }
+    this.events.addAttachment(attachment);
   }
 
   /**
@@ -180,7 +88,7 @@ export class Storage {
    * @param {TestCase} testCase
    */
   public addTestCase(testCase: TestCase): void {
-    this.testCases[testCase.id] = testCase;
+    this.events.addTestCase(testCase);
   }
 
   /**
@@ -188,10 +96,8 @@ export class Storage {
    * @param {TestCaseStarted} testCaseStarted
    */
   public addTestCaseStarted(testCaseStarted: TestCaseStarted): void {
-    this.testCaseStarts[testCaseStarted.id] =
-      testCaseStarted;
-    this.testCaseStartedResult[testCaseStarted.id] =
-      TestStatusEnum.passed;
+    this.events.addTestCaseStarted(testCaseStarted);
+    this.testCaseStartedResult[testCaseStarted.id] = TestStatusEnum.passed;
     if (this.profiler) {
       this.profilerStepSnapshots[testCaseStarted.id] = this.profiler.getAllSteps().length;
     }
@@ -213,7 +119,7 @@ export class Storage {
     // Determine status based on error type
     const newStatus = determineTestStatus(error, Storage.statusMap[testCaseStep.testStepResult.status]);
 
-    this.testCaseSteps[testCaseStep.testStepId] = testCaseStep;
+    this.events.addTestStepFinished(testCaseStep);
 
     if (newStatus !== TestStatusEnum.passed) {
       if (testCaseStep.testStepResult.message) {
@@ -241,20 +147,19 @@ export class Storage {
    * @returns {undefined | TestResultType}
    */
   public convertTestCase(testCase: TestCaseFinished): undefined | TestResultType {
-    const tcs =
-      this.testCaseStarts[testCase.testCaseStartedId];
+    const tcs = this.events.getTestCaseStarted(testCase.testCaseStartedId);
 
     if (!tcs) {
       return undefined;
     }
 
-    const tc = this.testCases[tcs.testCaseId];
+    const tc = this.events.getTestCase(tcs.testCaseId);
 
     if (!tc) {
       return undefined;
     }
 
-    const pickle = this.pickles[tc.pickleId];
+    const pickle = this.events.getPickle(tc.pickleId);
 
     if (!pickle) {
       return undefined;
@@ -271,7 +176,7 @@ export class Storage {
     let relations: Relation | null = null;
     let params: Record<string, string> = {};
     const nodeId = pickle.astNodeIds[0];
-    
+
     // If suite is specified in metadata, use it (split by tab for sub-suites)
     if (metadata.suite) {
       const suiteParts = metadata.suite.split('\t').filter(part => part.trim().length > 0);
@@ -283,13 +188,13 @@ export class Storage {
           })),
         },
       };
-    } else if (nodeId != undefined && this.scenarios[nodeId] != undefined) {
+    } else if (nodeId != undefined && this.events.getScenario(nodeId) != undefined) {
       // Otherwise, use feature name as suite
       relations = {
         suite: {
           data: [
             {
-              title: this.scenarios[nodeId]?.name ?? '',
+              title: this.events.getScenario(nodeId)?.name ?? '',
               public_id: null,
             },
           ],
@@ -298,10 +203,10 @@ export class Storage {
     }
 
     // Extract parameters from Gherkin examples
-    if (nodeId != undefined && this.scenarios[nodeId] != undefined) {
+    if (nodeId != undefined && this.events.getScenario(nodeId) != undefined) {
       for (const id of pickle.astNodeIds) {
-        if (this.scenarios[nodeId]?.parameters[id] != undefined) {
-          params = { ...params, ...this.scenarios[nodeId]?.parameters[id] };
+        if (this.events.getScenario(nodeId)?.parameters[id] != undefined) {
+          params = { ...params, ...this.events.getScenario(nodeId)?.parameters[id] };
         }
       }
     }
@@ -323,7 +228,7 @@ export class Storage {
 
     const hasProjectMapping = Object.keys(metadata.projectMapping).length > 0;
     const result = {
-      attachments: this.attachments[testCase.testCaseStartedId] ?? [],
+      attachments: this.events.getAttachments(testCase.testCaseStartedId),
       author: null,
       execution: {
         status: this.testCaseStartedResult[testCase.testCaseStartedId] ?? TestStatusEnum.passed,
@@ -362,7 +267,7 @@ export class Storage {
     const results: TestStepType[] = [];
 
     for (const s of testCase.testSteps) {
-      const finished = this.testCaseSteps[s.id];
+      const finished = this.events.getTestStepFinished(s.id);
       if (!finished) {
         continue;
       }
@@ -387,7 +292,7 @@ export class Storage {
             end_time: null,
             duration: finished.testStepResult.duration.seconds * 1000,
           },
-          attachments: this.attachments[s.id] ?? [],
+          attachments: this.events.getAttachments(s.id),
           steps: [],
           parent_id: null,
         }
@@ -429,29 +334,5 @@ export class Storage {
     return error;
   }
 
-  private getFileNameFromMediaType(mediaType: string): string {
-    const extensions: Record<string, string> = {
-      'text/plain': 'txt',
-      'application/json': 'json',
-      'image/png': 'png',
-      'image/jpeg': 'jpg',
-      'image/gif': 'gif',
-      'text/html': 'html',
-      'application/pdf': 'pdf',
-      'application/xml': 'xml',
-      'application/zip': 'zip',
-      'application/msword': 'doc',
-      'application/vnd.ms-excel': 'xls',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
-    };
-
-    const extension = extensions[mediaType];
-
-    if (extension) {
-      return `file.${extension}`;
-    } else {
-      return 'file';
-    }
-  }
 }
+

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -21,22 +21,17 @@ import { TagParser } from './modules/tagParser';
 import { EventStorage } from './modules/eventStorage';
 import { StatusTracker } from './modules/statusTracker';
 import { StepConverter } from './modules/stepConverter';
+import { ProfilerTracker } from './modules/profilerTracker';
 
 export class Storage {
   /**
-   * @type {NetworkProfiler | null}
+   * @type {ProfilerTracker}
    * @private
    */
-  private profiler: NetworkProfiler | null;
-
-  /**
-   * @type {Record<string, number>}
-   * @private
-   */
-  private profilerStepSnapshots: Record<string, number> = {};
+  private profilerTracker: ProfilerTracker;
 
   constructor(profiler: NetworkProfiler | null = null) {
-    this.profiler = profiler;
+    this.profilerTracker = new ProfilerTracker(profiler);
   }
 
   /**
@@ -90,9 +85,7 @@ export class Storage {
   public addTestCaseStarted(testCaseStarted: TestCaseStarted): void {
     this.events.addTestCaseStarted(testCaseStarted);
     this.statusTracker.onTestStarted(testCaseStarted.id);
-    if (this.profiler) {
-      this.profilerStepSnapshots[testCaseStarted.id] = this.profiler.getAllSteps().length;
-    }
+    this.profilerTracker.onTestStart(testCaseStarted.id);
   }
 
   /**
@@ -186,13 +179,8 @@ export class Storage {
     );
 
     // Collect profiler steps since this test case started
-    let profilerSteps: TestStepType[] = [];
-    if (this.profiler) {
-      const snapshot = this.profilerStepSnapshots[testCase.testCaseStartedId] ?? 0;
-      const allSteps = this.profiler.getAllSteps();
-      profilerSteps = allSteps.slice(snapshot);
-      delete this.profilerStepSnapshots[testCase.testCaseStartedId];
-    }
+    const profilerSteps: TestStepType[] = this.profilerTracker.getEvents(testCase.testCaseStartedId);
+    this.profilerTracker.reset(testCase.testCaseStartedId);
 
     const hasProjectMapping = Object.keys(metadata.projectMapping).length > 0;
     const result = {
@@ -236,6 +224,10 @@ export class Storage {
    */
   private getSignature(pickle: Pickle, ids: number[], parameters: Record<string, string> = {}): string {
     return generateSignature(ids, [...pickle.uri.split('/'), pickle.name], parameters);
+  }
+
+  public restore(): void {
+    this.profilerTracker.restore();
   }
 
 }

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -2,7 +2,6 @@ import {
   Attachment as Attach,
   GherkinDocument,
   Pickle,
-  PickleStep,
   TestCaseFinished,
   TestCaseStarted,
   TestStepFinished,
@@ -11,7 +10,6 @@ import {
   generateSignature,
   Relation,
   StepStatusEnum,
-  StepType,
   TestResultType,
   TestStatusEnum,
   TestStepType,
@@ -22,6 +20,7 @@ import { STATUS_MAP, STEP_STATUS_MAP, TestStepResultStatus } from './modules/sta
 import { TagParser } from './modules/tagParser';
 import { EventStorage } from './modules/eventStorage';
 import { StatusTracker } from './modules/statusTracker';
+import { StepConverter } from './modules/stepConverter';
 
 export class Storage {
   /**
@@ -179,7 +178,12 @@ export class Storage {
     // Parameters from tags take precedence over Gherkin examples
     params = { ...params, ...metadata.parameters };
 
-    const steps = this.convertSteps(pickle.steps, tc);
+    const steps = StepConverter.convert(
+      pickle.steps,
+      tc,
+      this.events.getAllTestStepFinished(),
+      (stepId) => this.events.getAttachments(stepId),
+    );
 
     // Collect profiler steps since this test case started
     let profilerSteps: TestStepType[] = [];
@@ -218,54 +222,6 @@ export class Storage {
       tags: metadata.tags,
     } as unknown as TestResultType;
     return result;
-  }
-
-  /**
-   * Convert test steps to test result steps
-   * @param {readonly PickleStep[]} steps
-   * @param {TestCase} testCase
-   * @returns {TestStepType[]}
-   * @private
-   */
-  private convertSteps(steps: readonly PickleStep[], testCase: TestCase): TestStepType[] {
-    const results: TestStepType[] = [];
-
-    for (const s of testCase.testSteps) {
-      const finished = this.events.getTestStepFinished(s.id);
-      if (!finished) {
-        continue;
-      }
-
-      const step = steps.find((step) => step.id === s.pickleStepId);
-
-      if (!step) {
-        continue;
-      }
-
-      const result: TestStepType = {
-          id: s.id,
-          step_type: StepType.GHERKIN,
-          data: {
-            keyword: step.text,
-            name: step.text,
-            line: 0,
-          },
-          execution: {
-            status: Storage.stepStatusMap[finished.testStepResult.status],
-            start_time: null,
-            end_time: null,
-            duration: finished.testStepResult.duration.seconds * 1000,
-          },
-          attachments: this.events.getAttachments(s.id),
-          steps: [],
-          parent_id: null,
-        }
-      ;
-
-      results.push(result);
-    }
-
-    return results;
   }
 
   static statusMap: Record<TestStepResultStatus, TestStatusEnum> = STATUS_MAP;

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -7,12 +7,9 @@ import {
   TestStepFinished,
 } from '@cucumber/messages';
 import {
-  generateSignature,
-  Relation,
   StepStatusEnum,
   TestResultType,
   TestStatusEnum,
-  TestStepType,
 } from 'qase-javascript-commons';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
 import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
@@ -22,6 +19,7 @@ import { EventStorage } from './modules/eventStorage';
 import { StatusTracker } from './modules/statusTracker';
 import { StepConverter } from './modules/stepConverter';
 import { ProfilerTracker } from './modules/profilerTracker';
+import { ResultBuilder } from './modules/resultBuilder';
 
 export class Storage {
   /**
@@ -104,72 +102,33 @@ export class Storage {
    */
   public convertTestCase(testCase: TestCaseFinished): undefined | TestResultType {
     const tcs = this.events.getTestCaseStarted(testCase.testCaseStartedId);
-
-    if (!tcs) {
-      return undefined;
-    }
+    if (!tcs) return undefined;
 
     const tc = this.events.getTestCase(tcs.testCaseId);
-
-    if (!tc) {
-      return undefined;
-    }
+    if (!tc) return undefined;
 
     const pickle = this.events.getPickle(tc.pickleId);
-
-    if (!pickle) {
-      return undefined;
-    }
+    if (!pickle) return undefined;
 
     const metadata = TagParser.parse(pickle.tags);
-
-    if (metadata.isIgnore) {
-      return undefined;
-    }
+    if (metadata.isIgnore) return undefined;
 
     const error = this.statusTracker.getErrors(tcs.id);
+    const status = this.statusTracker.getStatus(testCase.testCaseStartedId);
 
-    let relations: Relation | null = null;
-    let params: Record<string, string> = {};
     const nodeId = pickle.astNodeIds[0];
+    const scenario = nodeId !== undefined ? this.events.getScenario(nodeId) : undefined;
 
-    // If suite is specified in metadata, use it (split by tab for sub-suites)
-    if (metadata.suite) {
-      const suiteParts = metadata.suite.split('\t').filter(part => part.trim().length > 0);
-      relations = {
-        suite: {
-          data: suiteParts.map((suite) => ({
-            title: suite.trim(),
-            public_id: null,
-          })),
-        },
-      };
-    } else if (nodeId != undefined && this.events.getScenario(nodeId) != undefined) {
-      // Otherwise, use feature name as suite
-      relations = {
-        suite: {
-          data: [
-            {
-              title: this.events.getScenario(nodeId)?.name ?? '',
-              public_id: null,
-            },
-          ],
-        },
-      };
-    }
-
-    // Extract parameters from Gherkin examples
-    if (nodeId != undefined && this.events.getScenario(nodeId) != undefined) {
+    // Extract parameters from gherkin examples
+    let scenarioParameters: Record<string, string> = {};
+    if (scenario) {
       for (const id of pickle.astNodeIds) {
-        if (this.events.getScenario(nodeId)?.parameters[id] != undefined) {
-          params = { ...params, ...this.events.getScenario(nodeId)?.parameters[id] };
+        const params = scenario.parameters[id];
+        if (params) {
+          scenarioParameters = { ...scenarioParameters, ...params };
         }
       }
     }
-
-    // Merge parameters from tags with parameters from Gherkin examples
-    // Parameters from tags take precedence over Gherkin examples
-    params = { ...params, ...metadata.parameters };
 
     const steps = StepConverter.convert(
       pickle.steps,
@@ -178,53 +137,28 @@ export class Storage {
       (stepId) => this.events.getAttachments(stepId),
     );
 
-    // Collect profiler steps since this test case started
-    const profilerSteps: TestStepType[] = this.profilerTracker.getEvents(testCase.testCaseStartedId);
+    const profilerSteps = this.profilerTracker.getEvents(testCase.testCaseStartedId);
     this.profilerTracker.reset(testCase.testCaseStartedId);
 
-    const hasProjectMapping = Object.keys(metadata.projectMapping).length > 0;
-    const result = {
+    return ResultBuilder.build({
+      testCaseFinished: testCase,
+      testCaseStarted: tcs,
+      testCase: tc,
+      pickle,
+      metadata,
+      status,
+      error,
+      steps,
+      profilerSteps,
       attachments: this.events.getAttachments(testCase.testCaseStartedId),
-      author: null,
-      execution: {
-        status: this.statusTracker.getStatus(testCase.testCaseStartedId),
-        start_time: tcs.timestamp.seconds,
-        end_time: testCase.timestamp.seconds,
-        duration: Math.abs(testCase.timestamp.seconds - tcs.timestamp.seconds) * 1000,
-        stacktrace: error?.stacktrace ?? null,
-        thread: null,
-      },
-      fields: metadata.fields,
-      message: error?.message ?? null,
-      muted: false,
-      params: params,
-      group_params: metadata.group_params,
-      relations: relations,
-      run_id: null,
-      signature: this.getSignature(pickle, metadata.ids, params),
-      steps: [...steps, ...profilerSteps],
-      testops_id: metadata.ids.length > 0 ? metadata.ids : null,
-      testops_project_mapping: hasProjectMapping ? metadata.projectMapping : null,
-      id: tcs.id,
-      title: metadata.title ?? pickle.name,
-      tags: metadata.tags,
-    } as unknown as TestResultType;
-    return result;
+      scenarioName: scenario?.name,
+      scenarioParameters,
+    });
   }
 
   static statusMap: Record<TestStepResultStatus, TestStatusEnum> = STATUS_MAP;
 
   static stepStatusMap: Record<TestStepResultStatus, StepStatusEnum> = STEP_STATUS_MAP;
-
-  /**
-   * @param {Pickle} pickle
-   * @param {number[]} ids
-   * @param {Record<string, string>} parameters
-   * @private
-   */
-  private getSignature(pickle: Pickle, ids: number[], parameters: Record<string, string> = {}): string {
-    return generateSignature(ids, [...pickle.uri.split('/'), pickle.name], parameters);
-  }
 
   public restore(): void {
     this.profilerTracker.restore();

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -22,84 +22,48 @@ import { ProfilerTracker } from './modules/profilerTracker';
 import { ResultBuilder } from './modules/resultBuilder';
 
 export class Storage {
-  /**
-   * @type {ProfilerTracker}
-   * @private
-   */
+  static statusMap: Record<TestStepResultStatus, TestStatusEnum> = STATUS_MAP;
+  static stepStatusMap: Record<TestStepResultStatus, StepStatusEnum> = STEP_STATUS_MAP;
+
+  private events: EventStorage = new EventStorage();
+  private statusTracker: StatusTracker = new StatusTracker();
   private profilerTracker: ProfilerTracker;
 
   constructor(profiler: NetworkProfiler | null = null) {
     this.profilerTracker = new ProfilerTracker(profiler);
   }
 
-  /**
-   * @type {EventStorage}
-   * @private
-   */
-  private events: EventStorage = new EventStorage();
+  public restore(): void {
+    this.profilerTracker.restore();
+  }
 
-  /**
-   * @type {StatusTracker}
-   * @private
-   */
-  private statusTracker: StatusTracker = new StatusTracker();
-
-  /**
-   * Add pickle to storage
-   * @param {Pickle} pickle
-   */
   public addPickle(pickle: Pickle): void {
     this.events.addPickle(pickle);
   }
 
-  /**
-   * Add scenario to storage
-   * @param {GherkinDocument} document
-   */
   public addScenario(document: GherkinDocument): void {
     this.events.addScenario(document);
   }
 
-  /**
-   * Add attachment to storage
-   * @param {Attach} attachment
-   */
   public addAttachment(attachment: Attach): void {
     this.events.addAttachment(attachment);
   }
 
-  /**
-   * Add test case to storage
-   * @param {TestCase} testCase
-   */
   public addTestCase(testCase: TestCase): void {
     this.events.addTestCase(testCase);
   }
 
-  /**
-   * Get all test cases
-   * @param {TestCaseStarted} testCaseStarted
-   */
   public addTestCaseStarted(testCaseStarted: TestCaseStarted): void {
     this.events.addTestCaseStarted(testCaseStarted);
     this.statusTracker.onTestStarted(testCaseStarted.id);
     this.profilerTracker.onTestStart(testCaseStarted.id);
   }
 
-  /**
-   * Add test case step to storage
-   * @param {TestStepFinished} testCaseStep
-   */
   public addTestCaseStep(testCaseStep: TestStepFinished): void {
     this.events.addTestStepFinished(testCaseStep);
     this.statusTracker.applyStep(testCaseStep);
   }
 
-  /**
-   * Convert test case to test result
-   * @param {TestCaseFinished} testCase
-   * @returns {undefined | TestResultType}
-   */
   public convertTestCase(testCase: TestCaseFinished): undefined | TestResultType {
     const tcs = this.events.getTestCaseStarted(testCase.testCaseStartedId);
     if (!tcs) return undefined;
@@ -119,7 +83,6 @@ export class Storage {
     const nodeId = pickle.astNodeIds[0];
     const scenario = nodeId !== undefined ? this.events.getScenario(nodeId) : undefined;
 
-    // Extract parameters from gherkin examples
     let scenarioParameters: Record<string, string> = {};
     if (scenario) {
       for (const id of pickle.astNodeIds) {
@@ -155,15 +118,4 @@ export class Storage {
       scenarioParameters,
     });
   }
-
-  static statusMap: Record<TestStepResultStatus, TestStatusEnum> = STATUS_MAP;
-
-  static stepStatusMap: Record<TestStepResultStatus, StepStatusEnum> = STEP_STATUS_MAP;
-
-  public restore(): void {
-    this.profilerTracker.restore();
-  }
-
 }
-
-

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -8,7 +8,6 @@ import {
   TestStepFinished,
 } from '@cucumber/messages';
 import {
-  CompoundError,
   generateSignature,
   Relation,
   StepStatusEnum,
@@ -16,13 +15,13 @@ import {
   TestResultType,
   TestStatusEnum,
   TestStepType,
-  determineTestStatus,
 } from 'qase-javascript-commons';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
 import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
 import { STATUS_MAP, STEP_STATUS_MAP, TestStepResultStatus } from './modules/statusMaps';
 import { TagParser } from './modules/tagParser';
 import { EventStorage } from './modules/eventStorage';
+import { StatusTracker } from './modules/statusTracker';
 
 export class Storage {
   /**
@@ -48,16 +47,10 @@ export class Storage {
   private events: EventStorage = new EventStorage();
 
   /**
-   * @type {Record<string, TestStatusEnum>}
+   * @type {StatusTracker}
    * @private
    */
-  private testCaseStartedResult: Record<string, TestStatusEnum> = {};
-
-  /**
-   * @type {Record<string, string[]>}
-   * @private
-   */
-  private testCaseStartedErrors: Record<string, string[]> = {};
+  private statusTracker: StatusTracker = new StatusTracker();
 
   /**
    * Add pickle to storage
@@ -97,7 +90,7 @@ export class Storage {
    */
   public addTestCaseStarted(testCaseStarted: TestCaseStarted): void {
     this.events.addTestCaseStarted(testCaseStarted);
-    this.testCaseStartedResult[testCaseStarted.id] = TestStatusEnum.passed;
+    this.statusTracker.onTestStarted(testCaseStarted.id);
     if (this.profiler) {
       this.profilerStepSnapshots[testCaseStarted.id] = this.profiler.getAllSteps().length;
     }
@@ -108,37 +101,8 @@ export class Storage {
    * @param {TestStepFinished} testCaseStep
    */
   public addTestCaseStep(testCaseStep: TestStepFinished): void {
-    const oldStatus = this.testCaseStartedResult[testCaseStep.testCaseStartedId];
-    
-    // Create error object for status determination
-    let error: Error | null = null;
-    if (testCaseStep.testStepResult.message) {
-      error = new Error(testCaseStep.testStepResult.message);
-    }
-    
-    // Determine status based on error type
-    const newStatus = determineTestStatus(error, Storage.statusMap[testCaseStep.testStepResult.status]);
-
     this.events.addTestStepFinished(testCaseStep);
-
-    if (newStatus !== TestStatusEnum.passed) {
-      if (testCaseStep.testStepResult.message) {
-
-        if (!this.testCaseStartedErrors[testCaseStep.testCaseStartedId]) {
-          this.testCaseStartedErrors[testCaseStep.testCaseStartedId] = [];
-        }
-
-        this.testCaseStartedErrors[testCaseStep.testCaseStartedId]?.push(testCaseStep.testStepResult.message);
-      }
-
-      if (oldStatus) {
-        if (oldStatus !== TestStatusEnum.failed && oldStatus !== TestStatusEnum.invalid) {
-          this.testCaseStartedResult[testCaseStep.testCaseStartedId] = newStatus;
-        }
-      } else {
-        this.testCaseStartedResult[testCaseStep.testCaseStartedId] = newStatus;
-      }
-    }
+    this.statusTracker.applyStep(testCaseStep);
   }
 
   /**
@@ -171,7 +135,7 @@ export class Storage {
       return undefined;
     }
 
-    const error = this.getError(tcs.id);
+    const error = this.statusTracker.getErrors(tcs.id);
 
     let relations: Relation | null = null;
     let params: Record<string, string> = {};
@@ -231,7 +195,7 @@ export class Storage {
       attachments: this.events.getAttachments(testCase.testCaseStartedId),
       author: null,
       execution: {
-        status: this.testCaseStartedResult[testCase.testCaseStartedId] ?? TestStatusEnum.passed,
+        status: this.statusTracker.getStatus(testCase.testCaseStartedId),
         start_time: tcs.timestamp.seconds,
         end_time: testCase.timestamp.seconds,
         duration: Math.abs(testCase.timestamp.seconds - tcs.timestamp.seconds) * 1000,
@@ -318,21 +282,6 @@ export class Storage {
     return generateSignature(ids, [...pickle.uri.split('/'), pickle.name], parameters);
   }
 
-  private getError(testCaseId: string): CompoundError | undefined {
-    const testErrors = this.testCaseStartedErrors[testCaseId];
-
-    if (!testErrors) {
-      return undefined;
-    }
-
-    const error = new CompoundError();
-    testErrors.forEach((message) => {
-      error.addMessage(message);
-      error.addStacktrace(message);
-    });
-
-    return error;
-  }
-
 }
+
 

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -3,7 +3,6 @@ import {
   GherkinDocument,
   Pickle,
   PickleStep,
-  PickleTag,
   TestCaseFinished,
   TestCaseStarted,
   TestStepFinished,
@@ -19,23 +18,13 @@ import {
   TestStatusEnum,
   TestStepType,
   determineTestStatus,
-  parseProjectMappingFromTags,
 } from 'qase-javascript-commons';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
 import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
 import { v4 as uuidv4 } from 'uuid';
-import { ScenarioData, TestMetadata } from './models';
+import { ScenarioData } from './models';
 import { STATUS_MAP, STEP_STATUS_MAP, TestStepResultStatus } from './modules/statusMaps';
-
-const qaseIdRegExp = /^@[Qq]-?(\d+)$/;
-const newQaseIdRegExp = /^@[Qq]ase[Ii][Dd]=(\d+(?:,\s*\d+)*)$/;
-const qaseTitleRegExp = /^@[Qq]ase[Tt]itle=(.+)$/;
-const qaseFieldsRegExp = /^@[Qq]ase[Ff]ields=(.+)$/;
-const qaseParametersRegExp = /^@[Qq]ase[Pp]arameters=(.+)$/;
-const qaseGroupParametersRegExp = /^@[Qq]ase[Gg]roup[Pp]arameters=(.+)$/;
-const qaseSuiteRegExp = /^@[Qq]ase[Ss]uite=(.+)$/;
-const qaseIgnoreRegExp = /^@[Qq]ase[Ii][Gg][Nn][Oo][Rr][Ee]$/;
-const qaseTagsRegExp = /^@[Qq]ase[Tt]ags=(.+)$/;
+import { TagParser } from './modules/tagParser';
 
 export class Storage {
   /**
@@ -271,7 +260,7 @@ export class Storage {
       return undefined;
     }
 
-    const metadata = this.parseTags(pickle.tags);
+    const metadata = TagParser.parse(pickle.tags);
 
     if (metadata.isIgnore) {
       return undefined;
@@ -414,92 +403,6 @@ export class Storage {
 
   static stepStatusMap: Record<TestStepResultStatus, StepStatusEnum> = STEP_STATUS_MAP;
 
-  private parseTags(tags: readonly PickleTag[]): TestMetadata {
-    const tagNames = tags.map((t) => t.name);
-    const { legacyIds, projectMapping } = parseProjectMappingFromTags(tagNames);
-
-    const metadata: TestMetadata = {
-      ids: [...legacyIds],
-      projectMapping: { ...projectMapping },
-      fields: {},
-      title: null,
-      isIgnore: false,
-      parameters: {},
-      group_params: {},
-      suite: null,
-      tags: [],
-    };
-
-    for (const tag of tags) {
-      if (qaseIdRegExp.test(tag.name)) {
-        metadata.ids.push(Number(tag.name.replace(/^@[Qq]-?/, '')));
-        continue;
-      }
-
-      if (newQaseIdRegExp.test(tag.name)) {
-        const idsStr = tag.name.replace(/^@[Qq]ase[Ii][Dd]=/, '');
-        metadata.ids.push(...idsStr.split(',').map((s) => Number(s.trim())));
-        continue;
-      }
-
-      if (qaseTitleRegExp.test(tag.name)) {
-        metadata.title = tag.name.replace(/^@[Qq]ase[Tt]itle=/, '');
-        continue;
-      }
-
-      if (qaseFieldsRegExp.test(tag.name)) {
-        const value = tag.name.replace(/^@[Qq]ase[Ff]ields=/, '');
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const record: Record<string, string> = JSON.parse(this.normalizeJsonString(value));
-          metadata.fields = { ...metadata.fields, ...record };
-        } catch (e) {
-          // do nothing
-        }
-      }
-
-      if (qaseParametersRegExp.test(tag.name)) {
-        const value = tag.name.replace(/^@[Qq]ase[Pp]arameters=/, '');
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const record: Record<string, string> = JSON.parse(this.normalizeJsonString(value));
-          metadata.parameters = { ...metadata.parameters, ...record };
-        } catch (e) {
-          // do nothing
-        }
-      }
-
-      if (qaseGroupParametersRegExp.test(tag.name)) {
-        const value = tag.name.replace(/^@[Qq]ase[Gg]roup[Pp]arameters=/, '');
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const record: Record<string, string> = JSON.parse(this.normalizeJsonString(value));
-          metadata.group_params = { ...metadata.group_params, ...record };
-        } catch (e) {
-          // do nothing
-        }
-      }
-
-      if (qaseSuiteRegExp.test(tag.name)) {
-        metadata.suite = tag.name.replace(/^@[Qq]ase[Ss]uite=/, '');
-        continue;
-      }
-
-      if (qaseTagsRegExp.test(tag.name)) {
-        const value = tag.name.replace(/^@[Qq]ase[Tt]ags=/, '');
-        const parsedTags = value.split(',').map(t => t.trim()).filter(t => t.length > 0);
-        metadata.tags.push(...parsedTags);
-        continue;
-      }
-
-      if (qaseIgnoreRegExp.test(tag.name)) {
-        metadata.isIgnore = true;
-      }
-    }
-
-    return metadata;
-  }
-
   /**
    * @param {Pickle} pickle
    * @param {number[]} ids
@@ -524,23 +427,6 @@ export class Storage {
     });
 
     return error;
-  }
-
-  /**
-   * Normalize JSON string by converting single quotes to double quotes
-   * This allows parsing JSON-like strings with single quotes
-   * @param {string} jsonString
-   * @returns {string}
-   * @private
-   */
-  private normalizeJsonString(jsonString: string): string {
-    // If the string contains single quotes, convert them to double quotes
-    // This handles cases like {'key':'value'} which should be {"key":"value"}
-    if (jsonString.includes("'")) {
-      return jsonString.replace(/'/g, '"');
-    }
-    // If no single quotes, return as-is (already valid JSON or will fail with proper error)
-    return jsonString;
   }
 
   private getFileNameFromMediaType(mediaType: string): string {

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -23,11 +23,9 @@ import {
 } from 'qase-javascript-commons';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
 import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
-import { Status } from '@cucumber/cucumber';
 import { v4 as uuidv4 } from 'uuid';
 import { ScenarioData, TestMetadata } from './models';
-
-type TestStepResultStatus = (typeof Status)[keyof typeof Status];
+import { STATUS_MAP, STEP_STATUS_MAP, TestStepResultStatus } from './modules/statusMaps';
 
 const qaseIdRegExp = /^@[Qq]-?(\d+)$/;
 const newQaseIdRegExp = /^@[Qq]ase[Ii][Dd]=(\d+(?:,\s*\d+)*)$/;
@@ -412,31 +410,9 @@ export class Storage {
     return results;
   }
 
-  /**
-   * @type {Record<TestStepResultStatus, TestStatusEnum>}
-   */
-  static statusMap: Record<TestStepResultStatus, TestStatusEnum> = {
-    [Status.PASSED]: TestStatusEnum.passed,
-    [Status.FAILED]: TestStatusEnum.failed,
-    [Status.SKIPPED]: TestStatusEnum.skipped,
-    [Status.AMBIGUOUS]: TestStatusEnum.invalid,
-    [Status.PENDING]: TestStatusEnum.skipped,
-    [Status.UNDEFINED]: TestStatusEnum.skipped,
-    [Status.UNKNOWN]: TestStatusEnum.skipped,
-  };
+  static statusMap: Record<TestStepResultStatus, TestStatusEnum> = STATUS_MAP;
 
-  /**
-   * @type {Record<TestStepResultStatus, StepStatusEnum>}
-   */
-  static stepStatusMap: Record<TestStepResultStatus, StepStatusEnum> = {
-    [Status.PASSED]: StepStatusEnum.passed,
-    [Status.FAILED]: StepStatusEnum.failed,
-    [Status.SKIPPED]: StepStatusEnum.skipped,
-    [Status.AMBIGUOUS]: StepStatusEnum.failed,
-    [Status.PENDING]: StepStatusEnum.skipped,
-    [Status.UNDEFINED]: StepStatusEnum.skipped,
-    [Status.UNKNOWN]: StepStatusEnum.skipped,
-  };
+  static stepStatusMap: Record<TestStepResultStatus, StepStatusEnum> = STEP_STATUS_MAP;
 
   private parseTags(tags: readonly PickleTag[]): TestMetadata {
     const tagNames = tags.map((t) => t.name);

--- a/qase-cucumberjs/test/eventStorage.test.ts
+++ b/qase-cucumberjs/test/eventStorage.test.ts
@@ -1,0 +1,83 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { GherkinDocument, Pickle, TestCaseStarted, TestStepFinished } from '@cucumber/messages';
+import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
+import { EventStorage } from '../src/modules/eventStorage';
+
+describe('EventStorage', () => {
+  let storage: EventStorage;
+
+  beforeEach(() => {
+    storage = new EventStorage();
+  });
+
+  it('addPickle / getPickle round-trip', () => {
+    const pickle = { id: 'p1', name: 'pickle one', tags: [], steps: [], astNodeIds: [], uri: 'features/x.feature', language: 'en' } as unknown as Pickle;
+    storage.addPickle(pickle);
+    expect(storage.getPickle('p1')).toBe(pickle);
+    expect(storage.getPickle('missing')).toBeUndefined();
+  });
+
+  it('addTestCase / getTestCase round-trip', () => {
+    const tc = { id: 'tc1', pickleId: 'p1', testSteps: [] } as unknown as TestCase;
+    storage.addTestCase(tc);
+    expect(storage.getTestCase('tc1')).toBe(tc);
+  });
+
+  it('addTestCaseStarted / getTestCaseStarted round-trip', () => {
+    const tcs = { id: 'tcs1', testCaseId: 'tc1', timestamp: { seconds: 1, nanos: 0 } } as unknown as TestCaseStarted;
+    storage.addTestCaseStarted(tcs);
+    expect(storage.getTestCaseStarted('tcs1')).toBe(tcs);
+  });
+
+  it('addScenario extracts feature name and example parameters', () => {
+    const doc = {
+      feature: {
+        name: 'Feature A',
+        children: [{
+          scenario: {
+            id: 'sc1',
+            examples: [{
+              tableHeader: { cells: [{ value: 'env' }, { value: 'region' }] },
+              tableBody: [
+                { id: 'row1', cells: [{ value: 'prod' }, { value: 'eu' }] },
+              ],
+            }],
+          },
+        }],
+      },
+    } as unknown as GherkinDocument;
+    storage.addScenario(doc);
+    const sc = storage.getScenario('sc1');
+    expect(sc).toBeDefined();
+    expect(sc?.name).toBe('Feature A');
+    expect(sc?.parameters).toEqual({ row1: { env: 'prod', region: 'eu' } });
+  });
+
+  it('addAttachment keys both testStepId and testCaseStartedId', () => {
+    storage.addAttachment({
+      testStepId: 'step1',
+      mediaType: 'image/png',
+      body: 'data',
+      contentEncoding: 'BASE64',
+    } as any);
+    storage.addAttachment({
+      testCaseStartedId: 'tcs1',
+      mediaType: 'text/plain',
+      body: 'log',
+      contentEncoding: 'IDENTITY',
+    } as any);
+
+    expect(storage.getAttachments('step1')).toHaveLength(1);
+    expect(storage.getAttachments('step1')[0]?.mime_type).toBe('image/png');
+    expect(storage.getAttachments('tcs1')).toHaveLength(1);
+    expect(storage.getAttachments('tcs1')[0]?.mime_type).toBe('text/plain');
+    expect(storage.getAttachments('missing')).toEqual([]);
+  });
+
+  it('addTestStepFinished / getTestStepFinished round-trip', () => {
+    const finished = { testStepId: 's1', testCaseStartedId: 'tcs1', testStepResult: { status: 'PASSED', duration: { seconds: 0, nanos: 0 } } } as unknown as TestStepFinished;
+    storage.addTestStepFinished(finished);
+    expect(storage.getTestStepFinished('s1')).toBe(finished);
+  });
+});

--- a/qase-cucumberjs/test/profilerTracker.test.ts
+++ b/qase-cucumberjs/test/profilerTracker.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable */
+import { describe, expect, it } from '@jest/globals';
+import { TestStepType, StepType, StepStatusEnum } from 'qase-javascript-commons';
+import { ProfilerTracker } from '../src/modules/profilerTracker';
+
+class FakeProfiler {
+  private steps: TestStepType[] = [];
+  private restored = false;
+
+  push(action: string): void {
+    this.steps.push({
+      step_type: StepType.TEXT,
+      data: { action, expected_result: null, data: null },
+      execution: { start_time: 0, status: StepStatusEnum.passed, end_time: 0, duration: 0 },
+      id: action,
+      parent_id: null,
+      attachments: [],
+      steps: [],
+    });
+  }
+
+  getAllSteps(): TestStepType[] {
+    return this.steps;
+  }
+
+  restore(): void {
+    this.restored = true;
+  }
+
+  isRestored(): boolean {
+    return this.restored;
+  }
+}
+
+describe('ProfilerTracker', () => {
+  it('null profiler returns empty events array', () => {
+    const tracker = new ProfilerTracker(null);
+    tracker.onTestStart('tcs1');
+    expect(tracker.getEvents('tcs1')).toEqual([]);
+  });
+
+  it('per-case isolation: each testCaseStartedId snapshots independently', () => {
+    const profiler = new FakeProfiler();
+    profiler.push('initial-1');
+    profiler.push('initial-2');
+
+    const tracker = new ProfilerTracker(profiler as any);
+    tracker.onTestStart('tcs1');
+
+    profiler.push('during-1');
+    tracker.onTestStart('tcs2');
+    profiler.push('during-2');
+
+    expect(tracker.getEvents('tcs1').map((s) => s.id)).toEqual(['during-1', 'during-2']);
+    expect(tracker.getEvents('tcs2').map((s) => s.id)).toEqual(['during-2']);
+  });
+
+  it('reset(testCaseStartedId) deletes snapshot for that id', () => {
+    const profiler = new FakeProfiler();
+    profiler.push('a');
+    const tracker = new ProfilerTracker(profiler as any);
+    tracker.onTestStart('tcs1');
+    profiler.push('b');
+
+    tracker.reset('tcs1');
+    profiler.push('c');
+
+    expect(tracker.getEvents('tcs1').map((s) => s.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('restore() proxies to underlying profiler', () => {
+    const profiler = new FakeProfiler();
+    const tracker = new ProfilerTracker(profiler as any);
+    tracker.restore();
+    expect(profiler.isRestored()).toBe(true);
+  });
+});

--- a/qase-cucumberjs/test/reporter.test.ts
+++ b/qase-cucumberjs/test/reporter.test.ts
@@ -25,6 +25,7 @@ const storageMock = {
   addTestCaseStarted: jest.fn(),
   addTestCaseStep: jest.fn(),
   convertTestCase: jest.fn(() => ({ id: 'result-id' })) as jest.Mock,
+  restore: jest.fn(),
 };
 
 jest.mock('qase-javascript-commons', () => ({

--- a/qase-cucumberjs/test/resultBuilder.test.ts
+++ b/qase-cucumberjs/test/resultBuilder.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable */
+import { describe, expect, it } from '@jest/globals';
+import { Pickle, TestCase, TestCaseFinished, TestCaseStarted } from '@cucumber/messages';
+import { TestStatusEnum } from 'qase-javascript-commons';
+import { TestMetadata } from '../src/models';
+import { ResultBuilder } from '../src/modules/resultBuilder';
+
+const baseMetadata: TestMetadata = {
+  ids: [],
+  projectMapping: {},
+  fields: {},
+  title: null,
+  isIgnore: false,
+  parameters: {},
+  group_params: {},
+  suite: null,
+  tags: [],
+};
+
+function makeArgs(overrides: any = {}) {
+  const pickle = { id: 'p1', name: 'A scenario', tags: [], steps: [], astNodeIds: ['scenario-1'], uri: 'features/x.feature', language: 'en' } as unknown as Pickle;
+  const tcs = { id: 'tcs1', testCaseId: 'tc1', timestamp: { seconds: 100, nanos: 0 } } as unknown as TestCaseStarted;
+  const tc = { id: 'tc1', pickleId: 'p1', testSteps: [] } as unknown as TestCase;
+  const tcf = { testCaseStartedId: 'tcs1', timestamp: { seconds: 110, nanos: 0 } } as unknown as TestCaseFinished;
+  return {
+    testCaseFinished: tcf,
+    testCaseStarted: tcs,
+    testCase: tc,
+    pickle,
+    metadata: { ...baseMetadata },
+    status: TestStatusEnum.passed,
+    error: undefined,
+    steps: [],
+    profilerSteps: [],
+    attachments: [],
+    scenarioName: 'Feature A',
+    scenarioParameters: {},
+    ...overrides,
+  };
+}
+
+describe('ResultBuilder', () => {
+  it('builds a passed result with default metadata', () => {
+    const result = ResultBuilder.build(makeArgs());
+    expect(result.execution.status).toBe(TestStatusEnum.passed);
+    expect(result.title).toBe('A scenario');
+    expect(result.testops_id).toBeNull();
+  });
+
+  it('uses metadata.title override', () => {
+    const result = ResultBuilder.build(makeArgs({
+      metadata: { ...baseMetadata, title: 'Override Title' },
+    }));
+    expect(result.title).toBe('Override Title');
+  });
+
+  it('uses metadata.suite override (tab-separated for sub-suites)', () => {
+    const result = ResultBuilder.build(makeArgs({
+      metadata: { ...baseMetadata, suite: 'Outer\tInner' },
+    }));
+    const data = (result.relations as any).suite.data.map((d: any) => d.title);
+    expect(data).toEqual(['Outer', 'Inner']);
+  });
+
+  it('falls back to scenarioName when metadata.suite missing', () => {
+    const result = ResultBuilder.build(makeArgs({ scenarioName: 'My Feature' }));
+    const data = (result.relations as any).suite.data.map((d: any) => d.title);
+    expect(data).toEqual(['My Feature']);
+  });
+
+  it('merges scenario parameters with metadata.parameters (metadata wins)', () => {
+    const result = ResultBuilder.build(makeArgs({
+      metadata: { ...baseMetadata, parameters: { region: 'override' } },
+      scenarioParameters: { region: 'gherkin', env: 'prod' },
+    }));
+    expect(result.params).toEqual({ region: 'override', env: 'prod' });
+  });
+
+  it('respects project mapping precedence (testops_id null when projectMapping non-empty)', () => {
+    const result = ResultBuilder.build(makeArgs({
+      metadata: { ...baseMetadata, ids: [42], projectMapping: { PROJ: [10] } },
+    }));
+    expect(result.testops_id).toBeNull();
+    expect(result.testops_project_mapping).toEqual({ PROJ: [10] });
+  });
+});

--- a/qase-cucumberjs/test/statusTracker.test.ts
+++ b/qase-cucumberjs/test/statusTracker.test.ts
@@ -1,0 +1,72 @@
+/* eslint-disable */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { Status } from '@cucumber/cucumber';
+import { TestStatusEnum } from 'qase-javascript-commons';
+import { TestStepFinished } from '@cucumber/messages';
+import { StatusTracker } from '../src/modules/statusTracker';
+
+function step(opts: { testCaseStartedId: string; status: any; message?: string }): TestStepFinished {
+  return {
+    testStepId: 'step-' + Math.random(),
+    testCaseStartedId: opts.testCaseStartedId,
+    testStepResult: {
+      status: opts.status,
+      message: opts.message,
+      duration: { seconds: 0, nanos: 0 },
+    },
+  } as unknown as TestStepFinished;
+}
+
+describe('StatusTracker', () => {
+  let tracker: StatusTracker;
+
+  beforeEach(() => {
+    tracker = new StatusTracker();
+  });
+
+  it('initial status is passed when no steps applied', () => {
+    expect(tracker.getStatus('tcs1')).toBe(TestStatusEnum.passed);
+  });
+
+  it('applyStep with PASSED leaves status at passed', () => {
+    tracker.onTestStarted('tcs1');
+    tracker.applyStep(step({ testCaseStartedId: 'tcs1', status: Status.PASSED }));
+    expect(tracker.getStatus('tcs1')).toBe(TestStatusEnum.passed);
+  });
+
+  it('applyStep with FAILED + assertion error promotes to failed', () => {
+    tracker.onTestStarted('tcs1');
+    tracker.applyStep(step({ testCaseStartedId: 'tcs1', status: Status.FAILED, message: 'expected 1 to equal 2' }));
+    expect(tracker.getStatus('tcs1')).toBe(TestStatusEnum.failed);
+  });
+
+  it('failed status does NOT downgrade when later step is skipped', () => {
+    tracker.onTestStarted('tcs1');
+    tracker.applyStep(step({ testCaseStartedId: 'tcs1', status: Status.FAILED, message: 'expected 1 to equal 2' }));
+    tracker.applyStep(step({ testCaseStartedId: 'tcs1', status: Status.SKIPPED }));
+    expect(tracker.getStatus('tcs1')).toBe(TestStatusEnum.failed);
+  });
+
+  it('invalid status does NOT downgrade either', () => {
+    tracker.onTestStarted('tcs1');
+    tracker.applyStep(step({ testCaseStartedId: 'tcs1', status: Status.AMBIGUOUS, message: 'something' }));
+    tracker.applyStep(step({ testCaseStartedId: 'tcs1', status: Status.SKIPPED }));
+    expect(tracker.getStatus('tcs1')).toBe(TestStatusEnum.invalid);
+  });
+
+  it('getErrors collects all messages into a CompoundError', () => {
+    tracker.onTestStarted('tcs1');
+    tracker.applyStep(step({ testCaseStartedId: 'tcs1', status: Status.FAILED, message: 'first error' }));
+    tracker.applyStep(step({ testCaseStartedId: 'tcs1', status: Status.FAILED, message: 'second error' }));
+    const err = tracker.getErrors('tcs1');
+    expect(err).toBeDefined();
+    expect(err?.message).toContain('first error');
+    expect(err?.message).toContain('second error');
+  });
+
+  it('getErrors returns undefined when no failing step has a message', () => {
+    tracker.onTestStarted('tcs1');
+    tracker.applyStep(step({ testCaseStartedId: 'tcs1', status: Status.PASSED }));
+    expect(tracker.getErrors('tcs1')).toBeUndefined();
+  });
+});

--- a/qase-cucumberjs/test/stepConverter.test.ts
+++ b/qase-cucumberjs/test/stepConverter.test.ts
@@ -1,0 +1,90 @@
+/* eslint-disable */
+import { describe, expect, it } from '@jest/globals';
+import { Status } from '@cucumber/cucumber';
+import { PickleStep, TestStepFinished } from '@cucumber/messages';
+import { StepStatusEnum, StepType } from 'qase-javascript-commons';
+import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
+import { StepConverter } from '../src/modules/stepConverter';
+
+function pickleStep(id: string, text: string): PickleStep {
+  return { id, text, astNodeIds: [], type: 'Action' } as unknown as PickleStep;
+}
+
+function finished(stepId: string, status: any, durationSec = 1): TestStepFinished {
+  return {
+    testStepId: stepId,
+    testCaseStartedId: 'tcs1',
+    testStepResult: {
+      status,
+      duration: { seconds: durationSec, nanos: 0 },
+    },
+  } as unknown as TestStepFinished;
+}
+
+describe('StepConverter', () => {
+  it('converts a passed step', () => {
+    const pickleSteps = [pickleStep('p-step1', 'Given a thing')];
+    const tc = { id: 'tc1', testSteps: [{ id: 's1', pickleStepId: 'p-step1' }] } as unknown as TestCase;
+    const finishedMap = new Map<string, TestStepFinished>([
+      ['s1', finished('s1', Status.PASSED)],
+    ]);
+
+    const out = StepConverter.convert(pickleSteps, tc, finishedMap, () => []);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.step_type).toBe(StepType.GHERKIN);
+    expect(out[0]?.execution.status).toBe(StepStatusEnum.passed);
+    expect(out[0]?.execution.duration).toBe(1000);
+    expect((out[0]?.data as any).keyword).toBe('Given a thing');
+  });
+
+  it('skips test steps with no finished entry', () => {
+    const pickleSteps = [pickleStep('p-step1', 'Given a thing'), pickleStep('p-step2', 'Then it works')];
+    const tc = {
+      id: 'tc1',
+      testSteps: [{ id: 's1', pickleStepId: 'p-step1' }, { id: 's2', pickleStepId: 'p-step2' }],
+    } as unknown as TestCase;
+    const finishedMap = new Map<string, TestStepFinished>([
+      ['s1', finished('s1', Status.PASSED)],
+    ]);
+
+    const out = StepConverter.convert(pickleSteps, tc, finishedMap, () => []);
+    expect(out).toHaveLength(1);
+  });
+
+  it('skips test steps whose pickleStepId is not found in pickle.steps', () => {
+    const pickleSteps = [pickleStep('p-step1', 'Given a thing')];
+    const tc = {
+      id: 'tc1',
+      testSteps: [{ id: 's1', pickleStepId: 'non-existent' }],
+    } as unknown as TestCase;
+    const finishedMap = new Map<string, TestStepFinished>([
+      ['s1', finished('s1', Status.PASSED)],
+    ]);
+
+    const out = StepConverter.convert(pickleSteps, tc, finishedMap, () => []);
+    expect(out).toHaveLength(0);
+  });
+
+  it('attaches step attachments via lookup', () => {
+    const pickleSteps = [pickleStep('p-step1', 'Step')];
+    const tc = { id: 'tc1', testSteps: [{ id: 's1', pickleStepId: 'p-step1' }] } as unknown as TestCase;
+    const finishedMap = new Map<string, TestStepFinished>([
+      ['s1', finished('s1', Status.PASSED)],
+    ]);
+    const attach = { file_name: 'log.txt', mime_type: 'text/plain', content: 'x', file_path: null, size: 0, id: 'a1' };
+
+    const out = StepConverter.convert(pickleSteps, tc, finishedMap, (id) => id === 's1' ? [attach] : []);
+    expect(out[0]?.attachments).toEqual([attach]);
+  });
+
+  it('maps FAILED to StepStatusEnum.failed', () => {
+    const pickleSteps = [pickleStep('p-step1', 'Step')];
+    const tc = { id: 'tc1', testSteps: [{ id: 's1', pickleStepId: 'p-step1' }] } as unknown as TestCase;
+    const finishedMap = new Map<string, TestStepFinished>([
+      ['s1', finished('s1', Status.FAILED)],
+    ]);
+
+    const out = StepConverter.convert(pickleSteps, tc, finishedMap, () => []);
+    expect(out[0]?.execution.status).toBe(StepStatusEnum.failed);
+  });
+});

--- a/qase-cucumberjs/test/storage.test.ts
+++ b/qase-cucumberjs/test/storage.test.ts
@@ -2,6 +2,7 @@
 import { expect } from '@jest/globals';
 import { Storage } from '../src/storage';
 import { TagParser } from '../src/modules/tagParser';
+import { EventStorage } from '../src/modules/eventStorage';
 import { Status } from '@cucumber/cucumber';
 import { TestStatusEnum } from 'qase-javascript-commons';
 import { Pickle, GherkinDocument, Attachment, TestCase, TestCaseStarted, TestStepFinished, TestCaseFinished, AttachmentContentEncoding } from '@cucumber/messages';
@@ -30,7 +31,7 @@ describe('Storage', () => {
         uri: 'test.feature'
       };
       storage.addPickle(pickle);
-      expect((storage as any).pickles['pickle-1']).toBe(pickle);
+      expect((storage as any).events.getPickle('pickle-1')).toBe(pickle);
     });
   });
 
@@ -86,7 +87,7 @@ describe('Storage', () => {
 
       storage.addScenario(document);
 
-      expect((storage as any).scenarios['scenario-1']).toEqual({
+      expect((storage as any).events.getScenario('scenario-1')).toEqual({
         name: 'Test Feature',
         parameters: {
           'row-1': { param1: 'value1', param2: 'value2' },
@@ -124,7 +125,7 @@ describe('Storage', () => {
 
       storage.addScenario(document);
 
-      expect((storage as any).scenarios['scenario-1']).toEqual({
+      expect((storage as any).events.getScenario('scenario-1')).toEqual({
         name: 'Test Feature',
         parameters: {},
       });
@@ -142,8 +143,8 @@ describe('Storage', () => {
 
       storage.addAttachment(attachment);
 
-      expect((storage as any).attachments['step-1']).toHaveLength(1);
-      expect((storage as any).attachments['step-1']?.[0]).toEqual({
+      expect((storage as any).events.getAttachments('step-1')).toHaveLength(1);
+      expect((storage as any).events.getAttachments('step-1')[0]).toEqual({
         file_name: 'file.txt',
         mime_type: 'text/plain',
         file_path: null,
@@ -163,8 +164,8 @@ describe('Storage', () => {
 
       storage.addAttachment(attachment);
 
-      expect((storage as any).attachments['case-1']).toHaveLength(1);
-      expect((storage as any).attachments['case-1']?.[0]).toEqual({
+      expect((storage as any).events.getAttachments('case-1')).toHaveLength(1);
+      expect((storage as any).events.getAttachments('case-1')[0]).toEqual({
         file_name: 'file.png',
         mime_type: 'image/png',
         file_path: null,
@@ -191,7 +192,7 @@ describe('Storage', () => {
       storage.addAttachment(attachment1);
       storage.addAttachment(attachment2);
 
-      expect((storage as any).attachments['step-1']).toHaveLength(2);
+      expect((storage as any).events.getAttachments('step-1')).toHaveLength(2);
     });
   });
 
@@ -203,7 +204,7 @@ describe('Storage', () => {
         pickleId: 'pickle-1'
       };
       storage.addTestCase(testCase);
-      expect((storage as any).testCases['case-1']).toBe(testCase);
+      expect((storage as any).events.getTestCase('case-1')).toBe(testCase);
     });
   });
 
@@ -217,7 +218,7 @@ describe('Storage', () => {
       };
       storage.addTestCaseStarted(testCaseStarted);
 
-      expect((storage as any).testCaseStarts['started-1']).toBe(testCaseStarted);
+      expect((storage as any).events.getTestCaseStarted('started-1')).toBe(testCaseStarted);
       expect((storage as any).testCaseStartedResult['started-1']).toBe(TestStatusEnum.passed);
     });
   });
@@ -245,7 +246,7 @@ describe('Storage', () => {
 
       storage.addTestCaseStep(testStepFinished);
 
-      expect((storage as any).testCaseSteps['step-1']).toBe(testStepFinished);
+      expect((storage as any).events.getTestStepFinished('step-1')).toBe(testStepFinished);
       expect((storage as any).testCaseStartedResult['started-1']).toBe(TestStatusEnum.failed);
       expect((storage as any).testCaseStartedErrors['started-1']).toContain('Test failed');
     });
@@ -957,16 +958,16 @@ describe('Storage', () => {
     });
 
     it('should get file name from media type', () => {
-      expect((storage as any).getFileNameFromMediaType('text/plain')).toBe('file.txt');
-      expect((storage as any).getFileNameFromMediaType('application/json')).toBe('file.json');
-      expect((storage as any).getFileNameFromMediaType('image/png')).toBe('file.png');
-      expect((storage as any).getFileNameFromMediaType('image/jpeg')).toBe('file.jpg');
-      expect((storage as any).getFileNameFromMediaType('text/html')).toBe('file.html');
-      expect((storage as any).getFileNameFromMediaType('application/pdf')).toBe('file.pdf');
+      expect(EventStorage.getFileNameFromMediaType('text/plain')).toBe('file.txt');
+      expect(EventStorage.getFileNameFromMediaType('application/json')).toBe('file.json');
+      expect(EventStorage.getFileNameFromMediaType('image/png')).toBe('file.png');
+      expect(EventStorage.getFileNameFromMediaType('image/jpeg')).toBe('file.jpg');
+      expect(EventStorage.getFileNameFromMediaType('text/html')).toBe('file.html');
+      expect(EventStorage.getFileNameFromMediaType('application/pdf')).toBe('file.pdf');
     });
 
     it('should return default file name for unknown media type', () => {
-      expect((storage as any).getFileNameFromMediaType('unknown/type')).toBe('file');
+      expect(EventStorage.getFileNameFromMediaType('unknown/type')).toBe('file');
     });
   });
 }); 

--- a/qase-cucumberjs/test/storage.test.ts
+++ b/qase-cucumberjs/test/storage.test.ts
@@ -219,7 +219,7 @@ describe('Storage', () => {
       storage.addTestCaseStarted(testCaseStarted);
 
       expect((storage as any).events.getTestCaseStarted('started-1')).toBe(testCaseStarted);
-      expect((storage as any).testCaseStartedResult['started-1']).toBe(TestStatusEnum.passed);
+      expect((storage as any).statusTracker.getStatus('started-1')).toBe(TestStatusEnum.passed);
     });
   });
 
@@ -247,8 +247,8 @@ describe('Storage', () => {
       storage.addTestCaseStep(testStepFinished);
 
       expect((storage as any).events.getTestStepFinished('step-1')).toBe(testStepFinished);
-      expect((storage as any).testCaseStartedResult['started-1']).toBe(TestStatusEnum.failed);
-      expect((storage as any).testCaseStartedErrors['started-1']).toContain('Test failed');
+      expect((storage as any).statusTracker.getStatus('started-1')).toBe(TestStatusEnum.failed);
+      expect((storage as any).statusTracker.getErrors('started-1')?.message).toContain('Test failed');
     });
 
     it('should handle multiple failures for same test case', () => {
@@ -285,9 +285,9 @@ describe('Storage', () => {
       storage.addTestCaseStep(testStepFinished1);
       storage.addTestCaseStep(testStepFinished2);
 
-      expect((storage as any).testCaseStartedResult['started-1']).toBe(TestStatusEnum.invalid);
-      expect((storage as any).testCaseStartedErrors['started-1']).toContain('First failure');
-      expect((storage as any).testCaseStartedErrors['started-1']).toContain('Second failure');
+      expect((storage as any).statusTracker.getStatus('started-1')).toBe(TestStatusEnum.invalid);
+      expect((storage as any).statusTracker.getErrors('started-1')?.message).toContain('First failure');
+      expect((storage as any).statusTracker.getErrors('started-1')?.message).toContain('Second failure');
     });
   });
 

--- a/qase-cucumberjs/test/storage.test.ts
+++ b/qase-cucumberjs/test/storage.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import { expect } from '@jest/globals';
 import { Storage } from '../src/storage';
+import { TagParser } from '../src/modules/tagParser';
 import { Status } from '@cucumber/cucumber';
 import { TestStatusEnum } from 'qase-javascript-commons';
 import { Pickle, GherkinDocument, Attachment, TestCase, TestCaseStarted, TestStepFinished, TestCaseFinished, AttachmentContentEncoding } from '@cucumber/messages';
@@ -769,7 +770,7 @@ describe('Storage', () => {
         { name: '@QaseIgnore' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.ids).toEqual([123]);
       expect(result.title).toBe('Test Title');
@@ -782,7 +783,7 @@ describe('Storage', () => {
         { name: '@QaseID=123,456,789' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.ids).toEqual([123, 456, 789]);
     });
@@ -792,7 +793,7 @@ describe('Storage', () => {
         { name: '@QaseFields=invalid json' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.fields).toEqual({});
     });
@@ -802,7 +803,7 @@ describe('Storage', () => {
         { name: '@QaseParameters={"browser":"chrome","environment":"staging"}' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.parameters).toEqual({ browser: 'chrome', environment: 'staging' });
     });
@@ -812,7 +813,7 @@ describe('Storage', () => {
         { name: '@QaseGroupParameters={"test_group":"authentication","test_type":"smoke"}' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.group_params).toEqual({ test_group: 'authentication', test_type: 'smoke' });
     });
@@ -822,7 +823,7 @@ describe('Storage', () => {
         { name: "@QaseParameters={'browser':'chrome','environment':'staging'}" },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.parameters).toEqual({ browser: 'chrome', environment: 'staging' });
     });
@@ -832,7 +833,7 @@ describe('Storage', () => {
         { name: "@QaseGroupParameters={'group':'regression'}" },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.group_params).toEqual({ group: 'regression' });
     });
@@ -842,7 +843,7 @@ describe('Storage', () => {
         { name: '@QaseSuite=Authentication' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.suite).toBe('Authentication');
     });
@@ -852,7 +853,7 @@ describe('Storage', () => {
         { name: '@QaseSuite=Authentication\tLogin\tEdge Cases' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.suite).toBe('Authentication\tLogin\tEdge Cases');
     });
@@ -863,7 +864,7 @@ describe('Storage', () => {
         { name: '@QaseGroupParameters={"test_group":"authentication"}' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.parameters).toEqual({ browser: 'chrome' });
       expect(result.group_params).toEqual({ test_group: 'authentication' });
@@ -874,7 +875,7 @@ describe('Storage', () => {
         { name: '@QaseParameters=invalid json' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.parameters).toEqual({});
     });
@@ -883,7 +884,7 @@ describe('Storage', () => {
         { name: '@QaseTags=smoke,regression' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.tags).toEqual(['smoke', 'regression']);
     });
@@ -893,7 +894,7 @@ describe('Storage', () => {
         { name: '@qasetags=Smoke' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.tags).toEqual(['Smoke']);
     });
@@ -903,7 +904,7 @@ describe('Storage', () => {
         { name: '@QaseTags= smoke , regression ' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.tags).toEqual(['smoke', 'regression']);
     });
@@ -914,7 +915,7 @@ describe('Storage', () => {
         { name: '@QaseTags=regression' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.tags).toEqual(['smoke', 'regression']);
     });
@@ -926,7 +927,7 @@ describe('Storage', () => {
         { name: '@QaseFields={"severity":"high"}' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.ids).toContain(1);
       expect(result.tags).toEqual(['smoke']);
@@ -939,7 +940,7 @@ describe('Storage', () => {
         { name: '@QaseGroupParameters=invalid json' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.group_params).toEqual({});
     });
@@ -950,7 +951,7 @@ describe('Storage', () => {
         { name: '@QaseParameters={"environment":"staging"}' },
       ];
 
-      const result = (storage as any).parseTags(tags);
+      const result = TagParser.parse(tags);
 
       expect(result.parameters).toEqual({ browser: 'chrome', environment: 'staging' });
     });

--- a/qase-cucumberjs/test/tagParser.test.ts
+++ b/qase-cucumberjs/test/tagParser.test.ts
@@ -1,0 +1,73 @@
+/* eslint-disable */
+import { describe, expect, it } from '@jest/globals';
+import { PickleTag } from '@cucumber/messages';
+import { TagParser } from '../src/modules/tagParser';
+
+function tag(name: string): PickleTag {
+  return { name, astNodeId: '' } as PickleTag;
+}
+
+describe('TagParser', () => {
+  it('parses legacy @Q-123 / @q123 ids', () => {
+    const md = TagParser.parse([tag('@Q-7'), tag('@q42')]);
+    expect(md.ids).toEqual(expect.arrayContaining([7, 42]));
+  });
+
+  it('parses @QaseId=10,20,30 (new style, comma-separated)', () => {
+    const md = TagParser.parse([tag('@QaseId=10,20,30')]);
+    expect(md.ids).toEqual(expect.arrayContaining([10, 20, 30]));
+  });
+
+  it('parses @QaseTitle= override', () => {
+    const md = TagParser.parse([tag('@QaseTitle=Custom Title With Spaces')]);
+    expect(md.title).toBe('Custom Title With Spaces');
+  });
+
+  it('parses @QaseFields= JSON object', () => {
+    const md = TagParser.parse([tag('@QaseFields={"severity":"high"}')]);
+    expect(md.fields).toEqual({ severity: 'high' });
+  });
+
+  it('normalizes single quotes in @QaseFields= JSON', () => {
+    const md = TagParser.parse([tag(`@QaseFields={'env':'prod'}`)]);
+    expect(md.fields).toEqual({ env: 'prod' });
+  });
+
+  it('parses @QaseParameters= and @QaseGroupParameters=', () => {
+    const md = TagParser.parse([
+      tag('@QaseParameters={"region":"eu"}'),
+      tag('@QaseGroupParameters={"shard":"1"}'),
+    ]);
+    expect(md.parameters).toEqual({ region: 'eu' });
+    expect(md.group_params).toEqual({ shard: '1' });
+  });
+
+  it('parses @QaseSuite= override', () => {
+    const md = TagParser.parse([tag('@QaseSuite=My Suite')]);
+    expect(md.suite).toBe('My Suite');
+  });
+
+  it('parses @QaseIgnore as isIgnore=true', () => {
+    const md = TagParser.parse([tag('@QaseIgnore')]);
+    expect(md.isIgnore).toBe(true);
+  });
+
+  it('parses @QaseTags= comma-separated list', () => {
+    const md = TagParser.parse([tag('@QaseTags=smoke, regression, fast')]);
+    expect(md.tags).toEqual(['smoke', 'regression', 'fast']);
+  });
+
+  it('parseProjectMappingFromTags integration: legacy id + project mapping', () => {
+    // Just verify default empty path; project-mapping integration is exercised by storage.test.ts
+    const md = TagParser.parse([tag('@regular-tag-not-qase')]);
+    expect(md.ids).toEqual([]);
+    expect(md.projectMapping).toEqual({});
+    expect(md.fields).toEqual({});
+    expect(md.title).toBeNull();
+    expect(md.isIgnore).toBe(false);
+    expect(md.parameters).toEqual({});
+    expect(md.group_params).toEqual({});
+    expect(md.suite).toBeNull();
+    expect(md.tags).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Decompose `qase-cucumberjs/src/storage.ts` (595 → 121 LOC, -80%) into thin facade + 6 modules: `TagParser`, `EventStorage`, `StatusTracker`, `StepConverter`, `ProfilerTracker`, `ResultBuilder`. Phase 2 pattern, 5th reporter after wdio (#950) / playwright (#951) / cypress (#953) / mocha (#954).
- All 44 existing tests stay green; add 38 per-module unit tests (82 total).
- Bump `cucumberjs-qase-reporter` 2.3.0 → 2.4.0; public contract preserved (named export, ctor, static maps, 7 instance methods, 9 user-facing tag patterns).
- Bug fix: cross-reporter consistency for `testops_id` — now correctly `null` when `@qaseid.PROJ(ids)` project mapping is set, matching mocha/cypress/jest behavior.

## Test plan

- [ ] CI green on `refactor/cucumberjs-decomposition`.
- [x] `cd qase-cucumberjs && npx jest` passes locally with 82 tests.
- [ ] Smoke `QASE_MODE=report` against `examples/single/cucumberjs`: report file written, no errors in console.
- [ ] Smoke `QASE_MODE=testops` against `examples/single/cucumberjs` in DEVX project: run created, all results uploaded.
- [ ] Smoke parallel mode `QASE_MODE=testops` with `cucumber-js --parallel 2`: each worker creates a run; aggregate result count matches sequential.

## Design

- Spec: `docs/superpowers/specs/2026-04-29-cucumberjs-decomposition-design.md` (not committed; tracked locally).
- Plan: `docs/superpowers/plans/2026-04-29-cucumberjs-decomposition.md` (not committed; tracked locally).