### PR TITLE
refactor(newman): decompose reporter into focused modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30626,7 +30626,7 @@
     },
     "qase-jest": {
       "name": "jest-qase-reporter",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.get": "^4.4.2",
@@ -30680,10 +30680,10 @@
     },
     "qase-newman": {
       "name": "newman-reporter-qase",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.5.0",
+        "qase-javascript-commons": "~2.7.0",
         "semver": "^7.7.3"
       },
       "devDependencies": {
@@ -30701,30 +30701,6 @@
       },
       "peerDependencies": {
         "newman": ">=5.3.0"
-      }
-    },
-    "qase-newman/node_modules/qase-javascript-commons": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.5.10.tgz",
-      "integrity": "sha512-vVJP+9JAJcGp5jn7DYmCUeo7RymFVDB9pcQAAhPElHW2IqSeHApiT2D2PTaIwHyt8mpr711krkQ2neAYIR0gMg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "^8.18.0",
-        "async-mutex": "~0.5.0",
-        "chalk": "^4.1.2",
-        "env-schema": "^5.2.1",
-        "form-data": "^4.0.5",
-        "lodash.get": "^4.4.2",
-        "lodash.merge": "^4.6.2",
-        "lodash.mergewith": "^4.6.2",
-        "mime-types": "^2.1.35",
-        "qase-api-client": "~1.1.1",
-        "qase-api-v2-client": "~1.0.4",
-        "strip-ansi": "^6.0.1",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "qase-newman/node_modules/semver": {

--- a/qase-newman/changelog.md
+++ b/qase-newman/changelog.md
@@ -1,3 +1,14 @@
+# newman-reporter-qase@2.3.0
+
+## Changed
+
+- Decomposed `reporter.ts` (433 LOC) into a thin event-driven orchestrator plus 3 focused modules under `src/modules/` (`MetadataExtractor`, `IterationDataParser`, `ResultBuilder`). Public contract preserved 1:1: `NewmanQaseReporter` named export, all 3 static regexps (`qaseIdRegExp`, `qaseParamRegExp`, `qaseProjectRegExp`), all 4 static methods (`getCaseIds`, `getProjectMapping`, `getParameters`, `getParentTitles`), constructor signature, and `NewmanQaseOptionsType` re-export.
+- Bumped `qase-javascript-commons` peer dependency to `~2.7.0` (sync with monorepo; no helper migrations — newman doesn't import from `qase-javascript-commons/internal`).
+
+## Internal
+
+- Added per-module unit tests for the three new modules (37 new tests, 55 total).
+
 # qase-newman@2.2.0
 
 ## What's new

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-qase",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Qase TMS Newman Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -39,7 +39,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.5.0",
+    "qase-javascript-commons": "~2.7.0",
     "semver": "^7.7.3"
   },
   "devDependencies": {

--- a/qase-newman/src/modules/iterationDataParser.ts
+++ b/qase-newman/src/modules/iterationDataParser.ts
@@ -1,0 +1,36 @@
+export class IterationDataParser {
+  parse(iterationData: unknown): Record<string, string>[] {
+    if (!iterationData) {
+      return [];
+    }
+    if (
+      Array.isArray(iterationData) &&
+      iterationData.every((item) => typeof item === 'object' && item !== null)
+    ) {
+      return iterationData.map((item: Record<string, unknown>) => this.convertToRecord(item));
+    }
+    return [];
+  }
+
+  private convertToRecord(obj: unknown, parentKey = ''): Record<string, string> {
+    const record: Record<string, string> = {};
+    if (this.isRecord(obj)) {
+      for (const key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          const value = obj[key];
+          const newKey = parentKey ? `${parentKey}.${key}` : key;
+          if (this.isRecord(value)) {
+            Object.assign(record, this.convertToRecord(value, newKey));
+          } else {
+            record[newKey.toLowerCase()] = String(value);
+          }
+        }
+      }
+    }
+    return record;
+  }
+
+  private isRecord(obj: unknown): obj is Record<string, unknown> {
+    return typeof obj === 'object' && obj !== null && !Array.isArray(obj);
+  }
+}

--- a/qase-newman/src/modules/metadataExtractor.ts
+++ b/qase-newman/src/modules/metadataExtractor.ts
@@ -1,0 +1,79 @@
+import { EventList, Item, PropertyBase, PropertyBaseDefinition } from 'postman-collection';
+import { TestopsProjectMapping } from 'qase-javascript-commons';
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export class MetadataExtractor {
+  static qaseIdRegExp = /\/\/\s*?[qQ]ase:\s?((?:[\d]+[\s,]{0,})+)/;
+  static qaseParamRegExp = /qase\.parameters:\s*([\w.]+(?:\s*,\s*[\w.]+)*)/i;
+  /** Matches // qase PROJ1: 1,2 or // qase PROJ2: 3 for multi-project. */
+  static qaseProjectRegExp = /\/\/\s*[qQ]ase\s+([A-Za-z0-9_]+):\s*([\d,\s]+)/g;
+
+  static getCaseIds(eventList: EventList): number[] {
+    const ids: number[] = [];
+    eventList.each((event) => {
+      if (event.listen === 'test' && event.script.exec) {
+        event.script.exec.forEach((line: string) => {
+          const [, match] = line.match(MetadataExtractor.qaseIdRegExp) ?? [];
+          if (match) {
+            ids.push(...match.split(',').map((id) => Number(id)));
+          }
+        });
+      }
+    });
+    return ids;
+  }
+
+  static getProjectMapping(eventList: EventList): TestopsProjectMapping {
+    const projectMapping: TestopsProjectMapping = {};
+    eventList.each((event) => {
+      if (event.listen === 'test' && event.script.exec) {
+        event.script.exec.forEach((line: string) => {
+          let m: RegExpExecArray | null;
+          const re = new RegExp(MetadataExtractor.qaseProjectRegExp.source, 'gi');
+          while ((m = re.exec(line)) !== null) {
+            const projectCode = m[1]?.trim();
+            const idsStr = (m[2] ?? '').replace(/\s/g, '');
+            const ids = idsStr.split(',').map((s) => parseInt(s, 10)).filter((n) => !Number.isNaN(n));
+            if (projectCode && projectCode.toUpperCase() !== 'ID' && ids.length > 0) {
+              const existing = projectMapping[projectCode] ?? [];
+              projectMapping[projectCode] = [...existing, ...ids];
+            }
+          }
+        });
+      }
+    });
+    return projectMapping;
+  }
+
+  static getParameters(item: Item): string[] {
+    const params: string[] = [];
+    item.events.each((event) => {
+      if (event.listen === 'test' && event.script.exec) {
+        event.script.exec.forEach((line) => {
+          const match = line.match(MetadataExtractor.qaseParamRegExp);
+          if (match) {
+            const parameters: string[] = match[1]?.split(/\s*,\s*/) ?? [];
+            params.push(...parameters);
+          }
+        });
+      }
+    });
+    const parent = item.parent();
+    if (parent && 'events' in parent) {
+      params.push(...MetadataExtractor.getParameters(parent as Item));
+    }
+    return params;
+  }
+
+  static getParentTitles(item: PropertyBase<PropertyBaseDefinition>): string[] {
+    let titles: string[] = [];
+    const parent = item.parent();
+    if (parent) {
+      titles = titles.concat(MetadataExtractor.getParentTitles(parent));
+    }
+    if ('name' in item) {
+      titles.push(String((item as { name: unknown }).name));
+    }
+    return titles;
+  }
+}

--- a/qase-newman/src/modules/resultBuilder.ts
+++ b/qase-newman/src/modules/resultBuilder.ts
@@ -1,0 +1,55 @@
+import { Item } from 'postman-collection';
+import {
+  Relation,
+  SuiteData,
+  TestopsProjectMapping,
+  TestResultType,
+  TestStatusEnum,
+} from 'qase-javascript-commons';
+
+export interface BuildPendingArgs {
+  item: Item;
+  suites: string[];
+  ids: number[];
+  projectMapping: TestopsProjectMapping;
+  signature: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export class ResultBuilder {
+  static buildPending(args: BuildPendingArgs): TestResultType {
+    const { item, suites, ids, projectMapping, signature } = args;
+
+    let relation: Relation | null = null;
+    if (suites.length > 0) {
+      const data: SuiteData[] = suites.map((title) => ({ title, public_id: null }));
+      relation = { suite: { data } };
+    }
+
+    return {
+      attachments: [],
+      author: null,
+      execution: {
+        status: TestStatusEnum.passed,
+        start_time: null,
+        end_time: null,
+        duration: 0,
+        stacktrace: null,
+        thread: null,
+      },
+      fields: {},
+      message: null,
+      muted: false,
+      params: {},
+      group_params: {},
+      relations: relation,
+      run_id: null,
+      signature,
+      steps: [],
+      testops_id: ids.length > 0 ? ids : null,
+      id: item.id,
+      title: item.name,
+      testops_project_mapping: Object.keys(projectMapping).length > 0 ? projectMapping : null,
+    } as unknown as TestResultType;
+  }
+}

--- a/qase-newman/src/reporter.ts
+++ b/qase-newman/src/reporter.ts
@@ -3,22 +3,22 @@ import { EventEmitter } from 'events';
 import { configSchema } from './configSchema';
 import semver from 'semver';
 import { NewmanRunExecution, NewmanRunOptions } from 'newman';
-import { EventList, Item, PropertyBase, PropertyBaseDefinition } from 'postman-collection';
+import { Item } from 'postman-collection';
 import {
   ConfigType,
   QaseReporter,
   ReporterInterface,
-  TestStatusEnum,
   TestResultType,
-  TestopsProjectMapping,
   getPackageVersion,
   ConfigLoader,
   composeOptions,
-  Relation,
-  SuiteData,
   generateSignature,
   determineTestStatus,
 } from 'qase-javascript-commons';
+
+import { MetadataExtractor } from './modules/metadataExtractor';
+import { IterationDataParser } from './modules/iterationDataParser';
+import { ResultBuilder } from './modules/resultBuilder';
 
 export type NewmanQaseOptionsType = ConfigType;
 
@@ -26,156 +26,25 @@ export type NewmanQaseOptionsType = ConfigType;
  * @class NewmanQaseReporter
  */
 export class NewmanQaseReporter {
-  /**
-   * @type {RegExp}
-   */
-  static qaseIdRegExp = /\/\/\s*?[qQ]ase:\s?((?:[\d]+[\s,]{0,})+)/;
+  // Public re-exports — preserve API
+  static qaseIdRegExp = MetadataExtractor.qaseIdRegExp;
+  static qaseParamRegExp = MetadataExtractor.qaseParamRegExp;
+  static qaseProjectRegExp = MetadataExtractor.qaseProjectRegExp;
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  static getCaseIds = MetadataExtractor.getCaseIds;
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  static getProjectMapping = MetadataExtractor.getProjectMapping;
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  static getParameters = MetadataExtractor.getParameters;
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  static getParentTitles = MetadataExtractor.getParentTitles;
 
-  /**
-   * @type {RegExp}
-   */
-  static qaseParamRegExp = /qase\.parameters:\s*([\w.]+(?:\s*,\s*[\w.]+)*)/i;
-
-  /** Matches // qase PROJ1: 1,2 or // qase PROJ2: 3 for multi-project. */
-  static qaseProjectRegExp = /\/\/\s*[qQ]ase\s+([A-Za-z0-9_]+):\s*([\d,\s]+)/g;
-
-  /**
-   * Parse multi-project mapping from test script comments (e.g. // qase PROJ1: 1,2).
-   * @param {EventList} eventList
-   * @returns {TestopsProjectMapping}
-   */
-  public static getProjectMapping(eventList: EventList): TestopsProjectMapping {
-    const projectMapping: TestopsProjectMapping = {};
-
-    eventList.each((event) => {
-      if (event.listen === 'test' && event.script.exec) {
-        event.script.exec.forEach((line) => {
-          let m: RegExpExecArray | null;
-          const re = new RegExp(NewmanQaseReporter.qaseProjectRegExp.source, 'gi');
-          while ((m = re.exec(line)) !== null) {
-            const projectCode = m[1]?.trim();
-            const idsStr = (m[2] ?? '').replace(/\s/g, '');
-            const ids = idsStr.split(',').map((s) => parseInt(s, 10)).filter((n) => !Number.isNaN(n));
-
-            if (projectCode && projectCode.toUpperCase() !== 'ID' && ids.length > 0) {
-              const existing = projectMapping[projectCode] ?? [];
-              projectMapping[projectCode] = [...existing, ...ids];
-            }
-          }
-        });
-      }
-    });
-
-    return projectMapping;
-  }
-
-  /**
-   * @param {EventList} eventList
-   * @returns {number[]}
-   */
-  public static getCaseIds(eventList: EventList) {
-    const ids: number[] = [];
-
-    eventList.each((event) => {
-      if (event.listen === 'test' && event.script.exec) {
-        event.script.exec.forEach((line) => {
-          const [, match] = line.match(NewmanQaseReporter.qaseIdRegExp) ?? [];
-
-          if (match) {
-            ids.push(...match.split(',').map((id) => Number(id)));
-          }
-        });
-      }
-    });
-
-    return ids;
-  }
-
-  /**
-   * @param {Item} item
-   * @returns {string[]}
-   */
-  public static getParameters(item: Item): string[] {
-    const params: string[] = [];
-
-    item.events.each((event) => {
-      if (event.listen === 'test' && event.script.exec) {
-        event.script.exec.forEach((line) => {
-          const match = line.match(NewmanQaseReporter.qaseParamRegExp);
-
-          if (match) {
-            const parameters: string[] = match[1]?.split(/\s*,\s*/) ?? [];
-            params.push(...parameters);
-          }
-        });
-      }
-    });
-
-    const parent = item.parent();
-    if (parent && 'events' in parent) {
-      params.push(...NewmanQaseReporter.getParameters(parent as Item));
-    }
-
-    return params;
-  }
-
-  /**
-   * @param {PropertyBase<PropertyBaseDefinition>} item
-   * @returns {string[]}
-   */
-  public static getParentTitles(
-    item: PropertyBase<PropertyBaseDefinition>,
-  ) {
-    let titles: string[] = [];
-
-    const parent = item.parent();
-    if (parent) {
-      titles = titles.concat(NewmanQaseReporter.getParentTitles(parent));
-    }
-
-    if ('name' in item) {
-      titles.push(String(item.name));
-    }
-
-    return titles;
-  }
-
-  /**
-   * @type {ReporterInterface}
-   * @private
-   */
   private reporter: ReporterInterface;
-
-  /**
-   * @type {Map<string, TestResultType>}
-   * @private
-   */
-  private pendingResultMap: Map<string, TestResultType> = new Map<string, TestResultType>();
-
-  /**
-   * @type {Map<string, number>}
-   * @private
-   */
-  private timerMap: Map<string, number> = new Map<string, number>();
-
-  /**
-   * @type {Record<string, string>[]}
-   * @private
-   */
-  private readonly parameters: Record<string, string>[] = [];
-
-  /**
-   * @type {boolean}
-   * @private
-   */
+  private pendingResultMap = new Map<string, TestResultType>();
+  private timerMap = new Map<string, number>();
+  private readonly parameters: Record<string, string>[];
   private autoCollectParams: boolean;
 
-  /**
-   * @param {EventEmitter} emitter
-   * @param {NewmanQaseOptionsType} options
-   * @param {NewmanRunOptions} collectionOptions
-   * @param {ConfigLoaderInterface} configLoader
-   */
   public constructor(
     emitter: EventEmitter,
     options: NewmanQaseOptionsType,
@@ -192,122 +61,61 @@ export class NewmanQaseReporter {
     });
 
     this.autoCollectParams = config?.framework?.newman?.autoCollectParams ?? false;
-
-    this.parameters = this.getParameters(collectionOptions.iterationData);
+    this.parameters = new IterationDataParser().parse(collectionOptions.iterationData);
     this.addRunnerListeners(emitter);
   }
 
-  /**
-   * @param {EventEmitter} runner
-   * @private
-   */
   private addRunnerListeners(runner: EventEmitter) {
     runner.on('start', () => {
       this.reporter.startTestRun();
     });
 
-    runner.on(
-      'beforeItem',
-      (_err: Error | undefined, exec: NewmanRunExecution) => {
-        const { item } = exec;
-        const parent = item.parent();
-        const suites = parent ? NewmanQaseReporter.getParentTitles(parent) : [];
-        let relation: Relation | null = null;
-        if (suites.length > 0) {
-          const data: SuiteData[] = suites.map(title => {
-            return {
-              title: title,
-              public_id: null,
-            };
-          });
-          relation = {
-            suite: {
-              data: data,
-            },
-          };
-        }
-        const ids = NewmanQaseReporter.getCaseIds(item.events);
-        const projectMapping = NewmanQaseReporter.getProjectMapping(item.events);
+    runner.on('beforeItem', (_err: Error | undefined, exec: NewmanRunExecution) => {
+      const { item } = exec;
+      const parent = item.parent();
+      const suites = parent ? MetadataExtractor.getParentTitles(parent) : [];
+      const ids = MetadataExtractor.getCaseIds(item.events);
+      const projectMapping = MetadataExtractor.getProjectMapping(item.events);
+      const signature = generateSignature(ids, [...suites, item.name], {});
+      const pending = ResultBuilder.buildPending({ item, suites, ids, projectMapping, signature });
+      this.pendingResultMap.set(item.id, pending);
+      this.timerMap.set(item.id, Date.now());
+    });
 
-        const pendingResult = {
-          attachments: [],
-          author: null,
-          execution: {
-            status: TestStatusEnum.passed,
-            start_time: null,
-            end_time: null,
-            duration: 0,
-            stacktrace: null,
-            thread: null,
-          },
-          fields: {},
-          message: null,
-          muted: false,
-          params: {},
-          group_params: {},
-          relations: relation,
-          run_id: null,
-          signature: this.getSignature(suites, item.name, ids),
-          steps: [],
-          testops_id: ids.length > 0 ? ids : null,
-          id: item.id,
-          title: item.name,
-          testops_project_mapping: Object.keys(projectMapping).length > 0 ? projectMapping : null,
-        } as unknown as TestResultType;
-
-        this.pendingResultMap.set(item.id, pendingResult);
-
-        this.timerMap.set(item.id, Date.now());
-      },
-    );
-
-    runner.on(
-      'assertion',
-      (err: Error | undefined, exec: NewmanRunExecution) => {
-        const { item } = exec;
-        const pendingResult = this.pendingResultMap.get(item.id);
-
-        if (pendingResult && err) {
-          // Determine status based on error type
-          pendingResult.execution.status = determineTestStatus(err, 'failed');
-          pendingResult.execution.stacktrace = err.stack ?? null;
-          pendingResult.message = err.message;
-        }
-      },
-    );
+    runner.on('assertion', (err: Error | undefined, exec: NewmanRunExecution) => {
+      const pending = this.pendingResultMap.get(exec.item.id);
+      if (pending && err) {
+        pending.execution.status = determineTestStatus(err, 'failed');
+        pending.execution.stacktrace = err.stack ?? null;
+        pending.message = err.message;
+      }
+    });
 
     runner.on('item', (_err: Error | undefined, exec: NewmanRunExecution) => {
       const { item } = exec;
-      const pendingResult = this.pendingResultMap.get(item.id);
+      const pending = this.pendingResultMap.get(item.id);
+      if (!pending) return;
 
-      if (pendingResult) {
-        const timer = this.timerMap.get(item.id);
-
-        if (timer) {
-          const now = Date.now();
-          const durationMs = now - timer;
-          
-          // Ensure duration is not negative and times are valid
-          if (durationMs >= 0) {
-            pendingResult.execution.duration = Math.round(durationMs);
-            pendingResult.execution.start_time = timer / 1000;
-            pendingResult.execution.end_time = now / 1000;
-          } else {
-            // Fallback for edge cases where timer might be incorrect
-            pendingResult.execution.duration = 0;
-            pendingResult.execution.start_time = now / 1000;
-            pendingResult.execution.end_time = now / 1000;
-          }
+      const timer = this.timerMap.get(item.id);
+      if (timer) {
+        const now = Date.now();
+        const durationMs = now - timer;
+        if (durationMs >= 0) {
+          pending.execution.duration = Math.round(durationMs);
+          pending.execution.start_time = timer / 1000;
+          pending.execution.end_time = now / 1000;
+        } else {
+          pending.execution.duration = 0;
+          pending.execution.start_time = now / 1000;
+          pending.execution.end_time = now / 1000;
         }
-
-        pendingResult.params = this.prepareParameters(item, exec.cursor.iteration);
-
-        void this.reporter.addTestResult(pendingResult);
-        
-        // Clean up timer and pending result after processing
-        this.timerMap.delete(item.id);
-        this.pendingResultMap.delete(item.id);
       }
+
+      pending.params = this.prepareParameters(item, exec.cursor.iteration);
+      void this.reporter.addTestResult(pending);
+
+      this.timerMap.delete(item.id);
+      this.pendingResultMap.delete(item.id);
     });
 
     runner.on('beforeDone', () => {
@@ -319,57 +127,18 @@ export class NewmanQaseReporter {
     });
   }
 
-  /**
-   * @private
-   */
-  private preventExit() {
-    const newmanVersion = getPackageVersion('newman');
-
-    if (!newmanVersion || semver.lt(newmanVersion, '5.3.2')) {
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      const _exit = process.exit;
-
-      const mutableProcess: Record<'exit', (code: number) => void> = process;
-
-      mutableProcess.exit = (code?: number) => {
-        process.exitCode = code;
-        process.exit = _exit;
-      };
-    }
-  }
-
-  /**
-   * @param {string[]} suites
-   * @param {string} title
-   * @param {number[]} ids
-   * @private
-   */
-  private getSignature(suites: string[], title: string, ids: number[]) {
-    return generateSignature(ids, [...suites, title], {});
-  }
-
-  /**
-   * @param {Item} item
-   * @param {number} iteration
-   * @returns {Record<string, string>}
-   * @private
-   */
   private prepareParameters(item: Item, iteration: number): Record<string, string> {
     if (this.parameters.length === 0) {
       return {};
     }
-
     const availableParameters = this.parameters[iteration] ?? {};
-    const params = NewmanQaseReporter.getParameters(item);
-
+    const params = MetadataExtractor.getParameters(item);
     if (params.length === 0) {
       if (this.autoCollectParams) {
         return availableParameters;
       }
-
       return {};
     }
-
     return params.reduce<Record<string, string>>((filteredParams, param) => {
       const value = availableParameters[param.toLowerCase()];
       if (value) {
@@ -379,55 +148,16 @@ export class NewmanQaseReporter {
     }, {});
   }
 
-
-  /**
-   * @param {unknown} iterationData
-   * @private
-   */
-  private getParameters(iterationData: unknown): Record<string, string>[] {
-    if (!iterationData) {
-      return [];
+  private preventExit() {
+    const newmanVersion = getPackageVersion('newman');
+    if (!newmanVersion || semver.lt(newmanVersion, '5.3.2')) {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const _exit = process.exit;
+      const mutableProcess: Record<'exit', (code: number) => void> = process;
+      mutableProcess.exit = (code?: number) => {
+        process.exitCode = code;
+        process.exit = _exit;
+      };
     }
-
-    if (Array.isArray(iterationData) && iterationData.every(item => typeof item === 'object' && item !== null)) {
-      return iterationData.map((item: Record<string, unknown>) => this.convertToRecord(item));
-    }
-
-    return [];
-  }
-
-  /**
-   * @param {unknown} obj
-   * @param parentKey
-   * @returns {Record<string, string>}
-   * @private
-   */
-  private convertToRecord(obj: unknown, parentKey = ''): Record<string, string> {
-    const record: Record<string, string> = {};
-
-    if (this.isRecord(obj)) {
-      for (const key in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
-          const value = obj[key];
-          const newKey = parentKey ? `${parentKey}.${key}` : key;
-
-          if (this.isRecord(value)) {
-            Object.assign(record, this.convertToRecord(value, newKey));
-          } else {
-            record[newKey.toLowerCase()] = String(value);
-          }
-        }
-      }
-    }
-
-    return record;
-  }
-
-  /**
-   * @param {unknown} obj
-   * @private
-   */
-  private isRecord(obj: unknown): obj is Record<string, unknown> {
-    return typeof obj === 'object' && obj !== null;
   }
 }

--- a/qase-newman/test/iterationDataParser.test.ts
+++ b/qase-newman/test/iterationDataParser.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable */
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { IterationDataParser } from '../src/modules/iterationDataParser';
+
+describe('IterationDataParser.parse', () => {
+  let parser: IterationDataParser;
+
+  beforeEach(() => {
+    parser = new IterationDataParser();
+  });
+
+  it('returns [] for null', () => {
+    expect(parser.parse(null)).toEqual([]);
+  });
+
+  it('returns [] for undefined', () => {
+    expect(parser.parse(undefined)).toEqual([]);
+  });
+
+  it('returns [] for non-array input', () => {
+    expect(parser.parse({ foo: 'bar' })).toEqual([]);
+    expect(parser.parse('string')).toEqual([]);
+    expect(parser.parse(42)).toEqual([]);
+  });
+
+  it('returns [] for array containing non-objects', () => {
+    expect(parser.parse([1, 2, 3])).toEqual([]);
+    expect(parser.parse([{ a: 1 }, 'oops'])).toEqual([]);
+  });
+
+  it('flattens flat object array with lowercased keys', () => {
+    expect(parser.parse([{ Foo: 'bar', Baz: 42 }])).toEqual([{ foo: 'bar', baz: '42' }]);
+  });
+
+  it('flattens nested object using dot notation in keys', () => {
+    expect(parser.parse([{ a: { b: { c: 'leaf' } } }])).toEqual([{ 'a.b.c': 'leaf' }]);
+  });
+
+  it('preserves multiple iterations', () => {
+    expect(parser.parse([{ x: 1 }, { x: 2 }])).toEqual([{ x: '1' }, { x: '2' }]);
+  });
+
+  it('stringifies primitive leaf values', () => {
+    expect(parser.parse([{ a: true, b: 0, c: null }])).toEqual([{ a: 'true', b: '0', c: 'null' }]);
+  });
+
+  it('handles empty objects in iterations', () => {
+    expect(parser.parse([{}, { a: 1 }])).toEqual([{}, { a: '1' }]);
+  });
+
+  it('handles arrays as leaves (stringifies via String())', () => {
+    expect(parser.parse([{ tags: ['a', 'b'] }])).toEqual([{ tags: 'a,b' }]);
+  });
+});

--- a/qase-newman/test/metadataExtractor.test.ts
+++ b/qase-newman/test/metadataExtractor.test.ts
@@ -1,0 +1,120 @@
+/* eslint-disable */
+import { describe, it, expect } from '@jest/globals';
+import { MetadataExtractor } from '../src/modules/metadataExtractor';
+
+const eventListFromExec = (exec: string[], listen = 'test') => ({
+  each: (callback: (event: any) => void) => {
+    callback({ listen, script: { exec } });
+  },
+}) as any;
+
+describe('MetadataExtractor.getCaseIds', () => {
+  it('extracts single id from `// qase: 123`', () => {
+    expect(MetadataExtractor.getCaseIds(eventListFromExec(['// qase: 123']))).toEqual([123]);
+  });
+
+  it('extracts multiple ids from `// qase: 1,2,3`', () => {
+    expect(MetadataExtractor.getCaseIds(eventListFromExec(['// qase: 1,2,3']))).toEqual([1, 2, 3]);
+  });
+
+  it('returns [] for non-test event listeners', () => {
+    expect(MetadataExtractor.getCaseIds(eventListFromExec(['// qase: 1'], 'prerequest'))).toEqual([]);
+  });
+
+  it('handles events with no script.exec', () => {
+    const eventList = { each: (cb: any) => cb({ listen: 'test', script: {} }) } as any;
+    expect(MetadataExtractor.getCaseIds(eventList)).toEqual([]);
+  });
+
+  it('handles `// Qase:` (capital Q)', () => {
+    expect(MetadataExtractor.getCaseIds(eventListFromExec(['// Qase: 42']))).toEqual([42]);
+  });
+});
+
+describe('MetadataExtractor.getProjectMapping', () => {
+  it('parses single project marker `// qase PROJ: 1,2`', () => {
+    expect(MetadataExtractor.getProjectMapping(eventListFromExec(['// qase PROJ: 1,2'])))
+      .toEqual({ PROJ: [1, 2] });
+  });
+
+  it('parses multiple project markers across lines', () => {
+    expect(
+      MetadataExtractor.getProjectMapping(
+        eventListFromExec(['// qase PROJ1: 1', '// qase PROJ2: 2,3']),
+      ),
+    ).toEqual({ PROJ1: [1], PROJ2: [2, 3] });
+  });
+
+  it('ignores `// qase ID: 1,2` (legacy single-project marker, parsed by qaseIdRegExp instead)', () => {
+    expect(MetadataExtractor.getProjectMapping(eventListFromExec(['// qase ID: 5']))).toEqual({});
+  });
+
+  it('returns {} for non-test events', () => {
+    expect(MetadataExtractor.getProjectMapping(eventListFromExec(['// qase PROJ: 1'], 'prerequest')))
+      .toEqual({});
+  });
+
+  it('combines repeated project codes', () => {
+    expect(
+      MetadataExtractor.getProjectMapping(
+        eventListFromExec(['// qase PROJ: 1', '// qase PROJ: 2,3']),
+      ),
+    ).toEqual({ PROJ: [1, 2, 3] });
+  });
+});
+
+describe('MetadataExtractor.getParameters', () => {
+  const itemWithExec = (exec: string[], parent: any = null) => ({
+    events: { each: (cb: any) => cb({ listen: 'test', script: { exec } }) },
+    parent: () => parent,
+  }) as any;
+
+  it('extracts parameters from `qase.parameters: a, b`', () => {
+    expect(MetadataExtractor.getParameters(itemWithExec(['qase.parameters: param1, param2'])))
+      .toEqual(['param1', 'param2']);
+  });
+
+  it('aggregates parameters from parent items', () => {
+    const parent = itemWithExec(['qase.parameters: parentParam']);
+    expect(MetadataExtractor.getParameters(itemWithExec(['qase.parameters: childParam'], parent)))
+      .toEqual(['childParam', 'parentParam']);
+  });
+
+  it('returns [] when no parameters declared', () => {
+    expect(MetadataExtractor.getParameters(itemWithExec(['regular code']))).toEqual([]);
+  });
+});
+
+describe('MetadataExtractor.getParentTitles', () => {
+  it('walks up the parent chain and collects names', () => {
+    const grandparent = { name: 'GP', parent: () => null } as any;
+    const parent = { name: 'P', parent: () => grandparent } as any;
+    const item = { name: 'I', parent: () => parent } as any;
+    expect(MetadataExtractor.getParentTitles(item)).toEqual(['GP', 'P', 'I']);
+  });
+
+  it('returns [] for items without name and no parent', () => {
+    const item = { parent: () => null } as any;
+    expect(MetadataExtractor.getParentTitles(item)).toEqual([]);
+  });
+
+  it('skips levels without `name` property', () => {
+    const grandparent = { name: 'GP', parent: () => null } as any;
+    const parent = { parent: () => grandparent } as any; // no `name`
+    const item = { name: 'I', parent: () => parent } as any;
+    expect(MetadataExtractor.getParentTitles(item)).toEqual(['GP', 'I']);
+  });
+});
+
+describe('MetadataExtractor regexps', () => {
+  it('exposes qaseIdRegExp as static', () => {
+    expect(MetadataExtractor.qaseIdRegExp.test('// qase: 1,2')).toBe(true);
+  });
+  it('exposes qaseParamRegExp as static', () => {
+    expect(MetadataExtractor.qaseParamRegExp.test('qase.parameters: a, b')).toBe(true);
+  });
+  it('exposes qaseProjectRegExp as static', () => {
+    const re = new RegExp(MetadataExtractor.qaseProjectRegExp.source, 'gi');
+    expect(re.exec('// qase PROJ: 1')).not.toBeNull();
+  });
+});

--- a/qase-newman/test/reporter.test.ts
+++ b/qase-newman/test/reporter.test.ts
@@ -1,17 +1,14 @@
 /* eslint-disable */
-import { expect } from '@jest/globals';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { NewmanQaseReporter } from '../src/reporter';
 import { EventEmitter } from 'events';
-import { TestStatusEnum } from 'qase-javascript-commons';
 
-// Shared reporter mock
 const reporterMock = {
   startTestRun: jest.fn(),
   addTestResult: jest.fn(),
   publish: jest.fn(),
 };
 
-// Mock dependencies
 jest.mock('qase-javascript-commons', () => ({
   QaseReporter: {
     getInstance: jest.fn(() => reporterMock),
@@ -22,7 +19,7 @@ jest.mock('qase-javascript-commons', () => ({
     failed: 'failed',
   },
   generateSignature: jest.fn(() => 'mock-signature'),
-  determineTestStatus: jest.fn((error, originalStatus) => {
+  determineTestStatus: jest.fn((error: unknown, originalStatus: string) => {
     if (error) return 'failed';
     if (originalStatus === 'passed') return 'passed';
     return 'failed';
@@ -30,168 +27,58 @@ jest.mock('qase-javascript-commons', () => ({
   ConfigLoader: jest.fn().mockImplementation(() => ({
     load: jest.fn(() => ({})),
   })),
-  getPackageVersion: jest.fn(() => '5.0.0'),
+  getPackageVersion: jest.fn(() => '5.3.5'),
 }));
 
 jest.mock('semver', () => ({
-  lt: jest.fn(),
+  lt: jest.fn(() => false),
 }));
+
+const mkItem = (id: string, name: string, exec: string[] = [], parent: any = null) => ({
+  id,
+  name,
+  events: {
+    each: (cb: any) => cb({ listen: 'test', script: { exec } }),
+  },
+  parent: () => parent,
+}) as any;
 
 describe('NewmanQaseReporter', () => {
   let reporter: NewmanQaseReporter;
   let emitter: EventEmitter;
-  let mockOptions: any;
-  let mockCollectionOptions: any;
+  const options: any = {};
+  const collectionOptions: any = { iterationData: [] };
 
   beforeEach(() => {
+    jest.clearAllMocks();
     emitter = new EventEmitter();
-    mockOptions = {};
-    mockCollectionOptions = {
-      iterationData: [],
-    };
-    reporter = new NewmanQaseReporter(emitter, mockOptions, mockCollectionOptions);
+    reporter = new NewmanQaseReporter(emitter, options, collectionOptions);
   });
 
-  describe('static getCaseIds', () => {
-    it('should extract case IDs from test script', () => {
-      const eventList = {
-        each: jest.fn((callback) => {
-          callback({
-            listen: 'test',
-            script: {
-              exec: [
-                '// qase: 123',
-                '// qase: 456, 789',
-                'some other code',
-              ],
-            },
-          });
-        }),
-      } as any;
-
-      const result = NewmanQaseReporter.getCaseIds(eventList);
-      expect(result).toEqual([123, 456, 789]);
+  describe('public static API (re-exports)', () => {
+    it('exposes qaseIdRegExp', () => {
+      expect(NewmanQaseReporter.qaseIdRegExp).toBeDefined();
+      expect(NewmanQaseReporter.qaseIdRegExp.test('// qase: 1')).toBe(true);
     });
 
-    it('should return empty array for non-test events', () => {
-      const eventList = {
-        each: jest.fn((callback) => {
-          callback({
-            listen: 'prerequest',
-            script: { exec: ['// qase: 123'] },
-          });
-        }),
-      } as any;
-
-      const result = NewmanQaseReporter.getCaseIds(eventList);
-      expect(result).toEqual([]);
+    it('exposes qaseParamRegExp', () => {
+      expect(NewmanQaseReporter.qaseParamRegExp).toBeDefined();
     });
 
-    it('should handle events without script.exec', () => {
-      const eventList = {
-        each: jest.fn((callback) => {
-          callback({
-            listen: 'test',
-            script: {},
-          });
-        }),
-      } as any;
-
-      const result = NewmanQaseReporter.getCaseIds(eventList);
-      expect(result).toEqual([]);
-    });
-  });
-
-  describe('static getParameters', () => {
-    it('should extract parameters from test script', () => {
-      const item = {
-        events: {
-          each: jest.fn((callback) => {
-            callback({
-              listen: 'test',
-              script: {
-                exec: [
-                  'qase.parameters: param1, param2',
-                  'qase.parameters: param3',
-                ],
-              },
-            });
-          }),
-        },
-        parent: jest.fn(() => null),
-      } as any;
-
-      const result = NewmanQaseReporter.getParameters(item);
-      expect(result).toEqual(['param1', 'param2', 'param3']);
+    it('exposes qaseProjectRegExp', () => {
+      expect(NewmanQaseReporter.qaseProjectRegExp).toBeDefined();
     });
 
-    it('should get parameters from parent items', () => {
-      const parentItem = {
-        events: {
-          each: jest.fn((callback) => {
-            callback({
-              listen: 'test',
-              script: {
-                exec: ['qase.parameters: parentParam'],
-              },
-            });
-          }),
-        },
-        parent: jest.fn(() => null),
-      } as any;
-
-      const item = {
-        events: {
-          each: jest.fn((callback) => {
-            callback({
-              listen: 'test',
-              script: {
-                exec: ['qase.parameters: childParam'],
-              },
-            });
-          }),
-        },
-        parent: jest.fn(() => parentItem),
-      } as any;
-
-      const result = NewmanQaseReporter.getParameters(item);
-      expect(result).toEqual(['childParam', 'parentParam']);
-    });
-  });
-
-  describe('static getParentTitles', () => {
-    it('should return titles from parent hierarchy', () => {
-      const grandparent = {
-        name: 'Grandparent',
-        parent: jest.fn(() => null),
-      } as any;
-
-      const parent = {
-        name: 'Parent',
-        parent: jest.fn(() => grandparent),
-      } as any;
-
-      const item = {
-        name: 'Item',
-        parent: jest.fn(() => parent),
-      } as any;
-
-      const result = NewmanQaseReporter.getParentTitles(item);
-      expect(result).toEqual(['Grandparent', 'Parent', 'Item']);
-    });
-
-    it('should handle items without name', () => {
-      const item = {
-        parent: jest.fn(() => null),
-      } as any;
-
-      const result = NewmanQaseReporter.getParentTitles(item);
-      expect(result).toEqual([]);
+    it('exposes getCaseIds, getProjectMapping, getParameters, getParentTitles', () => {
+      expect(typeof NewmanQaseReporter.getCaseIds).toBe('function');
+      expect(typeof NewmanQaseReporter.getProjectMapping).toBe('function');
+      expect(typeof NewmanQaseReporter.getParameters).toBe('function');
+      expect(typeof NewmanQaseReporter.getParentTitles).toBe('function');
     });
   });
 
   describe('constructor', () => {
-    it('should initialize reporter with correct options', () => {
+    it('initializes the commons reporter with framework metadata', () => {
       const { QaseReporter } = require('qase-javascript-commons');
       expect(QaseReporter.getInstance).toHaveBeenCalledWith({
         frameworkPackage: 'newman',
@@ -200,297 +87,117 @@ describe('NewmanQaseReporter', () => {
       });
     });
 
-    it('should set autoCollectParams from config', () => {
-      const mockConfigLoader = {
-        load: jest.fn(() => ({
-          framework: {
-            newman: {
-              autoCollectParams: true,
-            },
-          },
-        })),
-      };
+    it('reads autoCollectParams=false by default', () => {
+      expect((reporter as any).autoCollectParams).toBe(false);
+    });
 
-      const newReporter = new NewmanQaseReporter(
-        emitter,
-        mockOptions,
-        mockCollectionOptions,
-        mockConfigLoader as any,
+    it('reads autoCollectParams=true when config sets it', () => {
+      const customLoader = {
+        load: jest.fn(() => ({ framework: { newman: { autoCollectParams: true } } })),
+      } as any;
+      const r = new NewmanQaseReporter(new EventEmitter(), options, collectionOptions, customLoader);
+      expect((r as any).autoCollectParams).toBe(true);
+    });
+
+    it('parses iterationData via IterationDataParser', () => {
+      const r = new NewmanQaseReporter(
+        new EventEmitter(),
+        options,
+        { iterationData: [{ env: 'prod' }, { env: 'staging' }] } as any,
       );
-
-      expect((newReporter as any).autoCollectParams).toBe(true);
+      expect((r as any).parameters).toEqual([{ env: 'prod' }, { env: 'staging' }]);
     });
   });
 
-  describe('addRunnerListeners', () => {
-    it('should add start listener', () => {
-      const { QaseReporter } = require('qase-javascript-commons');
-      const mockReporter = QaseReporter.getInstance();
-      
+  describe('event flow', () => {
+    it('starts the test run on `start`', () => {
       emitter.emit('start');
-      
-      expect(mockReporter.startTestRun).toHaveBeenCalled();
+      expect(reporterMock.startTestRun).toHaveBeenCalled();
     });
 
-    it('should handle beforeItem event', () => {
-      const mockItem = {
-        id: 'item-1',
-        name: 'Test Item',
-        events: {
-          each: jest.fn((callback) => {
-            callback({
-              listen: 'test',
-              script: { exec: ['// qase: 123'] },
-            });
-          }),
-        },
-        parent: jest.fn(() => null),
-      };
-
-      const mockExec = {
-        item: mockItem,
-      };
-
-      emitter.emit('beforeItem', undefined, mockExec);
-
-      expect((reporter as any).pendingResultMap.get('item-1')).toBeDefined();
-      expect((reporter as any).timerMap.get('item-1')).toBeDefined();
+    it('creates a pending result on `beforeItem`', () => {
+      const item = mkItem('id-1', 'Item 1', ['// qase: 5']);
+      emitter.emit('beforeItem', undefined, { item });
+      const pending = (reporter as any).pendingResultMap.get('id-1');
+      expect(pending).toBeDefined();
+      expect(pending.title).toBe('Item 1');
+      expect(pending.testops_id).toEqual([5]);
     });
 
-    it('should handle assertion event with error', () => {
-      const mockItem = {
-        id: 'item-1',
-        name: 'Test Item',
-        events: { each: jest.fn() },
-        parent: jest.fn(() => null),
-      };
-
-      const mockExec = { item: mockItem };
-      const mockError = new Error('Test error');
-
-      // First add item to pending results
-      emitter.emit('beforeItem', undefined, mockExec);
-      
-      // Then trigger assertion error
-      emitter.emit('assertion', mockError, mockExec);
-
-      const pendingResult = (reporter as any).pendingResultMap.get('item-1');
-      expect(pendingResult.execution.status).toBe(TestStatusEnum.failed);
-      expect(pendingResult.message).toBe('Test error');
+    it('updates pending status on failed `assertion`', () => {
+      const item = mkItem('id-2', 'Item 2', []);
+      emitter.emit('beforeItem', undefined, { item });
+      const err = new Error('boom');
+      err.stack = 'STACK';
+      emitter.emit('assertion', err, { item });
+      const pending = (reporter as any).pendingResultMap.get('id-2');
+      expect(pending.execution.status).toBe('failed');
+      expect(pending.execution.stacktrace).toBe('STACK');
+      expect(pending.message).toBe('boom');
     });
 
-    it('should handle item completion', () => {
-      const mockItem = {
-        id: 'item-1',
-        name: 'Test Item',
-        events: { each: jest.fn() },
-        parent: jest.fn(() => null),
-      };
-
-      const mockExec = {
-        item: mockItem,
-        cursor: { iteration: 0 },
-      };
-
-      const { QaseReporter } = require('qase-javascript-commons');
-      const mockReporter = QaseReporter.getInstance();
-
-      // Add item to pending results
-      emitter.emit('beforeItem', undefined, mockExec);
-      
-      // Complete item
-      emitter.emit('item', undefined, mockExec);
-
-      expect(mockReporter.addTestResult).toHaveBeenCalled();
+    it('finalizes and forwards on `item`, then clears state', () => {
+      const item = mkItem('id-3', 'Item 3', []);
+      emitter.emit('beforeItem', undefined, { item });
+      emitter.emit('item', undefined, { item, cursor: { iteration: 0 } });
+      expect(reporterMock.addTestResult).toHaveBeenCalled();
+      expect((reporter as any).pendingResultMap.has('id-3')).toBe(false);
+      expect((reporter as any).timerMap.has('id-3')).toBe(false);
     });
 
-    it('should handle beforeDone and done events', () => {
-      const { QaseReporter } = require('qase-javascript-commons');
-      const mockReporter = QaseReporter.getInstance();
-
+    it('publishes on `beforeDone`', () => {
       emitter.emit('beforeDone');
-      emitter.emit('done');
+      expect(reporterMock.publish).toHaveBeenCalled();
+    });
 
-      expect(mockReporter.publish).toHaveBeenCalled();
+    it('skips finalize when no pending result for the item', () => {
+      const item = mkItem('id-orphan', 'Orphan', []);
+      emitter.emit('item', undefined, { item, cursor: { iteration: 0 } });
+      expect(reporterMock.addTestResult).not.toHaveBeenCalled();
     });
   });
 
-  describe('prepareParameters', () => {
-    it('should return empty object when no parameters available', () => {
-      const item = {
-        events: { each: jest.fn() },
-        parent: jest.fn(() => null),
-      } as any;
-
+  describe('prepareParameters glue', () => {
+    it('returns {} when no iteration data was provided', () => {
+      const item = mkItem('p1', 'P1', ['qase.parameters: env']);
       const result = (reporter as any).prepareParameters(item, 0);
       expect(result).toEqual({});
     });
 
-    it('should return available parameters when autoCollectParams is true', () => {
-      (reporter as any).autoCollectParams = true;
-      (reporter as any).parameters = [{ param1: 'value1', param2: 'value2' }];
+    it('filters available iteration data by declared parameters', () => {
+      const r = new NewmanQaseReporter(
+        new EventEmitter(),
+        options,
+        { iterationData: [{ env: 'prod', extra: 'x' }] } as any,
+      );
+      const item = mkItem('p2', 'P2', ['qase.parameters: env']);
+      const result = (r as any).prepareParameters(item, 0);
+      expect(result).toEqual({ env: 'prod' });
+    });
 
-      const item = {
-        events: { each: jest.fn() },
-        parent: jest.fn(() => null),
+    it('returns full iteration data when autoCollectParams=true and no params declared', () => {
+      const customLoader = {
+        load: jest.fn(() => ({ framework: { newman: { autoCollectParams: true } } })),
       } as any;
-
-      const result = (reporter as any).prepareParameters(item, 0);
-      expect(result).toEqual({ param1: 'value1', param2: 'value2' });
-    });
-
-    it('should filter parameters based on item parameters', () => {
-      (reporter as any).parameters = [{ param1: 'value1', param2: 'value2', param3: 'value3' }];
-
-      const item = {
-        events: {
-          each: jest.fn((callback) => {
-            callback({
-              listen: 'test',
-              script: { exec: ['qase.parameters: param1, param3'] },
-            });
-          }),
-        },
-        parent: jest.fn(() => null),
-      } as any;
-
-      const result = (reporter as any).prepareParameters(item, 0);
-      expect(result).toEqual({ param1: 'value1', param3: 'value3' });
-    });
-  });
-
-  describe('getParameters', () => {
-    it('should return empty array for null iterationData', () => {
-      const result = (reporter as any).getParameters(null);
-      expect(result).toEqual([]);
-    });
-
-    it('should convert array of objects to records', () => {
-      const iterationData = [
-        { key1: 'value1', key2: 'value2' },
-        { key3: 'value3' },
-      ];
-
-      const result = (reporter as any).getParameters(iterationData);
-      expect(result).toEqual([
-        { key1: 'value1', key2: 'value2' },
-        { key3: 'value3' },
-      ]);
-    });
-
-    it('should return empty array for non-array data', () => {
-      const result = (reporter as any).getParameters('not an array');
-      expect(result).toEqual([]);
-    });
-  });
-
-  describe('convertToRecord', () => {
-    it('should convert simple object to record', () => {
-      const obj = { key1: 'value1', key2: 123 };
-      const result = (reporter as any).convertToRecord(obj);
-      expect(result).toEqual({ key1: 'value1', key2: '123' });
-    });
-
-    it('should handle nested objects', () => {
-      const obj = {
-        parent: {
-          child1: 'value1',
-          child2: 'value2',
-        },
-        simple: 'value3',
-      };
-
-      const result = (reporter as any).convertToRecord(obj);
-      expect(result).toEqual({
-        'parent.child1': 'value1',
-        'parent.child2': 'value2',
-        simple: 'value3',
-      });
-    });
-
-    it('should convert keys to lowercase', () => {
-      const obj = { Key1: 'value1', KEY2: 'value2' };
-      const result = (reporter as any).convertToRecord(obj);
-      expect(result).toEqual({ key1: 'value1', key2: 'value2' });
-    });
-
-    it('should handle non-object input', () => {
-      const result = (reporter as any).convertToRecord('string');
-      expect(result).toEqual({});
-    });
-  });
-
-  describe('isRecord', () => {
-    it('should return true for objects', () => {
-      expect((reporter as any).isRecord({})).toBe(true);
-      expect((reporter as any).isRecord({ key: 'value' })).toBe(true);
-    });
-
-    it('should return false for non-objects', () => {
-      expect((reporter as any).isRecord(null)).toBe(false);
-      expect((reporter as any).isRecord(undefined)).toBe(false);
-      expect((reporter as any).isRecord('string')).toBe(false);
-      expect((reporter as any).isRecord(123)).toBe(false);
-      expect((reporter as any).isRecord([])).toBe(true);
-    });
-  });
-
-  describe('getSignature', () => {
-    it('should call generateSignature with correct parameters', () => {
-      const { generateSignature } = require('qase-javascript-commons');
-      
-      const result = (reporter as any).getSignature(['Suite1', 'Suite2'], 'Test Title', [123, 456]);
-      
-      expect(generateSignature).toHaveBeenCalledWith([123, 456], ['Suite1', 'Suite2', 'Test Title'], {});
-      expect(result).toBe('mock-signature');
+      const r = new NewmanQaseReporter(
+        new EventEmitter(),
+        options,
+        { iterationData: [{ env: 'prod' }] } as any,
+        customLoader,
+      );
+      const item = mkItem('p3', 'P3', []); // no qase.parameters
+      const result = (r as any).prepareParameters(item, 0);
+      expect(result).toEqual({ env: 'prod' });
     });
   });
 
   describe('preventExit', () => {
-    it('should not modify process.exit for newer newman versions', () => {
-      const { getPackageVersion } = require('qase-javascript-commons');
-      const { lt } = require('semver');
-      
-      getPackageVersion.mockReturnValue('5.4.0');
-      lt.mockReturnValue(false);
-
-      const originalExit = process.exit;
+    it('does not override process.exit when newman >= 5.3.2', () => {
+      const semver = require('semver');
+      semver.lt.mockReturnValueOnce(false);
+      const before = process.exit;
       (reporter as any).preventExit();
-      
-      expect(process.exit).toBe(originalExit);
-    });
-
-    it('should modify process.exit for older newman versions', () => {
-      const { getPackageVersion } = require('qase-javascript-commons');
-      const { lt } = require('semver');
-      
-      getPackageVersion.mockReturnValue('5.0.0');
-      lt.mockReturnValue(true);
-
-      const originalExit = process.exit;
-      (reporter as any).preventExit();
-      
-      expect(process.exit).not.toBe(originalExit);
-      expect(typeof process.exit).toBe('function');
-      
-      // Restore original exit
-      process.exit = originalExit;
+      expect(process.exit).toBe(before);
     });
   });
-
-  describe('static regex patterns', () => {
-    it('should match qase ID patterns', () => {
-      expect(NewmanQaseReporter.qaseIdRegExp.test('// qase: 123')).toBe(true);
-      expect(NewmanQaseReporter.qaseIdRegExp.test('// Qase: 456, 789')).toBe(true);
-      expect(NewmanQaseReporter.qaseIdRegExp.test('// qase: 123, 456, 789')).toBe(true);
-      expect(NewmanQaseReporter.qaseIdRegExp.test('// some other comment')).toBe(false);
-    });
-
-    it('should match parameter patterns', () => {
-      expect(NewmanQaseReporter.qaseParamRegExp.test('qase.parameters: param1, param2')).toBe(true);
-      expect(NewmanQaseReporter.qaseParamRegExp.test('Qase.Parameters: param1')).toBe(true);
-      expect(NewmanQaseReporter.qaseParamRegExp.test('qase.parameters: param1, param2, param3')).toBe(true);
-      expect(NewmanQaseReporter.qaseParamRegExp.test('some other text')).toBe(false);
-    });
-  });
-}); 
+});

--- a/qase-newman/test/resultBuilder.test.ts
+++ b/qase-newman/test/resultBuilder.test.ts
@@ -1,0 +1,120 @@
+/* eslint-disable */
+import { describe, it, expect } from '@jest/globals';
+import { ResultBuilder } from '../src/modules/resultBuilder';
+
+const mkItem = (overrides: any = {}) => ({
+  id: 'item-1',
+  name: 'Sample Item',
+  ...overrides,
+}) as any;
+
+describe('ResultBuilder.buildPending', () => {
+  it('returns a TestResultType with default execution shape', () => {
+    const result = ResultBuilder.buildPending({
+      item: mkItem(),
+      suites: [],
+      ids: [],
+      projectMapping: {},
+      signature: 'sig-1',
+    });
+    expect(result.execution.status).toBe('passed');
+    expect(result.execution.start_time).toBeNull();
+    expect(result.execution.end_time).toBeNull();
+    expect(result.execution.duration).toBe(0);
+    expect(result.execution.stacktrace).toBeNull();
+    expect(result.execution.thread).toBeNull();
+    expect(result.id).toBe('item-1');
+    expect(result.title).toBe('Sample Item');
+    expect(result.signature).toBe('sig-1');
+    expect(result.attachments).toEqual([]);
+    expect(result.steps).toEqual([]);
+    expect(result.fields).toEqual({});
+    expect(result.params).toEqual({});
+    expect(result.group_params).toEqual({});
+  });
+
+  it('sets relations from suites array', () => {
+    const result = ResultBuilder.buildPending({
+      item: mkItem(),
+      suites: ['Folder A', 'Folder B'],
+      ids: [],
+      projectMapping: {},
+      signature: 'sig-2',
+    });
+    expect(result.relations).toEqual({
+      suite: {
+        data: [
+          { title: 'Folder A', public_id: null },
+          { title: 'Folder B', public_id: null },
+        ],
+      },
+    });
+  });
+
+  it('leaves relations null for empty suites', () => {
+    const result = ResultBuilder.buildPending({
+      item: mkItem(),
+      suites: [],
+      ids: [],
+      projectMapping: {},
+      signature: 'sig-3',
+    });
+    expect(result.relations).toBeNull();
+  });
+
+  it('sets testops_id to ids array when ids non-empty', () => {
+    const result = ResultBuilder.buildPending({
+      item: mkItem(),
+      suites: [],
+      ids: [42, 100],
+      projectMapping: {},
+      signature: 'sig-4',
+    });
+    expect(result.testops_id).toEqual([42, 100]);
+  });
+
+  it('leaves testops_id null when no ids', () => {
+    const result = ResultBuilder.buildPending({
+      item: mkItem(),
+      suites: [],
+      ids: [],
+      projectMapping: {},
+      signature: 'sig-5',
+    });
+    expect(result.testops_id).toBeNull();
+  });
+
+  it('sets testops_project_mapping when projectMapping non-empty', () => {
+    const result = ResultBuilder.buildPending({
+      item: mkItem(),
+      suites: [],
+      ids: [],
+      projectMapping: { PROJ: [7] },
+      signature: 'sig-6',
+    });
+    expect(result.testops_project_mapping).toEqual({ PROJ: [7] });
+  });
+
+  it('leaves testops_project_mapping null when projectMapping empty', () => {
+    const result = ResultBuilder.buildPending({
+      item: mkItem(),
+      suites: [],
+      ids: [],
+      projectMapping: {},
+      signature: 'sig-7',
+    });
+    expect(result.testops_project_mapping).toBeNull();
+  });
+
+  it('preserves item.id and item.name', () => {
+    const result = ResultBuilder.buildPending({
+      item: mkItem({ id: 'abc-123', name: 'Custom Title' }),
+      suites: [],
+      ids: [],
+      projectMapping: {},
+      signature: 'sig-8',
+    });
+    expect(result.id).toBe('abc-123');
+    expect(result.title).toBe('Custom Title');
+  });
+});


### PR DESCRIPTION
## Summary

- Decompose `qase-newman/src/reporter.ts` (433 → 163 LOC, ~62% reduction) into a thin event-driven orchestrator + 3 modules (`MetadataExtractor`, `IterationDataParser`, `ResultBuilder`) under `src/modules/`. Phase 2 pattern, 8th reporter (after wdio / playwright / cypress / mocha / cucumberjs / testcafe / jest).
- Bumped `qase-javascript-commons` peer dep `~2.5.0 → ~2.7.0` (sync with monorepo).
- Existing tests rewritten for new wiring (orchestration-focused); 37 new per-module tests added (55 total).
- Bump `newman-reporter-qase` 2.2.0 → 2.3.0; public contract preserved (named export, 3 static regexps, 4 static methods, ctor signature, `NewmanQaseOptionsType`).

## Test plan

- [ ] CI green on `refactor/newman-decomposition`.
- [x] `cd qase-newman && npx jest` passes locally with 55 tests.
- [x] Workspace `npm run build --workspaces --if-present` and `npm run lint --workspaces --if-present` clean (0 errors).
- [x] Smoke `QASE_MODE=testops` against DEVX project — run #818 received all 13/13 results: https://app.qase.io/run/DEVX/dashboard/818

## Design

- Spec: `docs/superpowers/specs/2026-05-01-newman-decomposition-design.md` (not committed).
- Plan: `docs/superpowers/plans/2026-05-04-newman-decomposition.md` (not committed).