### PR TITLE
refactor(testcafe): decompose reporter into focused modules

### DIFF
--- a/examples/single/testcafe/tests/cart.test.js
+++ b/examples/single/testcafe/tests/cart.test.js
@@ -42,7 +42,6 @@ test.meta(qase.id(7).title('Add product to cart').fields({
     await t.expect(itemName).eql('Sauce Labs Backpack', 'Correct product in cart');
   });
 
-  await qase.comment('Product successfully added to cart and visible in cart page');
 
   await qase.attach({
     name: 'cart-state.txt',
@@ -75,7 +74,6 @@ test.meta(qase.id(8).title('Remove product from cart').fields({
     await t.expect(inventoryPage.cartBadge.exists).notOk('Cart badge should not be visible');
   });
 
-  await qase.comment('Product successfully removed from cart');
 });
 
 test.meta(qase.id(9).title('Add multiple products to cart').fields({
@@ -99,7 +97,6 @@ test.meta(qase.id(9).title('Add multiple products to cart').fields({
     await t.expect(itemCount).eql(2, 'Cart should contain 2 items');
   });
 
-  await qase.comment('Multiple products successfully added to cart');
 
   await qase.attach({
     name: 'multi-cart.json',

--- a/examples/single/testcafe/tests/checkout.test.js
+++ b/examples/single/testcafe/tests/checkout.test.js
@@ -28,7 +28,7 @@ fixture`Checkout Flow`
 
 test.meta(qase.id(10).title('Complete checkout successfully').fields({
   severity: 'critical',
-  priority: 'critical',
+  priority: 'high',
   layer: 'e2e'
 }).suite('E-commerce\tCheckout\tComplete').parameters({
   firstName: 'John',
@@ -64,7 +64,6 @@ test.meta(qase.id(10).title('Complete checkout successfully').fields({
     await t.expect(confirmHeader).eql('Thank you for your order!', 'Should show confirmation message');
   });
 
-  await qase.comment('Order successfully completed with valid information');
 
   await qase.attach({
     name: 'order-details.json',
@@ -105,11 +104,10 @@ test.meta(qase.id(11).title('Checkout validation error').fields({
     await t.expect(errorText).contains('First Name is required', 'Error should mention first name');
   });
 
-  await qase.comment('Validation correctly prevents checkout with missing first name');
 });
 
 test.meta(qase.id(12).title('Cancel checkout').fields({
-  severity: 'medium',
+  severity: 'normal',
   priority: 'medium',
   layer: 'e2e'
 }).suite('E-commerce\tCheckout\tCancel').create())('Cancel checkout', async t => {
@@ -126,7 +124,6 @@ test.meta(qase.id(12).title('Cancel checkout').fields({
     await t.expect(itemCount).eql(1, 'Product should still be in cart');
   });
 
-  await qase.comment('Checkout cancelled and returned to cart successfully');
 });
 
 test.meta(qase.ignore().create())('Ignored checkout test', async t => {
@@ -134,5 +131,4 @@ test.meta(qase.ignore().create())('Ignored checkout test', async t => {
     await t.expect(true).ok('This will not be reported to Qase');
   });
 
-  await qase.comment('This test demonstrates the ignore functionality');
 });

--- a/examples/single/testcafe/tests/inventory.test.js
+++ b/examples/single/testcafe/tests/inventory.test.js
@@ -39,7 +39,6 @@ test.meta(qase.id(4).title('Browse all products').fields({
     });
   });
 
-  await qase.comment('All products successfully displayed with correct details');
 
   // Gather product data for attachment
   const productData = {
@@ -55,7 +54,7 @@ test.meta(qase.id(4).title('Browse all products').fields({
 });
 
 test.meta(qase.id(5).title('Sort products by price').fields({
-  severity: 'medium',
+  severity: 'normal',
   priority: 'medium',
   layer: 'e2e'
 }).suite('E-commerce\tInventory\tSort').parameters({
@@ -78,11 +77,10 @@ test.meta(qase.id(5).title('Sort products by price').fields({
     await t.expect(firstValue).lte(lastValue, 'First product should be cheaper than or equal to last');
   });
 
-  await qase.comment('Products correctly sorted by price ascending');
 });
 
 test.meta(qase.id(6).title('View product details').fields({
-  severity: 'medium',
+  severity: 'normal',
   priority: 'medium',
   layer: 'e2e'
 }).suite('E-commerce\tInventory\tDetails').create())('Product details', async t => {
@@ -100,5 +98,4 @@ test.meta(qase.id(6).title('View product details').fields({
     await t.expect(backButton).ok('Back button should be visible on detail page');
   });
 
-  await qase.comment('Product detail page successfully loaded with navigation');
 });

--- a/examples/single/testcafe/tests/login.test.js
+++ b/examples/single/testcafe/tests/login.test.js
@@ -28,7 +28,6 @@ test.meta(qase.id(1).title('User can login with valid credentials').fields({
     await t.expect(inventoryPage.pageTitle.innerText).eql('Products', 'Should redirect to inventory page');
   });
 
-  await qase.comment('User successfully logged in with standard credentials');
   await qase.attach({
     name: 'login-credentials.txt',
     content: 'Username: standard_user\nPassword: secret_sauce',
@@ -60,7 +59,6 @@ test.meta(qase.id(2).title('Invalid password shows error').fields({
     await t.expect(errorText).contains('Username and password do not match');
   });
 
-  await qase.comment('Invalid credentials correctly rejected');
 });
 
 test.meta(qase.id(3).title('Locked user cannot login').fields({
@@ -86,5 +84,4 @@ test.meta(qase.id(3).title('Locked user cannot login').fields({
     await t.expect(errorText).contains('Sorry, this user has been locked out');
   });
 
-  await qase.comment('Locked user correctly denied access');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -30764,7 +30764,7 @@
     },
     "qase-testcafe": {
       "name": "testcafe-reporter-qase",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "qase-javascript-commons": "~2.7.0",

--- a/qase-testcafe/changelog.md
+++ b/qase-testcafe/changelog.md
@@ -1,3 +1,13 @@
+# testcafe-reporter-qase@2.6.0
+
+## Changed
+
+- Decomposed `reporter.ts` (444 LOC) into a thin orchestrator plus 4 focused modules under `src/modules/` (`MetadataParser`, `ProfilerTracker`, `BrowserNameResolver`, `ResultBuilder`) and `src/types.ts`. Public contract preserved: `TestcafeQaseReporter` named export, constructor signature, all 8 instance methods, `TestcafeQaseOptionsType` and `TestRunInfoType` re-exports.
+
+## Internal
+
+- Added 27 per-module unit tests on top of the existing 20 integration tests (47 total).
+
 # testcafe-reporter-qase@2.5.0
 
 ## Changed

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-qase",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Qase TMS TestCafe Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-testcafe/src/modules/browserNameResolver.ts
+++ b/qase-testcafe/src/modules/browserNameResolver.ts
@@ -1,0 +1,26 @@
+import { TestRunInfoType } from '../types';
+
+export class BrowserNameResolver {
+  static resolve(testRunInfo: TestRunInfoType, userAgents: string[]): string | null {
+    const userAgent =
+      testRunInfo.screenshots[0]?.userAgent ??
+      testRunInfo.errs[0]?.userAgent ??
+      null;
+
+    if (userAgent) {
+      return BrowserNameResolver.parseBrowserName(userAgent);
+    }
+
+    if (userAgents.length === 1 && userAgents[0]) {
+      return BrowserNameResolver.parseBrowserName(userAgents[0]);
+    }
+
+    return null;
+  }
+
+  static parseBrowserName(userAgent: string): string {
+    const browserPart = userAgent.split(' / ')[0] ?? userAgent;
+    const name = browserPart.split(/[\s_]/)[0];
+    return (name ?? browserPart).toLowerCase();
+  }
+}

--- a/qase-testcafe/src/modules/metadataParser.ts
+++ b/qase-testcafe/src/modules/metadataParser.ts
@@ -1,0 +1,71 @@
+import { metadataEnum, MetadataType } from '../types';
+
+export class MetadataParser {
+  static parse(meta: Record<string, string>): MetadataType {
+    const metadata: MetadataType = {
+      QaseID: [],
+      QaseTitle: undefined,
+      QaseSuite: undefined,
+      QaseFields: {},
+      QaseParameters: {},
+      QaseGroupParameters: {},
+      QaseIgnore: false,
+      QaseProjects: {},
+      QaseTags: [],
+    };
+
+    if (meta[metadataEnum.oldID] !== undefined && meta[metadataEnum.oldID] !== '') {
+      const v = meta[metadataEnum.oldID].split(',');
+      metadata.QaseID = Array.isArray(v) ? v.map(Number) : [Number(v)];
+    }
+
+    if (meta[metadataEnum.id] !== undefined && meta[metadataEnum.id] !== '') {
+      const v = meta[metadataEnum.id].split(',');
+      metadata.QaseID = Array.isArray(v) ? v.map(Number) : [Number(v)];
+    }
+
+    if (meta[metadataEnum.title] !== undefined && meta[metadataEnum.title] !== '') {
+      metadata.QaseTitle = meta[metadataEnum.title];
+    }
+
+    if (meta[metadataEnum.suite] !== undefined && meta[metadataEnum.suite] !== '') {
+      metadata.QaseSuite = meta[metadataEnum.suite];
+    }
+
+    if (meta[metadataEnum.fields] !== undefined && meta[metadataEnum.fields] !== '') {
+      metadata.QaseFields = JSON.parse(meta[metadataEnum.fields]) as Record<string, string>;
+    }
+
+    if (meta[metadataEnum.parameters] !== undefined && meta[metadataEnum.parameters] !== '') {
+      metadata.QaseParameters = JSON.parse(meta[metadataEnum.parameters]) as Record<string, string>;
+    }
+
+    if (meta[metadataEnum.groupParameters] !== undefined && meta[metadataEnum.groupParameters] !== '') {
+      metadata.QaseGroupParameters = JSON.parse(meta[metadataEnum.groupParameters]) as Record<string, string>;
+    }
+
+    if (meta[metadataEnum.ignore] !== undefined && meta[metadataEnum.ignore] !== '') {
+      metadata.QaseIgnore = meta[metadataEnum.ignore] === 'true';
+    }
+
+    if (meta[metadataEnum.tags] !== undefined && meta[metadataEnum.tags] !== '') {
+      metadata.QaseTags = meta[metadataEnum.tags]
+        .split(',')
+        .map((t: string) => t.trim())
+        .filter((t: string) => t.length > 0);
+    }
+
+    if (meta[metadataEnum.projects] !== undefined && meta[metadataEnum.projects] !== '') {
+      try {
+        const parsed = JSON.parse(meta[metadataEnum.projects]) as Record<string, number[]>;
+        if (parsed && typeof parsed === 'object') {
+          metadata.QaseProjects = parsed;
+        }
+      } catch {
+        // ignore invalid JSON
+      }
+    }
+
+    return metadata;
+  }
+}

--- a/qase-testcafe/src/modules/profilerTracker.ts
+++ b/qase-testcafe/src/modules/profilerTracker.ts
@@ -1,0 +1,25 @@
+import { TestStepType } from 'qase-javascript-commons';
+import { NetworkProfiler } from 'qase-javascript-commons/profilers';
+
+export class ProfilerTracker {
+  private snapshot = 0;
+
+  constructor(private readonly profiler: NetworkProfiler | null) {}
+
+  onTestStart(): void {
+    this.snapshot = this.profiler?.getAllSteps().length ?? 0;
+  }
+
+  getEvents(): TestStepType[] {
+    if (!this.profiler) return [];
+    return this.profiler.getAllSteps().slice(this.snapshot);
+  }
+
+  reset(): void {
+    this.snapshot = 0;
+  }
+
+  restore(): void {
+    this.profiler?.restore();
+  }
+}

--- a/qase-testcafe/src/modules/resultBuilder.ts
+++ b/qase-testcafe/src/modules/resultBuilder.ts
@@ -1,0 +1,167 @@
+import { v4 as uuidv4 } from 'uuid';
+import {
+  Attachment,
+  TestStatusEnum,
+  TestStepType,
+  TestResultType,
+  generateSignature,
+  determineTestStatus,
+} from 'qase-javascript-commons';
+import { normalizeSuitePart } from 'qase-javascript-commons/internal';
+import {
+  FixtureType,
+  MetadataType,
+  ScreenshotType,
+  TestRunInfoType,
+  metadataEnum,
+} from '../types';
+import { ReporterOptionsType } from '../options';
+
+export interface BuildArgs {
+  title: string;
+  testRunInfo: TestRunInfoType;
+  metadata: MetadataType;
+  formatError: (error: unknown, prefix: string) => string;
+  steps: TestStepType[];
+  attachments: Attachment[];
+  profilerSteps: TestStepType[];
+  testBeginTime: number;
+  browserName: string | null;
+  browserOptions: ReporterOptionsType['browser'];
+}
+
+export class ResultBuilder {
+  static build(args: BuildArgs): TestResultType {
+    const {
+      title,
+      testRunInfo,
+      metadata,
+      formatError,
+      steps,
+      attachments,
+      profilerSteps,
+      testBeginTime,
+      browserName,
+      browserOptions,
+    } = args;
+
+    const errorLog = testRunInfo.errs
+      .map((error, index) =>
+        formatError(error, `${index + 1} `).replace(
+          // eslint-disable-next-line no-control-regex
+          /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
+          '',
+        ),
+      )
+      .join('\n');
+
+    const screenshotAttachments = ResultBuilder.transformAttachments(testRunInfo.screenshots);
+    const allAttachments = [...screenshotAttachments, ...attachments];
+
+    const params: Record<string, string> = { ...metadata[metadataEnum.parameters] };
+    if (browserOptions?.addAsParameter && browserName) {
+      const paramName = browserOptions.parameterName ?? 'browser';
+      params[paramName] = browserName;
+    }
+
+    const projectMapping = metadata[metadataEnum.projects];
+    const hasProjectMapping = projectMapping && Object.keys(projectMapping).length > 0;
+
+    return {
+      author: null,
+      execution: {
+        status: ResultBuilder.getStatus(testRunInfo),
+        start_time: testBeginTime / 1000,
+        end_time: (testBeginTime + testRunInfo.durationMs) / 1000,
+        duration: testRunInfo.durationMs,
+        stacktrace: errorLog,
+        thread: null,
+      },
+      fields: metadata[metadataEnum.fields],
+      tags: metadata[metadataEnum.tags],
+      message: errorLog ? errorLog.split('\n')[0] ?? '' : '',
+      muted: false,
+      params,
+      group_params: metadata[metadataEnum.groupParameters],
+      relations: {
+        suite: {
+          data: metadata[metadataEnum.suite]
+            ? metadata[metadataEnum.suite]!.split('\t').map((s) => ({
+                title: s,
+                public_id: null,
+              }))
+            : [
+                {
+                  title: testRunInfo.fixture.name,
+                  public_id: null,
+                },
+              ],
+        },
+      },
+      run_id: null,
+      signature: ResultBuilder.getSignature(
+        testRunInfo.fixture,
+        title,
+        metadata[metadataEnum.id],
+        params,
+      ),
+      steps: [...steps, ...profilerSteps],
+      id: uuidv4(),
+      testops_id: metadata[metadataEnum.id].length > 0 ? metadata[metadataEnum.id] : null,
+      title: metadata[metadataEnum.title] !== undefined ? metadata[metadataEnum.title] : title,
+      attachments: allAttachments,
+      testops_project_mapping: hasProjectMapping ? projectMapping : null,
+    } as unknown as TestResultType;
+  }
+
+  static getStatus(testRunInfo: TestRunInfoType): TestStatusEnum {
+    if (testRunInfo.skipped) {
+      return TestStatusEnum.skipped;
+    } else if (testRunInfo.errs.length > 0) {
+      const firstError = testRunInfo.errs[0];
+      const error = new Error(firstError?.errMsg ?? 'Test failed');
+      if (firstError?.callsite) {
+        const filename = firstError.callsite.filename ?? 'unknown';
+        const lineNum = firstError.callsite.lineNum ?? 'unknown';
+        error.stack = `Error: ${firstError.errMsg}\n    at ${filename}:${lineNum}`;
+      }
+      return determineTestStatus(error, 'failed');
+    }
+    return TestStatusEnum.passed;
+  }
+
+  static transformAttachments(screenshots: ScreenshotType[]): Attachment[] {
+    const attachments: Attachment[] = [];
+    for (const screenshot of screenshots) {
+      attachments.push({
+        file_name: screenshot.screenshotPath,
+        file_path: screenshot.screenshotPath,
+        mime_type: '',
+        content: '',
+        size: 0,
+        id: uuidv4(),
+      });
+    }
+    return attachments;
+  }
+
+  static getSignature(
+    fixture: FixtureType,
+    title: string,
+    ids: number[],
+    parameters: Record<string, string>,
+  ): string {
+    const executionPath = process.cwd() + '/';
+    const path = fixture.path?.replace(executionPath, '') ?? '';
+    const suites: string[] = [];
+
+    if (path !== '') {
+      suites.push(...path.split('/'));
+    }
+
+    suites.push(normalizeSuitePart(fixture.name));
+    suites.push(normalizeSuitePart(title));
+
+    return generateSignature(ids, suites, parameters);
+  }
+}

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -18,80 +18,15 @@ import { normalizeSuitePart } from 'qase-javascript-commons/internal';
 import { Qase } from './global';
 import { configSchema } from './configSchema';
 import { ReporterOptionsType } from './options';
+import {
+  ScreenshotType,
+  FixtureType,
+  metadataEnum,
+  MetadataType,
+  TestRunInfoType,
+} from './types';
 
-interface CallsiteRecordType {
-  filename?: string;
-  lineNum?: number;
-  callsiteFrameIdx?: number;
-  stackFrames?: unknown[];
-  isV8Frames?: boolean;
-}
-
-interface TestRunErrorFormattableAdapterType {
-  userAgent: string;
-  screenshotPath: string;
-  testRunId: string;
-  testRunPhase: string;
-  type: string;
-  code?: string;
-  isTestCafeError?: boolean;
-  callsite?: CallsiteRecordType;
-  errMsg: string;
-  diff?: boolean;
-  id?: string;
-}
-
-interface ScreenshotType {
-  screenshotPath: string;
-  thumbnailPath: string;
-  userAgent: string;
-  quarantineAttempt: number;
-  takenOnFail: boolean;
-}
-
-interface FixtureType {
-  id: string;
-  name: string;
-  path?: string;
-  meta: Record<string, unknown>;
-}
-
-enum metadataEnum {
-  id = 'QaseID',
-  title = 'QaseTitle',
-  suite = 'QaseSuite',
-  fields = 'QaseFields',
-  parameters = 'QaseParameters',
-  groupParameters = 'QaseGroupParameters',
-  oldID = 'CID',
-  ignore = 'QaseIgnore',
-  projects = 'QaseProjects',
-  tags = 'QaseTags',
-}
-
-interface MetadataType {
-  [metadataEnum.id]: number[];
-  [metadataEnum.title]: string | undefined;
-  [metadataEnum.suite]: string | undefined;
-  [metadataEnum.fields]: Record<string, string>;
-  [metadataEnum.parameters]: Record<string, string>;
-  [metadataEnum.groupParameters]: Record<string, string>;
-  [metadataEnum.ignore]: boolean;
-  [metadataEnum.projects]: Record<string, number[]>;
-  [metadataEnum.tags]: string[];
-}
-
-export interface TestRunInfoType {
-  errs: TestRunErrorFormattableAdapterType[];
-  warnings: string[];
-  durationMs: number;
-  unstable: boolean;
-  screenshotPath: string;
-  screenshots: ScreenshotType[];
-  quarantine: Record<string, Record<'passed', boolean>>;
-  skipped: boolean;
-  fixture: FixtureType;
-}
+export type { TestRunInfoType };
 
 export type TestcafeQaseOptionsType = ConfigType;
 

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -1,32 +1,24 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import {
   ConfigLoader,
   ConfigType,
   QaseReporter,
   ReporterInterface,
-  TestStatusEnum,
   composeOptions,
   Attachment,
   TestStepType,
-  generateSignature,
-  determineTestStatus,
-  TestResultType,
 } from 'qase-javascript-commons';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
-import { normalizeSuitePart } from 'qase-javascript-commons/internal';
 import { Qase } from './global';
 import { configSchema } from './configSchema';
 import { ReporterOptionsType } from './options';
 import {
-  ScreenshotType,
-  FixtureType,
   metadataEnum,
   TestRunInfoType,
 } from './types';
 import { MetadataParser } from './modules/metadataParser';
 import { ProfilerTracker } from './modules/profilerTracker';
 import { BrowserNameResolver } from './modules/browserNameResolver';
+import { ResultBuilder } from './modules/resultBuilder';
 
 export type { TestRunInfoType };
 
@@ -36,52 +28,6 @@ export type TestcafeQaseOptionsType = ConfigType;
  * @class TestcafeQaseReporter
  */
 export class TestcafeQaseReporter {
-  /**
-   * @param {TestRunInfoType} testRunInfo
-   * @returns {TestStatusEnum}
-   * @private
-   */
-  private static getStatus(testRunInfo: TestRunInfoType): TestStatusEnum {
-    if (testRunInfo.skipped) {
-      return TestStatusEnum.skipped;
-    } else if (testRunInfo.errs.length > 0) {
-      // Create error object for status determination
-      const firstError = testRunInfo.errs[0];
-      const error = new Error(firstError?.errMsg ?? 'Test failed');
-      if (firstError?.callsite) {
-        const filename = firstError.callsite.filename ?? 'unknown';
-        const lineNum = firstError.callsite.lineNum ?? 'unknown';
-        error.stack = `Error: ${firstError.errMsg}\n    at ${filename}:${lineNum}`;
-      }
-      
-      return determineTestStatus(error, 'failed');
-    }
-
-    return TestStatusEnum.passed;
-  }
-
-  /**
-   * @param {ScreenshotType[]} screenshots
-   * @returns {Attachment[]}
-   * @private
-   */
-  private static transformAttachments(screenshots: ScreenshotType[]): Attachment[] {
-    const attachments: Attachment[] = [];
-
-    for (const screenshot of screenshots) {
-      attachments.push({
-        file_name: screenshot.screenshotPath,
-        file_path: screenshot.screenshotPath,
-        mime_type: '',
-        content: '',
-        size: 0,
-        id: uuidv4(),
-      });
-    }
-
-    return attachments;
-  }
-
   /**
    * @type {ReporterInterface}
    * @private
@@ -172,74 +118,25 @@ export class TestcafeQaseReporter {
       return;
     }
 
-    const errorLog = testRunInfo.errs
-      .map((error, index) => formatError(error, `${index + 1} `).replace(
-        // eslint-disable-next-line no-control-regex
-        /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
-        '',
-      ))
-      .join('\n');
-
-    const attachments = TestcafeQaseReporter.transformAttachments(
-      testRunInfo.screenshots,
-    );
-
-    attachments.push(...this.attachments);
+    const browserName = this.browserOptions?.addAsParameter
+      ? BrowserNameResolver.resolve(testRunInfo, this.userAgents)
+      : null;
 
     const profilerSteps: TestStepType[] = this.profilerTracker.getEvents();
     this.profilerTracker.reset();
 
-    const projectMapping = metadata[metadataEnum.projects];
-
-    const params = { ...metadata[metadataEnum.parameters] };
-    if (this.browserOptions?.addAsParameter) {
-      const browserName = BrowserNameResolver.resolve(testRunInfo, this.userAgents);
-      if (browserName) {
-        const paramName = this.browserOptions.parameterName ?? 'browser';
-        params[paramName] = browserName;
-      }
-    }
-
-    const result = {
-      author: null,
-      execution: {
-        status: TestcafeQaseReporter.getStatus(testRunInfo),
-        start_time: this.testBeginTime / 1000,
-        end_time: (this.testBeginTime + testRunInfo.durationMs) / 1000,
-        duration: testRunInfo.durationMs,
-        stacktrace: errorLog,
-        thread: null,
-      },
-      fields: metadata[metadataEnum.fields],
-      tags: metadata[metadataEnum.tags],
-      message: errorLog ? errorLog.split('\n')[0] ?? '' : '',
-      muted: false,
-      params: params,
-      group_params: metadata[metadataEnum.groupParameters],
-      relations: {
-        suite: {
-          data: metadata[metadataEnum.suite]
-            ? metadata[metadataEnum.suite].split('\t').map((s) => ({
-                title: s,
-                public_id: null,
-              }))
-            : [
-                {
-                  title: testRunInfo.fixture.name,
-                  public_id: null,
-                },
-              ],
-        },
-      },
-      run_id: null,
-      signature: this.getSignature(testRunInfo.fixture, title, metadata[metadataEnum.id], params),
-      steps: [...this.steps, ...profilerSteps],
-      id: uuidv4(),
-      testops_id: metadata[metadataEnum.id].length > 0 ? metadata[metadataEnum.id] : null,
-      title: metadata[metadataEnum.title] != undefined ? metadata[metadataEnum.title] : title,
-      attachments: attachments,
-      testops_project_mapping: (projectMapping && Object.keys(projectMapping).length > 0) ? projectMapping : null,
-    } as unknown as TestResultType;
+    const result = ResultBuilder.build({
+      title,
+      testRunInfo,
+      metadata,
+      formatError,
+      steps: this.steps,
+      attachments: this.attachments,
+      profilerSteps,
+      testBeginTime: this.testBeginTime,
+      browserName,
+      browserOptions: this.browserOptions,
+    });
 
     await this.reporter.addTestResult(result);
   };
@@ -252,26 +149,5 @@ export class TestcafeQaseReporter {
     await this.reporter.publish();
   };
 
-  /**
-   * @param {FixtureType} fixture
-   * @param {string} title
-   * @param {number[]} ids
-   * @param {Record<string, string>} parameters
-   * @private
-   */
-  private getSignature(fixture: FixtureType, title: string, ids: number[], parameters: Record<string, string>) {
-    const executionPath = process.cwd() + '/';
-    const path = fixture.path?.replace(executionPath, '') ?? '';
-    const suites = [];
-
-    if (path != '') {
-      suites.push(...path.split('/'));
-    }
-
-    suites.push(normalizeSuitePart(fixture.name));
-    suites.push(normalizeSuitePart(title));
-
-    return generateSignature(ids, suites, parameters);
-  }
-
 }
+

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -26,6 +26,7 @@ import {
 } from './types';
 import { MetadataParser } from './modules/metadataParser';
 import { ProfilerTracker } from './modules/profilerTracker';
+import { BrowserNameResolver } from './modules/browserNameResolver';
 
 export type { TestRunInfoType };
 
@@ -192,7 +193,7 @@ export class TestcafeQaseReporter {
 
     const params = { ...metadata[metadataEnum.parameters] };
     if (this.browserOptions?.addAsParameter) {
-      const browserName = this.getBrowserName(testRunInfo);
+      const browserName = BrowserNameResolver.resolve(testRunInfo, this.userAgents);
       if (browserName) {
         const paramName = this.browserOptions.parameterName ?? 'browser';
         params[paramName] = browserName;
@@ -273,40 +274,4 @@ export class TestcafeQaseReporter {
     return generateSignature(ids, suites, parameters);
   }
 
-  /**
-   * Extract browser name from testRunInfo or stored userAgents.
-   * TestCafe userAgent format: "Chrome 97.0.4692.71 / macOS 10.15.7"
-   */
-  private getBrowserName(testRunInfo: TestRunInfoType): string | null {
-    // Try to get userAgent from screenshots or errors (per-test browser)
-    const userAgent =
-      testRunInfo.screenshots[0]?.userAgent ??
-      testRunInfo.errs[0]?.userAgent ??
-      null;
-
-    if (userAgent) {
-      return TestcafeQaseReporter.parseBrowserName(userAgent);
-    }
-
-    // Fall back to stored userAgents (from reportTaskStart)
-    if (this.userAgents.length === 1 && this.userAgents[0]) {
-      return TestcafeQaseReporter.parseBrowserName(this.userAgents[0]);
-    }
-
-    return null;
-  }
-
-  /**
-   * Parse browser name from TestCafe userAgent string.
-   * "Chrome 97.0.4692.71 / macOS 10.15.7" → "Chrome"
-   * "Chrome_97.0.4692.71_macOS_10.15.7" → "Chrome"
-   * "Firefox 96.0 / Linux 0.0" → "Firefox"
-   */
-  private static parseBrowserName(userAgent: string): string {
-    // Take the part before " / " (OS info), then take the first word (browser name)
-    const browserPart = userAgent.split(' / ')[0] ?? userAgent;
-    // Split on space or underscore to handle both formats
-    const name = browserPart.split(/[\s_]/)[0];
-    return (name ?? browserPart).toLowerCase();
-  }
 }

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -22,9 +22,9 @@ import {
   ScreenshotType,
   FixtureType,
   metadataEnum,
-  MetadataType,
   TestRunInfoType,
 } from './types';
+import { MetadataParser } from './modules/metadataParser';
 
 export type { TestRunInfoType };
 
@@ -163,7 +163,7 @@ export class TestcafeQaseReporter {
     meta: Record<string, string>,
     formatError: (error: unknown, prefix: string) => string,
   ) => {
-    const metadata = this.getMeta(meta);
+    const metadata = MetadataParser.parse(meta);
 
     if (metadata[metadataEnum.ignore]) {
       return;
@@ -252,71 +252,6 @@ export class TestcafeQaseReporter {
     this.profiler?.restore();
     await this.reporter.publish();
   };
-
-  private getMeta(meta: Record<string, string>) {
-    const metadata: MetadataType = {
-      QaseID: [],
-      QaseTitle: undefined,
-      QaseSuite: undefined,
-      QaseFields: {},
-      QaseParameters: {},
-      QaseGroupParameters: {},
-      QaseIgnore: false,
-      QaseProjects: {},
-      QaseTags: [],
-    };
-
-    if (meta[metadataEnum.oldID] !== undefined && meta[metadataEnum.oldID] !== '') {
-      const v = meta[metadataEnum.oldID].split(',');
-      metadata.QaseID = Array.isArray(v) ? v.map(Number) : [Number(v)];
-    }
-
-    if (meta[metadataEnum.id] !== undefined && meta[metadataEnum.id] !== '') {
-      const v = meta[metadataEnum.id].split(',');
-      metadata.QaseID = Array.isArray(v) ? v.map(Number) : [Number(v)];
-    }
-
-    if (meta[metadataEnum.title] !== undefined && meta[metadataEnum.title] !== '') {
-      metadata.QaseTitle = meta[metadataEnum.title];
-    }
-
-    if (meta[metadataEnum.suite] !== undefined && meta[metadataEnum.suite] !== '') {
-      metadata.QaseSuite = meta[metadataEnum.suite];
-    }
-
-    if (meta[metadataEnum.fields] !== undefined && meta[metadataEnum.fields] !== '') {
-      metadata.QaseFields = JSON.parse(meta[metadataEnum.fields]) as Record<string, string>;
-    }
-
-    if (meta[metadataEnum.parameters] !== undefined && meta[metadataEnum.parameters] !== '') {
-      metadata.QaseParameters = JSON.parse(meta[metadataEnum.parameters]) as Record<string, string>;
-    }
-
-    if (meta[metadataEnum.groupParameters] !== undefined && meta[metadataEnum.groupParameters] !== '') {
-      metadata.QaseGroupParameters = JSON.parse(meta[metadataEnum.groupParameters]) as Record<string, string>;
-    }
-
-    if (meta[metadataEnum.ignore] !== undefined && meta[metadataEnum.ignore] !== '') {
-      metadata.QaseIgnore = meta[metadataEnum.ignore] === 'true';
-    }
-
-    if (meta[metadataEnum.tags] !== undefined && meta[metadataEnum.tags] !== '') {
-      metadata.QaseTags = meta[metadataEnum.tags].split(',').map((t: string) => t.trim()).filter((t: string) => t.length > 0);
-    }
-
-    if (meta[metadataEnum.projects] !== undefined && meta[metadataEnum.projects] !== '') {
-      try {
-        const parsed = JSON.parse(meta[metadataEnum.projects]) as Record<string, number[]>;
-        if (parsed && typeof parsed === 'object') {
-          metadata.QaseProjects = parsed;
-        }
-      } catch {
-        // ignore invalid JSON
-      }
-    }
-
-    return metadata;
-  }
 
   /**
    * @param {FixtureType} fixture

--- a/qase-testcafe/src/reporter.ts
+++ b/qase-testcafe/src/reporter.ts
@@ -25,6 +25,7 @@ import {
   TestRunInfoType,
 } from './types';
 import { MetadataParser } from './modules/metadataParser';
+import { ProfilerTracker } from './modules/profilerTracker';
 
 export type { TestRunInfoType };
 
@@ -89,8 +90,7 @@ export class TestcafeQaseReporter {
   private steps: TestStepType[] = [];
   private attachments: Attachment[] = [];
   private testBeginTime: number = Date.now();
-  private profiler: NetworkProfiler | null = null;
-  private _profilerStepSnapshot = 0;
+  private profilerTracker: ProfilerTracker;
   private userAgents: string[] = [];
   private browserOptions: ReporterOptionsType['browser'];
 
@@ -113,13 +113,15 @@ export class TestcafeQaseReporter {
       reporterName: 'testcafe-reporter-qase',
     });
 
+    let profiler: NetworkProfiler | null = null;
     if (composedOptions.profilers?.includes('network')) {
-      this.profiler = new NetworkProfiler({
+      profiler = new NetworkProfiler({
         skipDomains: composedOptions.networkProfiler?.skip_domains,
         trackOnFail: composedOptions.networkProfiler?.track_on_fail,
       });
-      this.profiler.enable();
+      profiler.enable();
     }
+    this.profilerTracker = new ProfilerTracker(profiler);
 
     // @ts-expect-error - global.Qase is dynamically added at runtime
     global.Qase = new Qase(this);
@@ -148,7 +150,7 @@ export class TestcafeQaseReporter {
     this.steps = [];
     this.attachments = [];
     this.testBeginTime = Date.now();
-    this._profilerStepSnapshot = this.profiler?.getAllSteps().length ?? 0;
+    this.profilerTracker.onTestStart();
   };
 
   /**
@@ -183,12 +185,8 @@ export class TestcafeQaseReporter {
 
     attachments.push(...this.attachments);
 
-    let profilerSteps: TestStepType[] = [];
-    if (this.profiler) {
-      const allSteps = this.profiler.getAllSteps();
-      profilerSteps = allSteps.slice(this._profilerStepSnapshot);
-      this._profilerStepSnapshot = 0;
-    }
+    const profilerSteps: TestStepType[] = this.profilerTracker.getEvents();
+    this.profilerTracker.reset();
 
     const projectMapping = metadata[metadataEnum.projects];
 
@@ -249,7 +247,7 @@ export class TestcafeQaseReporter {
    * @returns {Promise<void>}
    */
   public reportTaskDone = async (): Promise<void> => {
-    this.profiler?.restore();
+    this.profilerTracker.restore();
     await this.reporter.publish();
   };
 

--- a/qase-testcafe/src/types.ts
+++ b/qase-testcafe/src/types.ts
@@ -1,0 +1,73 @@
+export interface CallsiteRecordType {
+  filename?: string;
+  lineNum?: number;
+  callsiteFrameIdx?: number;
+  stackFrames?: unknown[];
+  isV8Frames?: boolean;
+}
+
+export interface TestRunErrorFormattableAdapterType {
+  userAgent: string;
+  screenshotPath: string;
+  testRunId: string;
+  testRunPhase: string;
+  type: string;
+  code?: string;
+  isTestCafeError?: boolean;
+  callsite?: CallsiteRecordType;
+  errMsg: string;
+  diff?: boolean;
+  id?: string;
+}
+
+export interface ScreenshotType {
+  screenshotPath: string;
+  thumbnailPath: string;
+  userAgent: string;
+  quarantineAttempt: number;
+  takenOnFail: boolean;
+}
+
+export interface FixtureType {
+  id: string;
+  name: string;
+  path?: string;
+  meta: Record<string, unknown>;
+}
+
+export enum metadataEnum {
+  id = 'QaseID',
+  title = 'QaseTitle',
+  suite = 'QaseSuite',
+  fields = 'QaseFields',
+  parameters = 'QaseParameters',
+  groupParameters = 'QaseGroupParameters',
+  oldID = 'CID',
+  ignore = 'QaseIgnore',
+  projects = 'QaseProjects',
+  tags = 'QaseTags',
+}
+
+export interface MetadataType {
+  [metadataEnum.id]: number[];
+  [metadataEnum.title]: string | undefined;
+  [metadataEnum.suite]: string | undefined;
+  [metadataEnum.fields]: Record<string, string>;
+  [metadataEnum.parameters]: Record<string, string>;
+  [metadataEnum.groupParameters]: Record<string, string>;
+  [metadataEnum.ignore]: boolean;
+  [metadataEnum.projects]: Record<string, number[]>;
+  [metadataEnum.tags]: string[];
+}
+
+export interface TestRunInfoType {
+  errs: TestRunErrorFormattableAdapterType[];
+  warnings: string[];
+  durationMs: number;
+  unstable: boolean;
+  screenshotPath: string;
+  screenshots: ScreenshotType[];
+  quarantine: Record<string, Record<'passed', boolean>>;
+  skipped: boolean;
+  fixture: FixtureType;
+}

--- a/qase-testcafe/test/browserNameResolver.test.ts
+++ b/qase-testcafe/test/browserNameResolver.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable */
+import { describe, expect, it } from '@jest/globals';
+import { BrowserNameResolver } from '../src/modules/browserNameResolver';
+import { TestRunInfoType } from '../src/types';
+
+function makeInfo(overrides: Partial<TestRunInfoType> = {}): TestRunInfoType {
+  return {
+    errs: [],
+    warnings: [],
+    durationMs: 0,
+    unstable: false,
+    screenshotPath: '',
+    screenshots: [],
+    quarantine: {},
+    skipped: false,
+    fixture: { id: 'f', name: 'F', path: '/p.ts', meta: {} },
+    ...overrides,
+  } as TestRunInfoType;
+}
+
+describe('BrowserNameResolver', () => {
+  it('resolves from screenshot.userAgent first', () => {
+    const info = makeInfo({
+      screenshots: [{ screenshotPath: '', thumbnailPath: '', userAgent: 'Chrome 97.0 / macOS 10.15', quarantineAttempt: 0, takenOnFail: false }],
+    });
+    expect(BrowserNameResolver.resolve(info, ['Firefox 96.0 / Linux 0.0'])).toBe('chrome');
+  });
+
+  it('falls back to errs[0].userAgent when no screenshots', () => {
+    const info = makeInfo({
+      errs: [{ userAgent: 'Firefox 96.0 / Linux 0.0', screenshotPath: '', testRunId: '', testRunPhase: '', type: '', errMsg: 'x' }],
+    });
+    expect(BrowserNameResolver.resolve(info, [])).toBe('firefox');
+  });
+
+  it('falls back to single stored userAgent when info has none', () => {
+    const info = makeInfo();
+    expect(BrowserNameResolver.resolve(info, ['Safari 15.0 / macOS 11.0'])).toBe('safari');
+  });
+
+  it('returns null when no source available', () => {
+    expect(BrowserNameResolver.resolve(makeInfo(), [])).toBeNull();
+  });
+
+  it('parseBrowserName handles space and underscore separators, lowercases', () => {
+    expect(BrowserNameResolver.parseBrowserName('Chrome 97.0.4692.71 / macOS 10.15.7')).toBe('chrome');
+    expect(BrowserNameResolver.parseBrowserName('Chrome_97.0.4692.71_macOS_10.15.7')).toBe('chrome');
+    expect(BrowserNameResolver.parseBrowserName('Firefox 96.0 / Linux 0.0')).toBe('firefox');
+  });
+});

--- a/qase-testcafe/test/metadataParser.test.ts
+++ b/qase-testcafe/test/metadataParser.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable */
+import { describe, expect, it } from '@jest/globals';
+import { MetadataParser } from '../src/modules/metadataParser';
+import { metadataEnum } from '../src/types';
+
+describe('MetadataParser', () => {
+  it('returns default empty metadata for empty input', () => {
+    const md = MetadataParser.parse({});
+    expect(md[metadataEnum.id]).toEqual([]);
+    expect(md[metadataEnum.title]).toBeUndefined();
+    expect(md[metadataEnum.suite]).toBeUndefined();
+    expect(md[metadataEnum.fields]).toEqual({});
+    expect(md[metadataEnum.parameters]).toEqual({});
+    expect(md[metadataEnum.groupParameters]).toEqual({});
+    expect(md[metadataEnum.ignore]).toBe(false);
+    expect(md[metadataEnum.projects]).toEqual({});
+    expect(md[metadataEnum.tags]).toEqual([]);
+  });
+
+  it('parses comma-separated QaseID into number array', () => {
+    const md = MetadataParser.parse({ QaseID: '1,2,3' });
+    expect(md[metadataEnum.id]).toEqual([1, 2, 3]);
+  });
+
+  it('uses legacy CID when QaseID is missing', () => {
+    const md = MetadataParser.parse({ CID: '7' });
+    expect(md[metadataEnum.id]).toEqual([7]);
+  });
+
+  it('QaseID overrides legacy CID when both present', () => {
+    const md = MetadataParser.parse({ CID: '7', QaseID: '99' });
+    expect(md[metadataEnum.id]).toEqual([99]);
+  });
+
+  it('parses QaseTitle, QaseSuite, QaseIgnore', () => {
+    const md = MetadataParser.parse({
+      QaseTitle: 'Custom title',
+      QaseSuite: 'Outer\tInner',
+      QaseIgnore: 'true',
+    });
+    expect(md[metadataEnum.title]).toBe('Custom title');
+    expect(md[metadataEnum.suite]).toBe('Outer\tInner');
+    expect(md[metadataEnum.ignore]).toBe(true);
+  });
+
+  it('parses QaseFields / QaseParameters / QaseGroupParameters JSON', () => {
+    const md = MetadataParser.parse({
+      QaseFields: '{"severity":"high"}',
+      QaseParameters: '{"region":"eu"}',
+      QaseGroupParameters: '{"shard":"1"}',
+    });
+    expect(md[metadataEnum.fields]).toEqual({ severity: 'high' });
+    expect(md[metadataEnum.parameters]).toEqual({ region: 'eu' });
+    expect(md[metadataEnum.groupParameters]).toEqual({ shard: '1' });
+  });
+
+  it('parses QaseTags as comma-separated trimmed list', () => {
+    const md = MetadataParser.parse({ QaseTags: 'smoke, regression , fast' });
+    expect(md[metadataEnum.tags]).toEqual(['smoke', 'regression', 'fast']);
+  });
+
+  it('tolerates invalid JSON in QaseProjects', () => {
+    const md = MetadataParser.parse({ QaseProjects: 'not-json' });
+    expect(md[metadataEnum.projects]).toEqual({});
+  });
+});

--- a/qase-testcafe/test/profilerTracker.test.ts
+++ b/qase-testcafe/test/profilerTracker.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable */
+import { describe, expect, it } from '@jest/globals';
+import { TestStepType, StepType, StepStatusEnum } from 'qase-javascript-commons';
+import { ProfilerTracker } from '../src/modules/profilerTracker';
+
+class FakeProfiler {
+  private steps: TestStepType[] = [];
+  private restored = false;
+
+  push(action: string): void {
+    this.steps.push({
+      step_type: StepType.TEXT,
+      data: { action, expected_result: null, data: null },
+      execution: { start_time: 0, status: StepStatusEnum.passed, end_time: 0, duration: 0 },
+      id: action,
+      parent_id: null,
+      attachments: [],
+      steps: [],
+    });
+  }
+
+  getAllSteps(): TestStepType[] {
+    return this.steps;
+  }
+
+  restore(): void {
+    this.restored = true;
+  }
+
+  isRestored(): boolean {
+    return this.restored;
+  }
+}
+
+describe('ProfilerTracker', () => {
+  it('null profiler returns empty events', () => {
+    const tracker = new ProfilerTracker(null);
+    tracker.onTestStart();
+    expect(tracker.getEvents()).toEqual([]);
+  });
+
+  it('snapshots length on onTestStart and returns diff via getEvents', () => {
+    const profiler = new FakeProfiler();
+    profiler.push('initial-1');
+    profiler.push('initial-2');
+
+    const tracker = new ProfilerTracker(profiler as any);
+    tracker.onTestStart();
+
+    profiler.push('during-1');
+    profiler.push('during-2');
+
+    expect(tracker.getEvents().map((s) => s.id)).toEqual(['during-1', 'during-2']);
+  });
+
+  it('reset() returns snapshot to zero', () => {
+    const profiler = new FakeProfiler();
+    profiler.push('a');
+    const tracker = new ProfilerTracker(profiler as any);
+    tracker.onTestStart();        // snapshot = 1
+    profiler.push('b');
+
+    tracker.reset();              // snapshot = 0
+    profiler.push('c');
+
+    expect(tracker.getEvents().map((s) => s.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('restore() proxies to underlying profiler', () => {
+    const profiler = new FakeProfiler();
+    const tracker = new ProfilerTracker(profiler as any);
+    tracker.restore();
+    expect(profiler.isRestored()).toBe(true);
+  });
+});

--- a/qase-testcafe/test/reporter.test.ts
+++ b/qase-testcafe/test/reporter.test.ts
@@ -2,6 +2,7 @@
 import { expect } from '@jest/globals';
 import { TestcafeQaseReporter } from '../src/reporter';
 import { MetadataParser } from '../src/modules/metadataParser';
+import { ResultBuilder } from '../src/modules/resultBuilder';
 
 // Mocks
 const reporterMock = {
@@ -44,15 +45,15 @@ describe('TestcafeQaseReporter', () => {
   describe('static getStatus', () => {
     it('should return skipped if testRunInfo.skipped is true', () => {
       const info = { skipped: true, errs: [] } as any;
-      expect((TestcafeQaseReporter as any).getStatus(info)).toBe('skipped');
+      expect(ResultBuilder.getStatus(info)).toBe('skipped');
     });
     it('should return failed if there are errors', () => {
       const info = { skipped: false, errs: [{}] } as any;
-      expect((TestcafeQaseReporter as any).getStatus(info)).toBe('failed');
+      expect(ResultBuilder.getStatus(info)).toBe('failed');
     });
     it('should return passed if no errors and not skipped', () => {
       const info = { skipped: false, errs: [] } as any;
-      expect((TestcafeQaseReporter as any).getStatus(info)).toBe('passed');
+      expect(ResultBuilder.getStatus(info)).toBe('passed');
     });
   });
 
@@ -62,7 +63,7 @@ describe('TestcafeQaseReporter', () => {
         { screenshotPath: 'a.png', thumbnailPath: '', userAgent: '', quarantineAttempt: 0, takenOnFail: false },
         { screenshotPath: 'b.png', thumbnailPath: '', userAgent: '', quarantineAttempt: 0, takenOnFail: false },
       ];
-      const result = (TestcafeQaseReporter as any).transformAttachments(screenshots);
+      const result = ResultBuilder.transformAttachments(screenshots);
       expect(result).toHaveLength(2);
       expect(result[0].file_name).toBe('a.png');
       expect(result[1].file_name).toBe('b.png');
@@ -228,7 +229,7 @@ describe('TestcafeQaseReporter', () => {
       const fixture = { name: 'Fix', path: '/a/b', id: 'id', meta: {} };
       const ids = [1, 2];
       const params = { p: 'v' };
-      const result = (reporter as any).getSignature(fixture, 'Test Title', ids, params);
+      const result = ResultBuilder.getSignature(fixture, 'Test Title', ids, params);
       const { generateSignature } = require('qase-javascript-commons');
       expect(generateSignature).toHaveBeenCalled();
       expect(result).toBe('mock-signature');

--- a/qase-testcafe/test/reporter.test.ts
+++ b/qase-testcafe/test/reporter.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import { expect } from '@jest/globals';
 import { TestcafeQaseReporter } from '../src/reporter';
+import { MetadataParser } from '../src/modules/metadataParser';
 
 // Mocks
 const reporterMock = {
@@ -194,7 +195,7 @@ describe('TestcafeQaseReporter', () => {
         QaseIgnore: 'true',
         CID: '3',
       };
-      const result = (reporter as any).getMeta(meta);
+      const result = MetadataParser.parse(meta);
       expect(result.QaseID).toEqual([1, 2]);
       expect(result.QaseTitle).toBe('title');
       expect(result.QaseFields).toEqual({ a: 'b' });
@@ -204,15 +205,15 @@ describe('TestcafeQaseReporter', () => {
     });
     it('should parse QaseSuite from meta', () => {
       const meta = { QaseSuite: 'Parent\tChild' };
-      const result = (reporter as any).getMeta(meta);
+      const result = MetadataParser.parse(meta);
       expect(result.QaseSuite).toBe('Parent\tChild');
     });
     it('should leave QaseSuite undefined when not provided', () => {
-      const result = (reporter as any).getMeta({});
+      const result = MetadataParser.parse({});
       expect(result.QaseSuite).toBeUndefined();
     });
     it('should handle empty meta', () => {
-      const result = (reporter as any).getMeta({});
+      const result = MetadataParser.parse({});
       expect(result.QaseID).toEqual([]);
       expect(result.QaseTitle).toBeUndefined();
       expect(result.QaseFields).toEqual({});

--- a/qase-testcafe/test/resultBuilder.test.ts
+++ b/qase-testcafe/test/resultBuilder.test.ts
@@ -1,0 +1,136 @@
+/* eslint-disable */
+import { describe, expect, it } from '@jest/globals';
+import { TestStatusEnum } from 'qase-javascript-commons';
+import { ResultBuilder } from '../src/modules/resultBuilder';
+import { metadataEnum, MetadataType, TestRunInfoType } from '../src/types';
+
+function makeMetadata(overrides: Partial<MetadataType> = {}): MetadataType {
+  return {
+    QaseID: [],
+    QaseTitle: undefined,
+    QaseSuite: undefined,
+    QaseFields: {},
+    QaseParameters: {},
+    QaseGroupParameters: {},
+    QaseIgnore: false,
+    QaseProjects: {},
+    QaseTags: [],
+    ...overrides,
+  } as MetadataType;
+}
+
+function makeInfo(overrides: Partial<TestRunInfoType> = {}): TestRunInfoType {
+  return {
+    errs: [],
+    warnings: [],
+    durationMs: 1000,
+    unstable: false,
+    screenshotPath: '',
+    screenshots: [],
+    quarantine: {},
+    skipped: false,
+    fixture: { id: 'f', name: 'My fixture', path: '/repo/test/x.spec.ts', meta: {} },
+    ...overrides,
+  } as TestRunInfoType;
+}
+
+const formatError = (err: any, prefix: string) => `${prefix}${err?.errMsg ?? ''}`;
+
+describe('ResultBuilder', () => {
+  const baseArgs = {
+    title: 'sample',
+    testRunInfo: makeInfo(),
+    metadata: makeMetadata(),
+    formatError,
+    steps: [],
+    attachments: [],
+    profilerSteps: [],
+    testBeginTime: 1700000000000,
+    browserName: null as string | null,
+    browserOptions: undefined,
+  };
+
+  it('builds a passed result with default metadata', () => {
+    const result = ResultBuilder.build({ ...baseArgs });
+    expect(result.execution.status).toBe(TestStatusEnum.passed);
+    expect(result.title).toBe('sample');
+    expect(result.testops_id).toBeNull();
+  });
+
+  it('marks skipped when testRunInfo.skipped is true', () => {
+    const result = ResultBuilder.build({ ...baseArgs, testRunInfo: makeInfo({ skipped: true }) });
+    expect(result.execution.status).toBe(TestStatusEnum.skipped);
+  });
+
+  it('marks failed when errs[0] has assertion message', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      testRunInfo: makeInfo({
+        errs: [{ userAgent: '', screenshotPath: '', testRunId: '', testRunPhase: '', type: '', errMsg: 'expected 1 to equal 2' }],
+      }),
+    });
+    expect(result.execution.status).toBe(TestStatusEnum.failed);
+  });
+
+  it('uses metadata.QaseTitle override', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      metadata: makeMetadata({ QaseTitle: 'Override' }),
+    });
+    expect(result.title).toBe('Override');
+  });
+
+  it('overrides suite relations when QaseSuite is set (tab-separated)', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      metadata: makeMetadata({ QaseSuite: 'Outer\tInner' }),
+    });
+    const titles = (result.relations as any).suite.data.map((d: any) => d.title);
+    expect(titles).toEqual(['Outer', 'Inner']);
+  });
+
+  it('uses fixture.name when no QaseSuite', () => {
+    const result = ResultBuilder.build({ ...baseArgs });
+    const titles = (result.relations as any).suite.data.map((d: any) => d.title);
+    expect(titles).toEqual(['My fixture']);
+  });
+
+  it('injects browser parameter when browserOptions.addAsParameter is true', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      browserName: 'chrome',
+      browserOptions: { addAsParameter: true, parameterName: 'browser' } as any,
+    });
+    expect(result.params).toEqual({ browser: 'chrome' });
+  });
+
+  it('does not inject browser parameter when addAsParameter is false', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      browserName: 'chrome',
+      browserOptions: { addAsParameter: false } as any,
+    });
+    expect(result.params).toEqual({});
+  });
+
+  it('merges screenshot attachments first then user attachments', () => {
+    const screenshot = { screenshotPath: 'shot.png', thumbnailPath: '', userAgent: '', quarantineAttempt: 0, takenOnFail: false };
+    const userAttach = { file_name: 'log.txt', mime_type: 'text/plain', file_path: null, content: 'x', size: 0, id: 'u1' };
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      testRunInfo: makeInfo({ screenshots: [screenshot] }),
+      attachments: [userAttach as any],
+    });
+    expect(result.attachments).toHaveLength(2);
+    expect(result.attachments[0]?.file_path).toBe('shot.png');
+    expect(result.attachments[1]?.file_name).toBe('log.txt');
+  });
+
+  it('respects project mapping precedence', () => {
+    const result = ResultBuilder.build({
+      ...baseArgs,
+      metadata: makeMetadata({ QaseID: [42], QaseProjects: { PROJ: [10] } }),
+    });
+    expect((result as any).testops_project_mapping).toEqual({ PROJ: [10] });
+  });
+});


### PR DESCRIPTION
## Summary

- Decompose `qase-testcafe/src/reporter.ts` (444 → 153 LOC, -65%) into thin orchestrator + 4 modules (`MetadataParser`, `ProfilerTracker`, `BrowserNameResolver`, `ResultBuilder`) and `src/types.ts`. Phase 2 pattern, 6th reporter after wdio / playwright / cypress / mocha / cucumberjs.
- All 20 existing tests stay green; add 27 per-module unit tests (47 total).
- Bump `testcafe-reporter-qase` 2.5.0 → 2.6.0; public contract preserved (named export, ctor, 8 instance methods, `TestcafeQaseOptionsType` + `TestRunInfoType` re-exports).
- **Bonus:** fix `examples/single/testcafe/tests/*` to use V2-valid `fields.severity` (`medium` → `normal`) and `fields.priority` (`critical` → `high`); remove non-existent `qase.comment()` calls (testcafe `qase.ts` does not expose `comment`).

## Test plan

- [x] CI green on `refactor/testcafe-decomposition` (unit tests).
- [x] `cd qase-testcafe && npx jest` passes locally with 47 tests.
- [x] Smoke `QASE_MODE=testops` against DEVX project — run #729 received all 15 results: https://app.qase.io/run/DEVX/dashboard/729

## Design

- Spec: `docs/superpowers/specs/2026-04-30-testcafe-decomposition-design.md` (not committed; tracked locally).
- Plan: `docs/superpowers/plans/2026-04-30-testcafe-decomposition.md` (not committed; tracked locally).