### PR TITLE
refactor(vitest): decompose reporter into focused modules

### DIFF
--- a/qase-vitest/changelog.md
+++ b/qase-vitest/changelog.md
@@ -1,3 +1,17 @@
+# vitest-qase-reporter@1.4.0
+
+## Changed
+
+- Decomposed `index.ts` (451 LOC) into a thin orchestrator plus 3 focused modules under `src/modules/` (`MetadataAccumulator`, `ProfilerTracker`, `ResultBuilder`). Public contract preserved: default + named `VitestQaseReporter` export, all 6 lifecycle hooks (`onTestRunStart`, `onTestRunEnd`, `onTestCaseResult`, `onTestCaseAnnotate`, `onTestSuiteReady`, `onTestSuiteResult`), constructor signature, and `VitestQaseOptionsType` re-export.
+
+## Removed
+
+- `static qaseIdRegExp` — deprecated since Phase 1; replaced by `parseProjectMappingFromTitle` from `qase-javascript-commons` (matches mocha 1.5.0, cypress 3.6.0, jest 2.5.0 precedent).
+
+## Internal
+
+- Added per-module unit tests for the three new modules (~50 new tests, 76 total).
+
 # vitest-qase-reporter@1.3.0
 
 ## Changed

--- a/qase-vitest/package.json
+++ b/qase-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-qase-reporter",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Qase TMS Vitest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-vitest/src/index.ts
+++ b/qase-vitest/src/index.ts
@@ -40,9 +40,6 @@ export class VitestQaseReporter implements Reporter {
     attachments: { name: string; path?: string; content?: string; contentType?: string }[];
   }> = new Map();
 
-  /** @deprecated Use parseProjectMappingFromTitle from qase-javascript-commons for multi-project support. */
-  static qaseIdRegExp = /\(Qase ID: ([\d,]+)\)/;
-
   constructor(
     options: VitestQaseOptionsType = {},
     configLoader = new ConfigLoader(),

--- a/qase-vitest/src/index.ts
+++ b/qase-vitest/src/index.ts
@@ -1,44 +1,26 @@
 import type { Reporter } from 'vitest/reporters';
 import type { TestAnnotation } from '@vitest/runner';
-import type {
-  TestCase,
-  TestSuite
-} from 'vitest/node';
+import type { TestCase, TestSuite } from 'vitest/node';
 import {
-  QaseReporter,
-  TestResultType,
-  TestStepType,
-  StepStatusEnum,
-  Attachment,
-  composeOptions,
-  ReporterInterface,
-  ConfigType,
-  determineTestStatus,
-  parseProjectMappingFromTitle,
   ConfigLoader,
+  ConfigType,
+  QaseReporter,
+  ReporterInterface,
+  TestStepType,
+  composeOptions,
 } from 'qase-javascript-commons';
 import { NetworkProfiler } from 'qase-javascript-commons/profilers';
-import { extractAndCleanStep } from 'qase-javascript-commons/internal';
+
+import { MetadataAccumulator } from './modules/metadataAccumulator';
+import { ProfilerTracker } from './modules/profilerTracker';
+import { ResultBuilder } from './modules/resultBuilder';
 
 export type VitestQaseOptionsType = ConfigType;
 
 export class VitestQaseReporter implements Reporter {
   private reporter: ReporterInterface;
-  private profiler: NetworkProfiler | null = null;
-  private _profilerStepSnapshot = 0;
-  private currentSuite: string | undefined = undefined;
-  private testMetadata: Map<string, {
-    title?: string;
-    comment?: string;
-    suite?: string;
-    fields?: Record<string, string>;
-    parameters?: Record<string, string>;
-    groupParameters?: Record<string, string>;
-    tags?: string[];
-    currentStep?: string;
-    steps: { name: string; status: 'start' | 'end' | 'failed' }[];
-    attachments: { name: string; path?: string; content?: string; contentType?: string }[];
-  }> = new Map();
+  private profilerTracker: ProfilerTracker;
+  private metadataAccumulator: MetadataAccumulator;
 
   constructor(
     options: VitestQaseOptionsType = {},
@@ -54,395 +36,64 @@ export class VitestQaseReporter implements Reporter {
       reporterName: 'vitest-qase-reporter',
     });
 
-    if (composedOptions.profilers?.includes('network')) {
-      this.profiler = new NetworkProfiler({
-        skipDomains: composedOptions.networkProfiler?.skip_domains,
-        trackOnFail: composedOptions.networkProfiler?.track_on_fail,
-      });
-    }
-  }
-
-
-
-
-  /**
-   * Create TestResultType from Vitest TestCase
-   */
-  private createTestResult(testCase: TestCase): TestResultType {
-    const result = testCase.result();
-    const parsed = parseProjectMappingFromTitle(testCase.name);
-    const diagnostic = testCase.diagnostic();
-    const testId = testCase.id ?? testCase.name;
-    const metadata = this.testMetadata.get(testId);
-
-    // Use title from metadata if available, otherwise use cleaned name (multi-project markers stripped)
-    const testTitle = metadata?.title ?? (parsed.cleanedTitle.replace(/\s+/g, ' ').trim() || testCase.name);
-    const testResult = new TestResultType(testTitle);
-    testResult.id = testCase.id ?? '';
-    testResult.signature = testCase.fullName ?? testCase.name;
-
-    // Multi-project: set testops_project_mapping when any (Qase PROJECT: ids) is present
-    const hasProjectMapping = Object.keys(parsed.projectMapping).length > 0;
-    if (hasProjectMapping) {
-      testResult.testops_project_mapping = parsed.projectMapping;
-      testResult.testops_id = null;
-    } else if (parsed.legacyIds.length > 0) {
-      testResult.testops_id = parsed.legacyIds.length === 1 ? parsed.legacyIds[0]! : parsed.legacyIds;
-    } else {
-      testResult.testops_id = null;
-    }
-
-    // Set relations for test suite
-    const suiteToUse = metadata?.suite ?? this.currentSuite ?? this.extractSuiteFromTestCase(testCase);
-    if (suiteToUse) {
-      testResult.relations = {
-        suite: {
-          data: [],
-        },
-      };
-
-      const suites = suiteToUse.split(' - ');
-      suites.forEach((suite) => {
-        testResult.relations!.suite!.data.push({ title: suite.trim(), public_id: null });
-      });
-    }
-
-    // Set execution details
-    testResult.execution.start_time = null;
-    testResult.execution.end_time = null;
-    testResult.execution.duration = Math.round(diagnostic?.duration || 0);
-
-    // Create error object for status determination
-    let error: Error | null = null;
-    if (result?.errors && result.errors.length > 0) {
-      const firstError = result.errors[0];
-      if (firstError && typeof firstError === 'object' && 'message' in firstError) {
-        error = new Error(String(firstError.message));
-        if ('stack' in firstError && firstError.stack) {
-          error.stack = String(firstError.stack);
-        }
-      }
-      
-      testResult.execution.stacktrace = result.errors.map((error: unknown) => {
-        if (error && typeof error === 'object' && 'stack' in error && 'message' in error) {
-          return (error.stack as string) ?? (error.message as string) ?? String(error);
-        }
-        return String(error);
-      }).join('\n');
-      testResult.message = result.errors[0] && typeof result.errors[0] === 'object' && 'message' in result.errors[0] 
-        ? String(result.errors[0].message) ?? 'Test failed'
-        : 'Test failed';
-    }
-
-    // Determine status based on error type
-    testResult.execution.status = determineTestStatus(error, result.state);
-
-    if (result.state === 'skipped') {
-      testResult.message = result && typeof result === 'object' && 'note' in result ? (result.note as string) ?? null : null;
-    }
-
-    // Add metadata from annotations
-    if (metadata) {
-      // Add comment if available - store in message field since execution doesn't have comment
-      if (metadata.comment) {
-        testResult.message = metadata.comment;
-      }
-
-      // Add fields if available
-      if (metadata.fields) {
-        testResult.fields = metadata.fields;
-      }
-
-      // Add parameters if available
-      if (metadata.parameters) {
-        testResult.params = metadata.parameters;
-      }
-
-      // Add group parameters if available
-      if (metadata.groupParameters) {
-        testResult.group_params = metadata.groupParameters;
-      }
-
-      // Add tags if available
-      if (metadata.tags && metadata.tags.length > 0) {
-        testResult.tags = metadata.tags;
-      }
-
-      // Add steps if available - create proper TestStepType objects
-      if (metadata.steps.length > 0) {
-        testResult.steps = metadata.steps.map(step => {
-          const stepObj = new TestStepType();
-          stepObj.id = Math.random().toString(36).substr(2, 9);
-          const stepData = extractAndCleanStep(step.name);
-          stepObj.data = {
-            action: stepData.cleanedString,
-            expected_result: stepData.expectedResult,
-            data: stepData.data
-          };
-          stepObj.execution.status = step.status === 'failed' ? StepStatusEnum.failed : StepStatusEnum.passed;
-          return stepObj;
-        });
-      }
-
-      // Add attachments if available
-      if (metadata.attachments.length > 0) {
-        testResult.attachments = metadata.attachments.map(attachment => {
-          const attachmentModel: Attachment = {
-            file_name: attachment.name,
-            mime_type: attachment.contentType || 'application/octet-stream',
-            file_path: attachment.path || null,
-            content: attachment.content || '',
-            size: attachment.content ? Buffer.byteLength(attachment.content) : 0,
-            id: Math.random().toString(36).substr(2, 9)
-          };
-          return attachmentModel;
-        });
-      }
-    }
-
-    // Merge profiler steps stored from setup.ts annotations
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    if (metadata && (metadata as any)._profilerSteps) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-      const profilerSteps = (metadata as any)._profilerSteps as TestStepType[];
-      testResult.steps = [...testResult.steps, ...profilerSteps];
-    }
-
-    // Clean up metadata after processing
-    this.testMetadata.delete(testId);
-
-    return testResult;
+    const profiler = composedOptions.profilers?.includes('network')
+      ? new NetworkProfiler({
+          skipDomains: composedOptions.networkProfiler?.skip_domains,
+          trackOnFail: composedOptions.networkProfiler?.track_on_fail,
+        })
+      : null;
+    this.profilerTracker = new ProfilerTracker(profiler);
+    this.metadataAccumulator = new MetadataAccumulator();
   }
 
   onTestRunStart?(): void {
     this.reporter.startTestRun();
-    // Enable profiler in main thread for single-fork/single-thread mode
-    this.profiler?.enable();
+    this.profilerTracker.enable();
   }
 
   async onTestRunEnd?(): Promise<void> {
-    this.profiler?.restore();
+    this.profilerTracker.restore();
     await this.reporter.publish();
   }
 
