### PR TITLE
fix(examples/cucumberjs): align example with V2 API validation

### DIFF
--- a/examples/single/cucumberjs/features/api-advanced.feature
+++ b/examples/single/cucumberjs/features/api-advanced.feature
@@ -22,7 +22,6 @@ Feature: Advanced Qase Features
   @QaseFields={"severity":"normal","layer":"api"}
   @QaseSuite=API\tAdvanced\tData_Validation
   @QaseGroupParameters={"environment":"production","region":"us-east"}
-  @QaseTags=advanced,api
   Scenario: Suite hierarchy and group parameters demonstration
     When I send a GET request to "/todos/1"
     Then the response status should be 200

--- a/examples/single/cucumberjs/features/api-advanced.feature
+++ b/examples/single/cucumberjs/features/api-advanced.feature
@@ -7,7 +7,7 @@ Feature: Advanced Qase Features
 
   @QaseID=12
   @QaseTitle=Fetch_user_and_their_posts_relationship
-  @QaseFields={"severity":"normal","priority":"medium","layer":"api"}
+  @QaseFields={"severity":"normal","priority":"high","layer":"api"}
   @QaseSuite=API\tAdvanced\tRelationships
   @QaseParameters={"testScope":"user_posts_relationship"}
   Scenario: Fetch user and their posts

--- a/examples/single/cucumberjs/features/api-errors.feature
+++ b/examples/single/cucumberjs/features/api-errors.feature
@@ -23,7 +23,7 @@ Feature: Error Handling
     And the response should be an empty object
 
   @QaseID=10
-  @QaseFields={"severity":"low","layer":"api"}
+  @QaseFields={"severity":"minor","layer":"api"}
   @QaseSuite=API\tErrors\tInvalid_Endpoint
   Scenario: Invalid endpoint returns 404
     When I send a GET request to "/invalid-endpoint"


### PR DESCRIPTION
## Summary

Minimal example feature data fixes so the `examples/single/cucumberjs` scenarios pass the Qase TestOps V2 results-API validation:

1. **`api-errors.feature:26`** — `severity:"low"` → `"minor"` (low isn't in the valid severity enum: blocker / critical / major / normal / minor / trivial).
2. **`api-advanced.feature:10`** — `priority:"medium"` → `"high"` (medium isn't a valid priority value).
3. **`api-advanced.feature` case 13** — drop `@QaseTags=advanced,api`. V2 silently drops results whose `fields.tags` references tag names that don't exist as project tags; the example used arbitrary names. Reporter-side tag handling is intentionally untouched — sending tags as written is the contract; reconciling tags against the project is the backend's responsibility.

## Test plan

- [x] `cd qase-cucumberjs && npx jest` — 82/82 pass.
- [x] Local `QASE_MODE=report` smoke against `examples/single/cucumberjs` — 17 results in `build/qase-report/results/`.
- [ ] CI green on the branch.

## Notes

Two pre-existing issues NOT addressed in this PR (out of scope):
- V2 silently drops results whose `start_time` falls outside its freshness window. Long-running suites (cucumberjs hitting real APIs) hit this; symptom is `200 OK` but 0–1/N results landing.
- V2 silently drops results whose `fields.tags` contains tag names not present in the project.

After merge, re-tag `qase-cucumberjs-v2.4.0 <merge-sha>` to publish the decomposition release that #955 merged but never tagged.