-
   async onTestCaseResult?(testCase: TestCase): Promise<void> {
-    const testResult = this.createTestResult(testCase);
+    const testId = testCase.id;
+    const metadata = this.metadataAccumulator.getMetadata(testId);
+    const currentSuite = this.metadataAccumulator.getCurrentSuite();
+    const localProfilerSteps = this.profilerTracker.getNewSteps();
+    const workerProfilerSteps = this.extractWorkerProfilerSteps(testCase);
+    const profilerSteps = [...localProfilerSteps, ...workerProfilerSteps];
 
-    // Direct fallback accumulator — works in single-fork/single-thread mode
-    if (this.profiler) {
-      const allSteps = this.profiler.getAllSteps();
-      const newSteps = allSteps.slice(this._profilerStepSnapshot);
-      this._profilerStepSnapshot = allSteps.length;
-      if (newSteps.length > 0) {
-        testResult.steps = [...testResult.steps, ...newSteps];
-      }
-    }
+    const result = ResultBuilder.build({ testCase, metadata, currentSuite, profilerSteps });
+    this.metadataAccumulator.clearMetadata(testId);
+    await this.reporter.addTestResult(result);
+  }
 
-    // Merge profiler steps from worker via task.meta (set by setup.ts)
+  onTestCaseAnnotate?(testCase: TestCase, annotation: TestAnnotation): void {
+    const testId = testCase.id;
+    this.metadataAccumulator.parseAnnotation(testId, annotation);
+  }
+
+  onTestSuiteReady?(testSuite: TestSuite): void {
+    this.metadataAccumulator.setCurrentSuite(testSuite.name);
+  }
+
+  onTestSuiteResult?(): void {
+    this.metadataAccumulator.clearCurrentSuite();
+  }
+
+  private extractWorkerProfilerSteps(testCase: TestCase): TestStepType[] {
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       const metaSteps = (testCase.meta() as any)?._qaseProfilerSteps as string | undefined;
       if (metaSteps) {
-        const profilerSteps = JSON.parse(metaSteps) as TestStepType[];
-        testResult.steps = [...testResult.steps, ...profilerSteps];
+        return JSON.parse(metaSteps) as TestStepType[];
       }
     } catch {
       // Silent failure — corrupted profiler data should not affect test results
     }
-
-    await this.reporter.addTestResult(testResult);
+    return [];
   }
-
-  onTestCaseAnnotate?(testCase: TestCase, annotation: TestAnnotation): void {
-    const testId = testCase.id ?? testCase.name;
-    
-    // Initialize metadata if not exists
-    if (!this.testMetadata.has(testId)) {
-      this.testMetadata.set(testId, {
-        steps: [],
-        attachments: []
-      });
-    }
-    
-    const metadata = this.testMetadata.get(testId);
-    if (!metadata) return;
-
-    // Check for profiler steps annotation from setup.ts (must be before the generic Qase check)
-    if (annotation.message && annotation.message.startsWith('Qase Profiler Steps: ')) {
-      try {
-        const stepsJson = annotation.message.replace('Qase Profiler Steps: ', '');
-        const profilerSteps = JSON.parse(stepsJson) as TestStepType[];
-        // Store profiler steps in metadata for merging in onTestCaseResult via createTestResult
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-        (metadata as any)._profilerSteps = profilerSteps;
-      } catch {
-        // Silent failure — corrupted profiler data should not affect test results
-      }
-      return; // Do not process further as a regular annotation
-    }
-
-    // Process qase annotations
-    // Check if this is a qase annotation by looking at the message pattern
-    if (annotation.message && annotation.message.startsWith('Qase ')) {
-      const qaseType = annotation.message.split(':')[0]?.replace('Qase ', '').toLowerCase().replace(' ', '-') ?? '';
-      
-      switch (qaseType) {
-        case 'title': {
-          metadata.title = annotation.message.replace('Qase Title: ', '');
-          break;
-        }
-          
-        case 'comment': {
-          metadata.comment = annotation.message.replace('Qase Comment: ', '');
-          break;
-        }
-          
-        case 'suite': {
-          metadata.suite = annotation.message.replace('Qase Suite: ', '');
-          break;
-        }
-          
-        case 'fields': {
-          const fieldsData = annotation.message.replace('Qase Fields: ', '');
-          try {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            const parsed = JSON.parse(fieldsData);
-            if (typeof parsed === 'object' && parsed !== null) {
-              metadata.fields = parsed as Record<string, string>;
-            }
-          } catch (e) {
-            console.warn('Failed to parse qase fields:', fieldsData);
-          }
-          break;
-        }
-          
-        case 'parameters': {
-          const parametersData = annotation.message.replace('Qase Parameters: ', '');
-          try {
-            const parsed: unknown = JSON.parse(parametersData);
-            if (typeof parsed === 'object' && parsed !== null) {
-              const stringified: Record<string, string> = {};
-              for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-                if (v != null) {
-                  stringified[k] = String(v);
-                }
-              }
-              metadata.parameters = stringified;
-            }
-          } catch (e) {
-            console.warn('Failed to parse qase parameters:', parametersData);
-          }
-          break;
-        }
-          
-        case 'group-parameters': {
-          const groupParametersData = annotation.message.replace('Qase Group Parameters: ', '');
-          try {
-            const parsed: unknown = JSON.parse(groupParametersData);
-            if (typeof parsed === 'object' && parsed !== null) {
-              const stringified: Record<string, string> = {};
-              for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-                if (v != null) {
-                  stringified[k] = String(v);
-                }
-              }
-              metadata.groupParameters = stringified;
-            }
-          } catch (e) {
-            console.warn('Failed to parse qase group parameters:', groupParametersData);
-          }
-          break;
-        }
-          
-        case 'tags': {
-          const tagsData = annotation.message.replace('Qase Tags: ', '');
-          try {
-            const parsed: unknown = JSON.parse(tagsData);
-            if (Array.isArray(parsed)) {
-              metadata.tags = [...(metadata.tags ?? []), ...parsed.map(String)];
-            }
-          } catch (e) {
-            metadata.tags = [...(metadata.tags ?? []), ...tagsData.split(',').map((t: string) => t.trim()).filter((t: string) => t.length > 0)];
-          }
-          break;
-        }
-
-        case 'step-start': {
-          const stepStartData = annotation.message.replace('Qase Step Start: ', '');
-          metadata.currentStep = stepStartData;
-          break;
-        }
-          
-        case 'step-end': {
-          if (metadata.currentStep) {
-            metadata.steps.push({ 
-              name: metadata.currentStep, 
-              status: 'end'
-            });
-            delete metadata.currentStep;
-          }
-          break;
-        }
-          
-        case 'step-failed': {
-          if (metadata.currentStep) {
-            metadata.steps.push({ 
-              name: metadata.currentStep, 
-              status: 'failed'
-            });
-            delete metadata.currentStep;
-          }
-          break;
-        }
-          
-        case 'attachment': {
-          const attachmentName = annotation.message.replace('Qase Attachment: ', '');
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const attachment = {
-            name: attachmentName,
-            ...(annotation.attachment?.path && { path: annotation.attachment.path }),
-            ...(annotation.attachment?.body && {
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              content: typeof annotation.attachment.body === 'string' 
-                ? annotation.attachment.body 
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                : new TextDecoder().decode(annotation.attachment.body)
-            }),
-            ...(annotation.attachment?.contentType && { contentType: annotation.attachment.contentType })
-          };
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          metadata.attachments.push(attachment);
-          break;
-        }
-      }
-    }
-  }
-
-  onTestSuiteReady?(testSuite: TestSuite): void {
-    this.currentSuite = testSuite.name;
-  }
-
-  onTestSuiteResult?(): void {
-    this.currentSuite = undefined;
-  }
-
-  private extractSuiteFromTestCase(testCase: TestCase): string | undefined {
-    // Extract suite from testCase.fullName or testCase.name
-    // Format is usually "Suite Name > Test Name" or just "Test Name"
-    const fullName = testCase.fullName ?? testCase.name;
-    const parts = fullName.split(' > ');
-    
-    if (parts.length > 1) {
-      // Return the suite part (everything except the last part)
-      return parts.slice(0, -1).join(' > ');
-    }
-    
-    // If no suite separator found, return undefined
-    // The test will be assigned to the default suite
-    return undefined;
-  }
-
 }
 
 export default VitestQaseReporter;

--- a/qase-vitest/src/modules/metadataAccumulator.ts
+++ b/qase-vitest/src/modules/metadataAccumulator.ts
@@ -1,0 +1,203 @@
+import type { TestAnnotation } from '@vitest/runner';
+import { TestStepType } from 'qase-javascript-commons';
+
+export interface MetadataShape {
+  title?: string;
+  comment?: string;
+  suite?: string;
+  fields?: Record<string, string>;
+  parameters?: Record<string, string>;
+  groupParameters?: Record<string, string>;
+  tags?: string[];
+  currentStep?: string;
+  steps: { name: string; status: 'start' | 'end' | 'failed' }[];
+  attachments: { name: string; path?: string; content?: string; contentType?: string }[];
+  _profilerSteps?: TestStepType[];
+}
+
+export class MetadataAccumulator {
+  private testMetadata = new Map<string, MetadataShape>();
+  private currentSuite: string | undefined = undefined;
+
+  parseAnnotation(testId: string, annotation: TestAnnotation): void {
+    if (!annotation.message) return;
+
+    if (!this.testMetadata.has(testId)) {
+      this.testMetadata.set(testId, { steps: [], attachments: [] });
+    }
+    const metadata = this.testMetadata.get(testId);
+    if (!metadata) return;
+
+    if (annotation.message.startsWith('Qase Profiler Steps: ')) {
+      try {
+        const stepsJson = annotation.message.replace('Qase Profiler Steps: ', '');
+        const profilerSteps = JSON.parse(stepsJson) as TestStepType[];
+        metadata._profilerSteps = profilerSteps;
+      } catch {
+        // Silent failure — corrupted profiler data should not affect test results
+      }
+      return;
+    }
+
+    if (!annotation.message.startsWith('Qase ')) {
+      // Unknown non-Qase message — but we already created the entry. Remove it
+      // to preserve "non-Qase annotation is ignored" semantics for the very
+      // first annotation if no Qase data was added.
+      if (
+        metadata.steps.length === 0 &&
+        metadata.attachments.length === 0 &&
+        metadata.title === undefined &&
+        metadata.comment === undefined &&
+        metadata.suite === undefined &&
+        metadata.fields === undefined &&
+        metadata.parameters === undefined &&
+        metadata.groupParameters === undefined &&
+        metadata.tags === undefined &&
+        metadata.currentStep === undefined &&
+        metadata._profilerSteps === undefined
+      ) {
+        this.testMetadata.delete(testId);
+      }
+      return;
+    }
+
+    const qaseType = annotation.message.split(':')[0]?.replace('Qase ', '').toLowerCase().replace(' ', '-') ?? '';
+
+    switch (qaseType) {
+      case 'title':
+        metadata.title = annotation.message.replace('Qase Title: ', '');
+        break;
+
+      case 'comment':
+        metadata.comment = annotation.message.replace('Qase Comment: ', '');
+        break;
+
+      case 'suite':
+        metadata.suite = annotation.message.replace('Qase Suite: ', '');
+        break;
+
+      case 'fields': {
+        const fieldsData = annotation.message.replace('Qase Fields: ', '');
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          const parsed = JSON.parse(fieldsData);
+          if (typeof parsed === 'object' && parsed !== null) {
+            metadata.fields = parsed as Record<string, string>;
+          }
+        } catch {
+          // ignore malformed JSON
+        }
+        break;
+      }
+
+      case 'parameters': {
+        const parametersData = annotation.message.replace('Qase Parameters: ', '');
+        try {
+          const parsed: unknown = JSON.parse(parametersData);
+          if (typeof parsed === 'object' && parsed !== null) {
+            const stringified: Record<string, string> = {};
+            for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+              if (v != null) stringified[k] = String(v);
+            }
+            metadata.parameters = stringified;
+          }
+        } catch {
+          // ignore malformed JSON
+        }
+        break;
+      }
+
+      case 'group-parameters': {
+        const groupParametersData = annotation.message.replace('Qase Group Parameters: ', '');
+        try {
+          const parsed: unknown = JSON.parse(groupParametersData);
+          if (typeof parsed === 'object' && parsed !== null) {
+            const stringified: Record<string, string> = {};
+            for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+              if (v != null) stringified[k] = String(v);
+            }
+            metadata.groupParameters = stringified;
+          }
+        } catch {
+          // ignore malformed JSON
+        }
+        break;
+      }
+
+      case 'tags': {
+        const tagsData = annotation.message.replace('Qase Tags: ', '');
+        try {
+          const parsed: unknown = JSON.parse(tagsData);
+          if (Array.isArray(parsed)) {
+            metadata.tags = [...(metadata.tags ?? []), ...parsed.map(String)];
+          } else {
+            // Non-array JSON valid — fall back to comma split
+            metadata.tags = [
+              ...(metadata.tags ?? []),
+              ...tagsData.split(',').map((t: string) => t.trim()).filter((t: string) => t.length > 0),
+            ];
+          }
+        } catch {
+          metadata.tags = [
+            ...(metadata.tags ?? []),
+            ...tagsData.split(',').map((t: string) => t.trim()).filter((t: string) => t.length > 0),
+          ];
+        }
+        break;
+      }
+
+      case 'step-start':
+        metadata.currentStep = annotation.message.replace('Qase Step Start: ', '');
+        break;
+
+      case 'step-end':
+        if (metadata.currentStep) {
+          metadata.steps.push({ name: metadata.currentStep, status: 'end' });
+          delete metadata.currentStep;
+        }
+        break;
+
+      case 'step-failed':
+        if (metadata.currentStep) {
+          metadata.steps.push({ name: metadata.currentStep, status: 'failed' });
+          delete metadata.currentStep;
+        }
+        break;
+
+      case 'attachment': {
+        const attachmentName = annotation.message.replace('Qase Attachment: ', '');
+        const a = annotation.attachment;
+        const attachment: MetadataShape['attachments'][number] = { name: attachmentName };
+        if (a?.path) attachment.path = a.path;
+        if (a?.body !== undefined) {
+          attachment.content = typeof a.body === 'string'
+            ? a.body
+            : new TextDecoder().decode(a.body);
+        }
+        if (a?.contentType) attachment.contentType = a.contentType;
+        metadata.attachments.push(attachment);
+        break;
+      }
+    }
+  }
+
+  getMetadata(testId: string): MetadataShape | undefined {
+    return this.testMetadata.get(testId);
+  }
+
+  clearMetadata(testId: string): void {
+    this.testMetadata.delete(testId);
+  }
+
+  setCurrentSuite(name: string): void {
+    this.currentSuite = name;
+  }
+
+  clearCurrentSuite(): void {
+    this.currentSuite = undefined;
+  }
+
+  getCurrentSuite(): string | undefined {
+    return this.currentSuite;
+  }
+}

--- a/qase-vitest/src/modules/profilerTracker.ts
+++ b/qase-vitest/src/modules/profilerTracker.ts
@@ -1,0 +1,27 @@
+import { TestStepType } from 'qase-javascript-commons';
+import { NetworkProfiler } from 'qase-javascript-commons/profilers';
+
+export class ProfilerTracker {
+  private profiler: NetworkProfiler | null;
+  private snapshot = 0;
+
+  constructor(profiler: NetworkProfiler | null) {
+    this.profiler = profiler;
+  }
+
+  enable(): void {
+    this.profiler?.enable();
+  }
+
+  restore(): void {
+    this.profiler?.restore();
+  }
+
+  getNewSteps(): TestStepType[] {
+    if (!this.profiler) return [];
+    const all = this.profiler.getAllSteps();
+    const fresh = all.slice(this.snapshot);
+    this.snapshot = all.length;
+    return fresh;
+  }
+}

--- a/qase-vitest/src/modules/resultBuilder.ts
+++ b/qase-vitest/src/modules/resultBuilder.ts
@@ -1,0 +1,146 @@
+import type { TestCase } from 'vitest/node';
+import {
+  Attachment,
+  StepStatusEnum,
+  TestResultType,
+  TestStepType,
+  determineTestStatus,
+  parseProjectMappingFromTitle,
+} from 'qase-javascript-commons';
+import { extractAndCleanStep } from 'qase-javascript-commons/internal';
+import { MetadataShape } from './metadataAccumulator';
+
+export interface BuildArgs {
+  testCase: TestCase;
+  metadata: MetadataShape | undefined;
+  currentSuite: string | undefined;
+  profilerSteps: TestStepType[];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export class ResultBuilder {
+  static build(args: BuildArgs): TestResultType {
+    const { testCase, metadata, currentSuite, profilerSteps } = args;
+
+    const result = testCase.result();
+    const parsed = parseProjectMappingFromTitle(testCase.name);
+    const diagnostic = testCase.diagnostic();
+
+    const testTitle = metadata?.title ?? (parsed.cleanedTitle.replace(/\s+/g, ' ').trim() || testCase.name);
+    const testResult = new TestResultType(testTitle);
+    testResult.id = testCase.id;
+    testResult.signature = testCase.fullName;
+
+    const hasProjectMapping = Object.keys(parsed.projectMapping).length > 0;
+    if (hasProjectMapping) {
+      testResult.testops_project_mapping = parsed.projectMapping;
+      testResult.testops_id = null;
+    } else if (parsed.legacyIds.length > 0) {
+      testResult.testops_id = parsed.legacyIds.length === 1 ? (parsed.legacyIds[0] ?? null) : parsed.legacyIds;
+    } else {
+      testResult.testops_id = null;
+    }
+
+    const suiteToUse = metadata?.suite ?? currentSuite ?? ResultBuilder.extractSuiteFromTestCase(testCase);
+    if (suiteToUse) {
+      testResult.relations = { suite: { data: [] } };
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const suiteData = testResult.relations.suite!.data;
+      const suites = suiteToUse.split(' - ');
+      suites.forEach((suite) => {
+        suiteData.push({ title: suite.trim(), public_id: null });
+      });
+    }
+
+    testResult.execution.start_time = null;
+    testResult.execution.end_time = null;
+    testResult.execution.duration = Math.round(diagnostic?.duration ?? 0);
+
+    let error: Error | null = null;
+    if (result.errors && result.errors.length > 0) {
+      const firstError = result.errors[0];
+      if (firstError) {
+        error = new Error(firstError.message);
+        if (firstError.stack) {
+          error.stack = firstError.stack;
+        }
+      }
+
+      testResult.execution.stacktrace = result.errors.map((err) => {
+        return err.stack ?? err.message;
+      }).join('\n');
+      testResult.message = firstError ? firstError.message : 'Test failed';
+    }
+
+    testResult.execution.status = determineTestStatus(error, result.state);
+
+    if (result.state === 'skipped') {
+      testResult.message = result.note ?? null;
+    }
+
+    if (metadata) {
+      if (metadata.comment) {
+        testResult.message = metadata.comment;
+      }
+      if (metadata.fields) {
+        testResult.fields = metadata.fields;
+      }
+      if (metadata.parameters) {
+        testResult.params = metadata.parameters;
+      }
+      if (metadata.groupParameters) {
+        testResult.group_params = metadata.groupParameters;
+      }
+      if (metadata.tags && metadata.tags.length > 0) {
+        testResult.tags = metadata.tags;
+      }
+      if (metadata.steps.length > 0) {
+        testResult.steps = metadata.steps.map((step) => {
+          const stepObj = new TestStepType();
+          stepObj.id = Math.random().toString(36).substr(2, 9);
+          const stepData = extractAndCleanStep(step.name);
+          stepObj.data = {
+            action: stepData.cleanedString,
+            expected_result: stepData.expectedResult,
+            data: stepData.data,
+          };
+          stepObj.execution.status = step.status === 'failed' ? StepStatusEnum.failed : StepStatusEnum.passed;
+          return stepObj;
+        });
+      }
+      if (metadata.attachments.length > 0) {
+        testResult.attachments = metadata.attachments.map((attachment) => {
+          const attachmentModel: Attachment = {
+            file_name: attachment.name,
+            mime_type: attachment.contentType ?? 'application/octet-stream',
+            file_path: attachment.path ?? null,
+            content: attachment.content ?? '',
+            size: attachment.content ? Buffer.byteLength(attachment.content) : 0,
+            id: Math.random().toString(36).substr(2, 9),
+          };
+          return attachmentModel;
+        });
+      }
+    }
+
+    if (metadata?._profilerSteps) {
+      testResult.steps = [...testResult.steps, ...metadata._profilerSteps];
+    }
+
+    if (profilerSteps.length > 0) {
+      testResult.steps = [...testResult.steps, ...profilerSteps];
+    }
+
+    return testResult;
+  }
+
+  static extractSuiteFromTestCase(testCase: TestCase): string | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const fullName = testCase.fullName ?? testCase.name;
+    const parts = fullName.split(' > ');
+    if (parts.length > 1) {
+      return parts.slice(0, -1).join(' > ');
+    }
+    return undefined;
+  }
+}

--- a/qase-vitest/test/index.test.ts
+++ b/qase-vitest/test/index.test.ts
@@ -1,75 +1,49 @@
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+/* eslint-disable */
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { VitestQaseReporter } from '../src/index';
-import { parseProjectMappingFromTitle } from 'qase-javascript-commons';
+import VitestQaseReporterDefault from '../src/index';
 
-// Mock qase-javascript-commons (use real parseProjectMappingFromTitle and other utils)
+const reporterMock = {
+  startTestRun: jest.fn(),
+  publish: jest.fn().mockResolvedValue(undefined),
+  addTestResult: jest.fn().mockResolvedValue(undefined),
+};
+
 jest.mock('qase-javascript-commons', () => {
-  const actual = jest.requireActual('qase-javascript-commons') as typeof import('qase-javascript-commons');
+  const actual = jest.requireActual<typeof import('qase-javascript-commons')>('qase-javascript-commons');
   return {
     ...actual,
-    ConfigLoader: jest.fn().mockImplementation(() => ({
-      load: jest.fn().mockReturnValue(null),
-    })),
     QaseReporter: {
-    getInstance: jest.fn().mockReturnValue({
-      startTestRun: jest.fn(),
-      publish: jest.fn().mockResolvedValue(undefined),
-      addTestResult: jest.fn().mockResolvedValue(undefined),
+      getInstance: jest.fn(() => reporterMock),
+    },
+    composeOptions: jest.fn(() => ({})),
+    determineTestStatus: jest.fn((error: unknown, originalStatus: string) => {
+      if (error) return 'failed';
+      if (originalStatus === 'passed') return 'passed';
+      if (originalStatus === 'skipped') return 'skipped';
+      return 'failed';
     }),
-  },
-  TestResultType: jest.fn().mockImplementation(() => ({
-    id: '',
-    signature: '',
-    testops_id: null,
-    relations: null,
-    execution: {
-      status: 'passed',
-      start_time: null,
-      end_time: null,
-      duration: 0,
-    },
-    message: null,
-    fields: null,
-    params: null,
-    group_params: null,
-    steps: [],
-    attachments: [],
-  })),
-  TestStepType: jest.fn().mockImplementation(() => ({
-    id: '',
-    data: {
-      action: '',
-      expected_result: null,
-      data: null,
-    },
-    execution: {
-      status: 'passed',
-    },
-  })),
-  TestStatusEnum: {
-    passed: 'passed',
-    failed: 'failed',
-    skipped: 'skipped',
-  },
-  StepStatusEnum: {
-    passed: 'passed',
-    failed: 'failed',
-  },
-  composeOptions: jest.fn().mockReturnValue({}),
-  determineTestStatus: jest.fn((error, originalStatus) => {
-    if (error) return 'failed';
-    if (originalStatus === 'passed') return 'passed';
-    if (originalStatus === 'pending') return 'skipped';
-    if (originalStatus === 'skipped') return 'skipped';
-    return 'failed';
-  }),
+    ConfigLoader: jest.fn().mockImplementation(() => ({
+      load: jest.fn(() => null),
+    })),
   };
 });
 
-describe('VitestQaseReporter - Main scenarios', () => {
+const mkTestCase = (overrides: any = {}) => ({
+  name: 'Test',
+  id: 'test-id',
+  fullName: 'Suite > Test',
+  result: jest.fn().mockReturnValue({ state: 'passed', errors: [] }),
+  diagnostic: jest.fn().mockReturnValue({ duration: 100 }),
+  meta: jest.fn().mockReturnValue({}),
+  ...overrides,
+}) as any;
+
+describe('VitestQaseReporter', () => {
   let reporter: VitestQaseReporter;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     reporter = new VitestQaseReporter();
   });
 
@@ -77,375 +51,116 @@ describe('VitestQaseReporter - Main scenarios', () => {
     jest.clearAllMocks();
   });
 
-  describe('Config file loading', () => {
-    it('should accept custom configLoader and call load() on it', () => {
-      const mockConfigLoader = { load: jest.fn().mockReturnValue({ debug: true, mode: 'testops' }) };
+  describe('exports', () => {
+    it('VitestQaseReporter is the default export', () => {
+      expect(VitestQaseReporterDefault).toBe(VitestQaseReporter);
+    });
+  });
+
+  describe('constructor', () => {
+    it('initializes commons reporter with framework metadata', () => {
+      const { QaseReporter } = require('qase-javascript-commons');
+      expect(QaseReporter.getInstance).toHaveBeenCalledWith(expect.objectContaining({
+        frameworkPackage: 'vitest',
+        frameworkName: 'vitest',
+        reporterName: 'vitest-qase-reporter',
+      }));
+    });
+
+    it('accepts custom configLoader and calls load() on it', () => {
+      const mockConfigLoader = { load: jest.fn().mockReturnValue({ debug: true }) };
       const composeOptionsMock = jest.requireMock('qase-javascript-commons').composeOptions;
-
-      new VitestQaseReporter({}, mockConfigLoader);
-
+      new VitestQaseReporter({}, mockConfigLoader as any);
       expect(mockConfigLoader.load).toHaveBeenCalled();
-      expect(composeOptionsMock).toHaveBeenCalledWith({}, { debug: true, mode: 'testops' });
+      expect(composeOptionsMock).toHaveBeenCalledWith({}, { debug: true });
     });
 
-    it('should pass config from loader to composeOptions', () => {
-      const mockConfig = { debug: true, mode: 'testops', environment: 'test' };
-      const mockConfigLoader = { load: jest.fn().mockReturnValue(mockConfig) };
-      const composeOptionsMock = jest.requireMock('qase-javascript-commons').composeOptions;
-
-      const constructorOptions = { mode: 'off' };
-      new VitestQaseReporter(constructorOptions, mockConfigLoader);
-
-      expect(composeOptionsMock).toHaveBeenCalledWith(constructorOptions, mockConfig);
-    });
-
-    it('should handle null config from loader', () => {
+    it('passes constructor options to composeOptions', () => {
       const mockConfigLoader = { load: jest.fn().mockReturnValue(null) };
       const composeOptionsMock = jest.requireMock('qase-javascript-commons').composeOptions;
+      new VitestQaseReporter({ mode: 'off' } as any, mockConfigLoader as any);
+      expect(composeOptionsMock).toHaveBeenCalledWith({ mode: 'off' }, null);
+    });
 
-      new VitestQaseReporter({}, mockConfigLoader);
-
-      expect(mockConfigLoader.load).toHaveBeenCalled();
-      expect(composeOptionsMock).toHaveBeenCalledWith({}, null);
+    it('initializes metadataAccumulator and profilerTracker', () => {
+      expect((reporter as any).metadataAccumulator).toBeDefined();
+      expect((reporter as any).profilerTracker).toBeDefined();
     });
   });
 
-
-  describe('Extracting Qase ID from test name (parseProjectMappingFromTitle)', () => {
-    it('should extract single Qase ID', () => {
-      const title = 'Test Name (Qase ID: 123)';
-      const parsed = parseProjectMappingFromTitle(title);
-      expect(parsed.legacyIds).toEqual([123]);
-      expect(Object.keys(parsed.projectMapping)).toHaveLength(0);
-    });
-
-    it('should extract multiple Qase IDs', () => {
-      const title = 'Test Name (Qase ID: 123,456,789)';
-      const parsed = parseProjectMappingFromTitle(title);
-      expect(parsed.legacyIds).toEqual([123, 456, 789]);
-    });
-
-    it('should return empty array if Qase ID not found', () => {
-      const title = 'Test Name without Qase ID';
-      const parsed = parseProjectMappingFromTitle(title);
-      expect(parsed.legacyIds).toEqual([]);
-    });
-
-    it('should handle invalid Qase IDs', () => {
-      const title = 'Test Name (Qase ID: abc,def)';
-      const parsed = parseProjectMappingFromTitle(title);
-      expect(parsed.legacyIds).toEqual([]);
-    });
-
-    it('should extract multi-project mapping', () => {
-      const title = 'Test (Qase PROJ1: 100) (Qase PROJ2: 200)';
-      const parsed = parseProjectMappingFromTitle(title);
-      expect(parsed.legacyIds).toEqual([]);
-      expect(parsed.projectMapping).toEqual({ PROJ1: [100], PROJ2: [200] });
-      expect(parsed.cleanedTitle).toBe('Test');
+  describe('onTestRunStart', () => {
+    it('calls commons reporter.startTestRun', () => {
+      reporter.onTestRunStart?.();
+      expect(reporterMock.startTestRun).toHaveBeenCalled();
     });
   });
 
-  describe('Removing Qase ID from test name (parseProjectMappingFromTitle cleanedTitle)', () => {
-    it('should remove Qase ID from name', () => {
-      const title = 'Test Name (Qase ID: 123)';
-      const parsed = parseProjectMappingFromTitle(title);
-      expect(parsed.cleanedTitle).toBe('Test Name');
-    });
-
-    it('should remove multiple Qase IDs from name', () => {
-      const title = 'Test Name (Qase ID: 123,456,789)';
-      const parsed = parseProjectMappingFromTitle(title);
-      expect(parsed.cleanedTitle).toBe('Test Name');
-    });
-
-    it('should return original name if Qase ID not found', () => {
-      const title = 'Test Name without Qase ID';
-      const parsed = parseProjectMappingFromTitle(title);
-      expect(parsed.cleanedTitle).toBe(title);
-    });
-
-    it('should handle trailing spaces', () => {
-      const title = 'Test Name (Qase ID: 123)   ';
-      const parsed = parseProjectMappingFromTitle(title);
-      expect(parsed.cleanedTitle).toBe('Test Name');
+  describe('onTestRunEnd', () => {
+    it('awaits commons reporter.publish', async () => {
+      await reporter.onTestRunEnd?.();
+      expect(reporterMock.publish).toHaveBeenCalled();
     });
   });
 
-  describe('Creating test result', () => {
-    it('should create test result with basic information', () => {
-      const mockTestCase = {
-        name: 'Test Name (Qase ID: 123)',
-        id: 'test-id',
-        fullName: 'Suite > Test Name (Qase ID: 123)',
-        result: jest.fn().mockReturnValue({
-          state: 'passed',
-          errors: [],
-        }),
-        diagnostic: jest.fn().mockReturnValue({
-          startTime: 1000,
-          duration: 500,
-        }),
-      };
-      
-      const result = reporter['createTestResult'](mockTestCase as any);
-      
-      expect(result.id).toBe('test-id');
-      expect(result.signature).toBe('Suite > Test Name (Qase ID: 123)');
-      expect(result.testops_id).toBe(123);
-      expect(result.execution.status).toBe('passed');
-      expect(result.execution.start_time).toBe(null);
-      expect(result.execution.end_time).toBe(null);
-      expect(result.execution.duration).toBe(500);
-    });
-
-    it('should handle test without Qase ID', () => {
-      const mockTestCase = {
-        name: 'Test Name without Qase ID',
-        id: 'test-id',
-        fullName: 'Suite > Test Name without Qase ID',
-        result: jest.fn().mockReturnValue({
-          state: 'passed',
-          errors: [],
-        }),
-        diagnostic: jest.fn().mockReturnValue({
-          startTime: 1000,
-          duration: 500,
-        }),
-      };
-      
-      const result = reporter['createTestResult'](mockTestCase as any);
-      
-      expect(result.testops_id).toBeNull();
-      expect(result.signature).toBe('Suite > Test Name without Qase ID');
-    });
-
-    it('should handle test with multiple Qase IDs', () => {
-      const mockTestCase = {
-        name: 'Test Name (Qase ID: 123,456)',
-        id: 'test-id',
-        fullName: 'Suite > Test Name (Qase ID: 123,456)',
-        result: jest.fn().mockReturnValue({
-          state: 'passed',
-          errors: [],
-        }),
-        diagnostic: jest.fn().mockReturnValue({
-          startTime: 1000,
-          duration: 500,
-        }),
-      };
-      
-      const result = reporter['createTestResult'](mockTestCase as any);
-      
-      expect(result.testops_id).toEqual([123, 456]);
-    });
-
-    it('should handle test with errors', () => {
-      const error = new Error('Test failed');
-      error.stack = 'Error stack trace';
-      const mockTestCase = {
-        name: 'Test Name (Qase ID: 123)',
-        id: 'test-id',
-        fullName: 'Suite > Test Name (Qase ID: 123)',
-        result: jest.fn().mockReturnValue({
-          state: 'failed',
-          errors: [error],
-        }),
-        diagnostic: jest.fn().mockReturnValue({
-          startTime: 1000,
-          duration: 500,
-        }),
-      };
-      
-      const result = reporter['createTestResult'](mockTestCase as any);
-      
-      expect(result.execution.status).toBe('failed');
-      expect(result.execution.stacktrace).toContain('Error stack trace');
-      expect(result.message).toBe('Test failed');
-    });
-
-    it('should handle skipped test with note', () => {
-      const mockTestCase = {
-        name: 'Test Name (Qase ID: 123)',
-        id: 'test-id',
-        fullName: 'Suite > Test Name (Qase ID: 123)',
-        result: jest.fn().mockReturnValue({
-          state: 'skipped',
-          note: 'Test skipped due to condition',
-        }),
-        diagnostic: jest.fn().mockReturnValue({
-          startTime: 1000,
-          duration: 500,
-        }),
-      };
-      
-      const result = reporter['createTestResult'](mockTestCase as any);
-      
-      expect(result.execution.status).toBe('skipped');
-      expect(result.message).toBe('Test skipped due to condition');
+  describe('onTestCaseAnnotate', () => {
+    it('forwards annotations to MetadataAccumulator', () => {
+      const tc = mkTestCase();
+      reporter.onTestCaseAnnotate?.(tc, { message: 'Qase Title: From Annotation' } as any);
+      const m = (reporter as any).metadataAccumulator.getMetadata('test-id');
+      expect(m?.title).toBe('From Annotation');
     });
   });
 
-  describe('Annotation processing', () => {
-    it('should process title annotation', () => {
-      const mockTestCase = {
-        id: 'test-id',
-        name: 'Test Name',
-      };
-      const mockAnnotation = {
-        message: 'Qase Title: Test Title',
-      };
-
-      reporter.onTestCaseAnnotate?.(mockTestCase as any, mockAnnotation as any);
-      
-      const metadata = reporter['testMetadata'].get('test-id');
-      expect(metadata?.title).toBe('Test Title');
-    });
-
-    it('should process comment annotation', () => {
-      const mockTestCase = {
-        id: 'test-id',
-        name: 'Test Name',
-      };
-      const mockAnnotation = {
-        message: 'Qase Comment: Test Comment',
-      };
-
-      reporter.onTestCaseAnnotate?.(mockTestCase as any, mockAnnotation as any);
-      
-      const metadata = reporter['testMetadata'].get('test-id');
-      expect(metadata?.comment).toBe('Test Comment');
-    });
-
-    it('should process suite annotation', () => {
-      const mockTestCase = {
-        id: 'test-id',
-        name: 'Test Name',
-      };
-      const mockAnnotation = {
-        message: 'Qase Suite: Test Suite',
-      };
-
-      reporter.onTestCaseAnnotate?.(mockTestCase as any, mockAnnotation as any);
-      
-      const metadata = reporter['testMetadata'].get('test-id');
-      expect(metadata?.suite).toBe('Test Suite');
-    });
-
-    it('should process fields annotation', () => {
-      const mockTestCase = {
-        id: 'test-id',
-        name: 'Test Name',
-      };
-      const mockAnnotation = {
-        message: 'Qase Fields: {"field1":"value1","field2":"value2"}',
-      };
-
-      reporter.onTestCaseAnnotate?.(mockTestCase as any, mockAnnotation as any);
-      
-      const metadata = reporter['testMetadata'].get('test-id');
-      expect(metadata?.fields).toEqual({ field1: 'value1', field2: 'value2' });
-    });
-
-    it('should process parameters annotation', () => {
-      const mockTestCase = {
-        id: 'test-id',
-        name: 'Test Name',
-      };
-      const mockAnnotation = {
-        message: 'Qase Parameters: {"param1":"value1"}',
-      };
-
-      reporter.onTestCaseAnnotate?.(mockTestCase as any, mockAnnotation as any);
-      
-      const metadata = reporter['testMetadata'].get('test-id');
-      expect(metadata?.parameters).toEqual({ param1: 'value1' });
-    });
-
-    it('should ignore non-Qase annotations', () => {
-      const mockTestCase = {
-        id: 'test-id',
-        name: 'Test Name',
-      };
-      const mockAnnotation = {
-        message: 'Regular annotation message',
-      };
-
-      reporter.onTestCaseAnnotate?.(mockTestCase as any, mockAnnotation as any);
-      
-      const metadata = reporter['testMetadata'].get('test-id');
-      expect(metadata).toEqual({ steps: [], attachments: [] });
+  describe('onTestSuiteReady / onTestSuiteResult', () => {
+    it('sets and clears currentSuite via MetadataAccumulator', () => {
+      reporter.onTestSuiteReady?.({ name: 'My Suite' } as any);
+      expect((reporter as any).metadataAccumulator.getCurrentSuite()).toBe('My Suite');
+      reporter.onTestSuiteResult?.();
+      expect((reporter as any).metadataAccumulator.getCurrentSuite()).toBeUndefined();
     });
   });
 
-  describe('Suite extraction', () => {
-    it('should extract suite from fullName with separator', () => {
-      const testCase = {
-        fullName: 'Suite Name > Test Name',
-        name: 'Test Name',
-      };
-      
-      const result = reporter['extractSuiteFromTestCase'](testCase as any);
-      
-      expect(result).toBe('Suite Name');
+  describe('onTestCaseResult', () => {
+    it('forwards a built result to commons reporter.addTestResult', async () => {
+      const tc = mkTestCase({ name: 'Test (Qase ID: 42)' });
+      await reporter.onTestCaseResult?.(tc);
+      expect(reporterMock.addTestResult).toHaveBeenCalled();
+      const call = (reporterMock.addTestResult.mock.calls[0] as any[])[0];
+      expect(call.testops_id).toBe(42);
+      expect(call.execution.status).toBe('passed');
     });
 
-    it('should extract suite from fullName with multiple separators', () => {
-      const testCase = {
-        fullName: 'Parent Suite > Child Suite > Test Name',
-        name: 'Test Name',
-      };
-      
-      const result = reporter['extractSuiteFromTestCase'](testCase as any);
-      
-      expect(result).toBe('Parent Suite > Child Suite');
+    it('applies metadata.title from annotation', async () => {
+      const tc = mkTestCase({ name: 'Test (Qase ID: 1)' });
+      reporter.onTestCaseAnnotate?.(tc, { message: 'Qase Title: Override' } as any);
+      await reporter.onTestCaseResult?.(tc);
+      const call = (reporterMock.addTestResult.mock.calls[0] as any[])[0];
+      expect(call.title).toBe('Override');
     });
 
-    it('should return undefined if separator not found', () => {
-      const testCase = {
-        fullName: 'Test Name',
-        name: 'Test Name',
-      };
-      
-      const result = reporter['extractSuiteFromTestCase'](testCase as any);
-      
-      expect(result).toBeUndefined();
+    it('clears metadata after processing the test case', async () => {
+      const tc = mkTestCase();
+      reporter.onTestCaseAnnotate?.(tc, { message: 'Qase Title: x' } as any);
+      await reporter.onTestCaseResult?.(tc);
+      const m = (reporter as any).metadataAccumulator.getMetadata('test-id');
+      expect(m).toBeUndefined();
     });
 
-    it('should use name if fullName not available', () => {
-      const testCase = {
-        name: 'Suite Name > Test Name',
-      };
-      
-      const result = reporter['extractSuiteFromTestCase'](testCase as any);
-      
-      expect(result).toBe('Suite Name');
-    });
-  });
-
-  describe('Reporter lifecycle', () => {
-    it('should have onTestRunStart method', () => {
-      expect(typeof reporter.onTestRunStart).toBe('function');
+    it('appends worker profiler steps from testCase.meta()._qaseProfilerSteps', async () => {
+      const profilerSteps = [{ id: 'worker-step-1' }];
+      const tc = mkTestCase({
+        meta: jest.fn().mockReturnValue({ _qaseProfilerSteps: JSON.stringify(profilerSteps) }),
+      });
+      await reporter.onTestCaseResult?.(tc);
+      const call = (reporterMock.addTestResult.mock.calls[0] as any[])[0];
+      expect(call.steps.length).toBeGreaterThan(0);
     });
 
-    it('should have onTestRunEnd method', () => {
-      expect(typeof reporter.onTestRunEnd).toBe('function');
-    });
-
-    it('should have onTestCaseResult method', () => {
-      expect(typeof reporter.onTestCaseResult).toBe('function');
-    });
-
-    it('should have onTestCaseAnnotate method', () => {
-      expect(typeof reporter.onTestCaseAnnotate).toBe('function');
-    });
-
-    it('should have onTestSuiteReady method', () => {
-      expect(typeof reporter.onTestSuiteReady).toBe('function');
-    });
-
-    it('should have onTestSuiteResult method', () => {
-      expect(typeof reporter.onTestSuiteResult).toBe('function');
+    it('silently swallows malformed worker profiler steps JSON', async () => {
+      const tc = mkTestCase({
+        meta: jest.fn().mockReturnValue({ _qaseProfilerSteps: 'not-json' }),
+      });
+      await expect(reporter.onTestCaseResult?.(tc)).resolves.not.toThrow();
     });
   });
 });

--- a/qase-vitest/test/metadataAccumulator.test.ts
+++ b/qase-vitest/test/metadataAccumulator.test.ts
@@ -1,0 +1,188 @@
+/* eslint-disable */
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { MetadataAccumulator } from '../src/modules/metadataAccumulator';
+
+const mkAnnotation = (message: string, attachment?: any) => ({
+  message,
+  attachment,
+}) as any;
+
+describe('MetadataAccumulator.parseAnnotation', () => {
+  let acc: MetadataAccumulator;
+
+  beforeEach(() => {
+    acc = new MetadataAccumulator();
+  });
+
+  it('lazily initializes metadata entry on first annotation', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Title: My Title'));
+    const m = acc.getMetadata('t1');
+    expect(m).toBeDefined();
+    expect(m!.title).toBe('My Title');
+    expect(m!.steps).toEqual([]);
+    expect(m!.attachments).toEqual([]);
+  });
+
+  it('parses Qase Title annotation', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Title: New Title'));
+    expect(acc.getMetadata('t1')!.title).toBe('New Title');
+  });
+
+  it('parses Qase Comment annotation', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Comment: A note'));
+    expect(acc.getMetadata('t1')!.comment).toBe('A note');
+  });
+
+  it('parses Qase Suite annotation', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Suite: My Suite'));
+    expect(acc.getMetadata('t1')!.suite).toBe('My Suite');
+  });
+
+  it('parses Qase Fields annotation as JSON', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Fields: {"severity":"critical"}'));
+    expect(acc.getMetadata('t1')!.fields).toEqual({ severity: 'critical' });
+  });
+
+  it('parses Qase Parameters annotation', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Parameters: {"env":"prod","port":8080}'));
+    expect(acc.getMetadata('t1')!.parameters).toEqual({ env: 'prod', port: '8080' });
+  });
+
+  it('parses Qase Group Parameters annotation', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Group Parameters: {"region":"eu"}'));
+    expect(acc.getMetadata('t1')!.groupParameters).toEqual({ region: 'eu' });
+  });
+
+  it('parses Qase Tags annotation as JSON array', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Tags: ["smoke","p0"]'));
+    expect(acc.getMetadata('t1')!.tags).toEqual(['smoke', 'p0']);
+  });
+
+  it('falls back on Qase Tags when JSON parse fails', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Tags: smoke, p0,p1'));
+    expect(acc.getMetadata('t1')!.tags).toEqual(['smoke', 'p0', 'p1']);
+  });
+
+  it('appends tags across multiple annotations', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Tags: ["a"]'));
+    acc.parseAnnotation('t1', mkAnnotation('Qase Tags: ["b","c"]'));
+    expect(acc.getMetadata('t1')!.tags).toEqual(['a', 'b', 'c']);
+  });
+
+  it('Qase Step Start sets currentStep but does not push', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Step Start: do thing'));
+    const m = acc.getMetadata('t1')!;
+    expect(m.currentStep).toBe('do thing');
+    expect(m.steps).toEqual([]);
+  });
+
+  it('Qase Step End pushes step and clears currentStep', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Step Start: do thing'));
+    acc.parseAnnotation('t1', mkAnnotation('Qase Step End: do thing'));
+    const m = acc.getMetadata('t1')!;
+    expect(m.steps).toEqual([{ name: 'do thing', status: 'end' }]);
+    expect(m.currentStep).toBeUndefined();
+  });
+
+  it('Qase Step Failed pushes failed step and clears currentStep', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Step Start: risky'));
+    acc.parseAnnotation('t1', mkAnnotation('Qase Step Failed: risky - boom'));
+    const m = acc.getMetadata('t1')!;
+    expect(m.steps).toEqual([{ name: 'risky', status: 'failed' }]);
+    expect(m.currentStep).toBeUndefined();
+  });
+
+  it('Qase Step End without prior Step Start is a no-op', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Step End: nothing'));
+    expect(acc.getMetadata('t1')!.steps).toEqual([]);
+  });
+
+  it('Qase Attachment with path stores path metadata', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Attachment: file.txt', {
+      path: '/tmp/file.txt',
+      contentType: 'text/plain',
+    }));
+    const m = acc.getMetadata('t1')!;
+    expect(m.attachments).toEqual([
+      { name: 'file.txt', path: '/tmp/file.txt', contentType: 'text/plain' },
+    ]);
+  });
+
+  it('Qase Attachment with body string stores content', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Attachment: data.json', {
+      body: '{"a":1}',
+      contentType: 'application/json',
+    }));
+    const m = acc.getMetadata('t1')!;
+    expect(m.attachments[0]).toEqual({
+      name: 'data.json',
+      content: '{"a":1}',
+      contentType: 'application/json',
+    });
+  });
+
+  it('Qase Profiler Steps annotation stores parsed steps on _profilerSteps', () => {
+    const steps = [{ id: 'step-1', data: { action: 'fetch' } }];
+    acc.parseAnnotation('t1', mkAnnotation(`Qase Profiler Steps: ${JSON.stringify(steps)}`));
+    const m = acc.getMetadata('t1')! as any;
+    expect(m._profilerSteps).toEqual(steps);
+  });
+
+  it('Qase Profiler Steps with malformed JSON is silently swallowed', () => {
+    expect(() =>
+      acc.parseAnnotation('t1', mkAnnotation('Qase Profiler Steps: not-json')),
+    ).not.toThrow();
+    const m = acc.getMetadata('t1')! as any;
+    expect(m._profilerSteps).toBeUndefined();
+  });
+
+  it('non-Qase annotation is ignored', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Some other annotation'));
+    expect(acc.getMetadata('t1')).toBeUndefined();
+  });
+
+  it('Qase Fields with malformed JSON does not throw', () => {
+    expect(() =>
+      acc.parseAnnotation('t1', mkAnnotation('Qase Fields: not-json')),
+    ).not.toThrow();
+    expect(acc.getMetadata('t1')!.fields).toBeUndefined();
+  });
+});
+
+describe('MetadataAccumulator state lifecycle', () => {
+  let acc: MetadataAccumulator;
+
+  beforeEach(() => {
+    acc = new MetadataAccumulator();
+  });
+
+  it('getMetadata returns undefined before any annotation', () => {
+    expect(acc.getMetadata('t1')).toBeUndefined();
+  });
+
+  it('clearMetadata removes the entry for a test', () => {
+    acc.parseAnnotation('t1', mkAnnotation('Qase Title: x'));
+    expect(acc.getMetadata('t1')).toBeDefined();
+    acc.clearMetadata('t1');
+    expect(acc.getMetadata('t1')).toBeUndefined();
+  });
+
+  it('clearMetadata of an unknown test is a no-op', () => {
+    expect(() => acc.clearMetadata('unknown')).not.toThrow();
+  });
+
+  it('setCurrentSuite stores the suite name', () => {
+    acc.setCurrentSuite('My Suite');
+    expect(acc.getCurrentSuite()).toBe('My Suite');
+  });
+
+  it('clearCurrentSuite resets to undefined', () => {
+    acc.setCurrentSuite('My Suite');
+    acc.clearCurrentSuite();
+    expect(acc.getCurrentSuite()).toBeUndefined();
+  });
+
+  it('getCurrentSuite returns undefined initially', () => {
+    expect(acc.getCurrentSuite()).toBeUndefined();
+  });
+});

--- a/qase-vitest/test/profilerTracker.test.ts
+++ b/qase-vitest/test/profilerTracker.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable */
+import { describe, it, expect } from '@jest/globals';
+import { ProfilerTracker } from '../src/modules/profilerTracker';
+
+describe('ProfilerTracker', () => {
+  it('returns [] from getNewSteps when profiler is null', () => {
+    const tracker = new ProfilerTracker(null);
+    expect(tracker.getNewSteps()).toEqual([]);
+  });
+
+  it('enable and restore are no-ops when profiler is null', () => {
+    const tracker = new ProfilerTracker(null);
+    expect(() => tracker.enable()).not.toThrow();
+    expect(() => tracker.restore()).not.toThrow();
+  });
+
+  it('enable delegates to profiler.enable', () => {
+    const profiler: any = { enable: jest.fn(), getAllSteps: () => [], restore: jest.fn() };
+    const tracker = new ProfilerTracker(profiler);
+    tracker.enable();
+    expect(profiler.enable).toHaveBeenCalledTimes(1);
+  });
+
+  it('restore delegates to profiler.restore', () => {
+    const profiler: any = { enable: jest.fn(), getAllSteps: () => [], restore: jest.fn() };
+    const tracker = new ProfilerTracker(profiler);
+    tracker.restore();
+    expect(profiler.restore).toHaveBeenCalledTimes(1);
+  });
+
+  it('getNewSteps returns only steps appended since last call', () => {
+    const allSteps: any[] = [];
+    const profiler: any = {
+      enable: jest.fn(),
+      restore: jest.fn(),
+      getAllSteps: () => allSteps,
+    };
+    const tracker = new ProfilerTracker(profiler);
+
+    expect(tracker.getNewSteps()).toEqual([]);
+    allSteps.push({ id: 's1' }, { id: 's2' });
+    expect(tracker.getNewSteps()).toEqual([{ id: 's1' }, { id: 's2' }]);
+    allSteps.push({ id: 's3' });
+    expect(tracker.getNewSteps()).toEqual([{ id: 's3' }]);
+    expect(tracker.getNewSteps()).toEqual([]);
+  });
+});

--- a/qase-vitest/test/resultBuilder.test.ts
+++ b/qase-vitest/test/resultBuilder.test.ts
@@ -1,0 +1,274 @@
+/* eslint-disable */
+import { describe, it, expect } from '@jest/globals';
+import { ResultBuilder } from '../src/modules/resultBuilder';
+import type { MetadataShape } from '../src/modules/metadataAccumulator';
+
+jest.mock('qase-javascript-commons', () => {
+  const actual = jest.requireActual<typeof import('qase-javascript-commons')>('qase-javascript-commons');
+  return {
+    ...actual,
+    determineTestStatus: jest.fn((error: unknown, originalStatus: string) => {
+      if (error) return 'failed';
+      if (originalStatus === 'passed') return 'passed';
+      if (originalStatus === 'skipped') return 'skipped';
+      return 'failed';
+    }),
+  };
+});
+
+const mkTestCase = (overrides: any = {}) => ({
+  name: 'Test',
+  id: 'test-id',
+  fullName: 'Suite > Test',
+  result: jest.fn().mockReturnValue({ state: 'passed', errors: [] }),
+  diagnostic: jest.fn().mockReturnValue({ duration: 100 }),
+  ...overrides,
+}) as any;
+
+const emptyMeta = (): MetadataShape => ({
+  steps: [],
+  attachments: [],
+});
+
+describe('ResultBuilder.build', () => {
+  it('builds a passed result with default execution shape', () => {
+    const result = ResultBuilder.build({
+      testCase: mkTestCase(),
+      metadata: undefined,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.execution.status).toBe('passed');
+    expect(result.execution.start_time).toBeNull();
+    expect(result.execution.end_time).toBeNull();
+    expect(result.execution.duration).toBe(100);
+    expect(result.id).toBe('test-id');
+    expect(result.signature).toBe('Suite > Test');
+    expect(result.steps).toEqual([]);
+  });
+
+  it('extracts single legacy id from name (Qase ID: 123)', () => {
+    const result = ResultBuilder.build({
+      testCase: mkTestCase({ name: 'Test (Qase ID: 123)', fullName: 'Suite > Test (Qase ID: 123)' }),
+      metadata: undefined,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.testops_id).toBe(123);
+    expect(result.title).toBe('Test');
+  });
+
+  it('extracts multiple legacy ids', () => {
+    const result = ResultBuilder.build({
+      testCase: mkTestCase({ name: 'Test (Qase ID: 1,2,3)' }),
+      metadata: undefined,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.testops_id).toEqual([1, 2, 3]);
+  });
+
+  it('uses projectMapping when (Qase PROJ: N) markers are present', () => {
+    const result = ResultBuilder.build({
+      testCase: mkTestCase({ name: 'Test (Qase PROJ1: 100) (Qase PROJ2: 200)' }),
+      metadata: undefined,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.testops_id).toBeNull();
+    expect(result.testops_project_mapping).toEqual({ PROJ1: [100], PROJ2: [200] });
+    expect(result.title).toBe('Test');
+  });
+
+  it('uses metadata.title when provided', () => {
+    const meta = emptyMeta();
+    meta.title = 'Override Title';
+    const result = ResultBuilder.build({
+      testCase: mkTestCase(),
+      metadata: meta,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.title).toBe('Override Title');
+  });
+
+  it('maps failed result with errors to status=failed and stacktrace', () => {
+    const error = new Error('boom');
+    error.stack = 'STACK';
+    const result = ResultBuilder.build({
+      testCase: mkTestCase({
+        result: jest.fn().mockReturnValue({ state: 'failed', errors: [error] }),
+      }),
+      metadata: undefined,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.execution.status).toBe('failed');
+    expect(result.execution.stacktrace).toContain('STACK');
+    expect(result.message).toBe('boom');
+  });
+
+  it('maps skipped result with note to status=skipped and message=note', () => {
+    const result = ResultBuilder.build({
+      testCase: mkTestCase({
+        result: jest.fn().mockReturnValue({ state: 'skipped', note: 'cond fail', errors: [] }),
+      }),
+      metadata: undefined,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.execution.status).toBe('skipped');
+    expect(result.message).toBe('cond fail');
+  });
+
+  it('uses metadata.suite for relations when present', () => {
+    const meta = emptyMeta();
+    meta.suite = 'My Suite - Sub';
+    const result = ResultBuilder.build({
+      testCase: mkTestCase(),
+      metadata: meta,
+      currentSuite: 'CurrentSuite',
+      profilerSteps: [],
+    });
+    expect(result.relations).toEqual({
+      suite: { data: [
+        { title: 'My Suite', public_id: null },
+        { title: 'Sub', public_id: null },
+      ] },
+    });
+  });
+
+  it('falls back to currentSuite when metadata.suite missing', () => {
+    const result = ResultBuilder.build({
+      testCase: mkTestCase(),
+      metadata: undefined,
+      currentSuite: 'OuterSuite',
+      profilerSteps: [],
+    });
+    expect(result.relations?.suite?.data?.[0]?.title).toBe('OuterSuite');
+  });
+
+  it('falls back to extractSuiteFromTestCase when no metadata.suite and no currentSuite', () => {
+    const result = ResultBuilder.build({
+      testCase: mkTestCase({ fullName: 'Outer > Inner > Test', name: 'Test' }),
+      metadata: undefined,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    const titles = result.relations?.suite?.data?.map((d: any) => d.title);
+    expect(titles).toEqual(['Outer > Inner']);
+  });
+
+  it('applies metadata.fields/parameters/groupParameters/tags', () => {
+    const meta = emptyMeta();
+    meta.fields = { severity: 'major' };
+    meta.parameters = { env: 'prod' };
+    meta.groupParameters = { region: 'eu' };
+    meta.tags = ['smoke'];
+    const result = ResultBuilder.build({
+      testCase: mkTestCase(),
+      metadata: meta,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.fields).toEqual({ severity: 'major' });
+    expect(result.params).toEqual({ env: 'prod' });
+    expect(result.group_params).toEqual({ region: 'eu' });
+    expect(result.tags).toEqual(['smoke']);
+  });
+
+  it('applies metadata.comment as message', () => {
+    const meta = emptyMeta();
+    meta.comment = 'Override comment';
+    const result = ResultBuilder.build({
+      testCase: mkTestCase(),
+      metadata: meta,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.message).toBe('Override comment');
+  });
+
+  it('builds steps from metadata.steps with extractAndCleanStep applied', () => {
+    const meta = emptyMeta();
+    meta.steps = [
+      { name: 'do thing QaseExpRes: ok', status: 'end' },
+      { name: 'failed step', status: 'failed' },
+    ];
+    const result = ResultBuilder.build({
+      testCase: mkTestCase(),
+      metadata: meta,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.steps.length).toBe(2);
+    expect(result.steps[0]?.execution?.status).toBe('passed');
+    expect(result.steps[1]?.execution?.status).toBe('failed');
+  });
+
+  it('builds attachments from metadata.attachments', () => {
+    const meta = emptyMeta();
+    meta.attachments = [
+      { name: 'a.txt', content: 'hello', contentType: 'text/plain' },
+      { name: 'b.bin', path: '/tmp/b.bin' },
+    ];
+    const result = ResultBuilder.build({
+      testCase: mkTestCase(),
+      metadata: meta,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.attachments.length).toBe(2);
+    expect(result.attachments[0]?.file_name).toBe('a.txt');
+    expect(result.attachments[0]?.mime_type).toBe('text/plain');
+    expect(result.attachments[1]?.file_path).toBe('/tmp/b.bin');
+    expect(result.attachments[1]?.mime_type).toBe('application/octet-stream');
+  });
+
+  it('appends metadata._profilerSteps when present', () => {
+    const meta = emptyMeta();
+    (meta as any)._profilerSteps = [{ id: 'meta-prof-1' }];
+    const result = ResultBuilder.build({
+      testCase: mkTestCase(),
+      metadata: meta,
+      currentSuite: undefined,
+      profilerSteps: [],
+    });
+    expect(result.steps).toEqual([{ id: 'meta-prof-1' }]);
+  });
+
+  it('appends profilerSteps argument after metadata steps', () => {
+    const meta = emptyMeta();
+    meta.steps = [{ name: 'manual', status: 'end' }];
+    const result = ResultBuilder.build({
+      testCase: mkTestCase(),
+      metadata: meta,
+      currentSuite: undefined,
+      profilerSteps: [{ id: 'prof-1' } as any],
+    });
+    expect(result.steps.length).toBe(2);
+    expect(result.steps[1]).toEqual({ id: 'prof-1' });
+  });
+});
+
+describe('ResultBuilder.extractSuiteFromTestCase', () => {
+  it('extracts suite from "Suite > Test" format', () => {
+    const tc = mkTestCase({ fullName: 'Outer > Test' });
+    expect(ResultBuilder.extractSuiteFromTestCase(tc)).toBe('Outer');
+  });
+
+  it('extracts multi-level suite from "A > B > Test" format', () => {
+    const tc = mkTestCase({ fullName: 'A > B > Test' });
+    expect(ResultBuilder.extractSuiteFromTestCase(tc)).toBe('A > B');
+  });
+
+  it('returns undefined when no suite separator', () => {
+    const tc = mkTestCase({ fullName: 'JustATest', name: 'JustATest' });
+    expect(ResultBuilder.extractSuiteFromTestCase(tc)).toBeUndefined();
+  });
+
+  it('falls back to testCase.name when fullName missing', () => {
+    const tc = { name: 'OnlyName' } as any;
+    expect(ResultBuilder.extractSuiteFromTestCase(tc)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Decompose `qase-vitest/src/index.ts` (451 → 99 LOC, ~78% reduction) into a thin orchestrator + 3 modules (`MetadataAccumulator`, `ProfilerTracker`, `ResultBuilder`) under `src/modules/`. Phase 2 pattern, **9th and final reporter** (after wdio / playwright / cypress / mocha / cucumberjs / testcafe / jest / newman).
- Existing tests rewritten for new wiring (orchestration-focused); ~50 new per-module tests added (76 total).
- Bump `vitest-qase-reporter` 1.3.0 → 1.4.0; public contract preserved (default + named export, 6 lifecycle hooks, ctor signature, `VitestQaseOptionsType`).
- Removed `static qaseIdRegExp` (deprecated since Phase 1; mocha/cypress/jest precedent).

## Test plan

- [ ] CI green on `refactor/vitest-decomposition`.
- [x] `cd qase-vitest && npx jest` — 76 tests pass locally.
- [x] Workspace `npm run build --workspaces --if-present` and `npm run lint --workspaces --if-present` clean (0 errors).
- [x] Smoke `QASE_MODE=testops` against DEVX project — run #820 received 25/28 results: https://app.qase.io/run/DEVX/dashboard/820 (3 results silent-dropped per known V2 batch backend bug).

## Design

- Spec: `docs/superpowers/specs/2026-05-04-vitest-decomposition-design.md` (not committed).
- Plan: `docs/superpowers/plans/2026-05-04-vitest-decomposition.md` (not committed).