### PR TITLE
fix(integration-tests): align jest expected severity with example fixes

### DIFF
--- a/expected/jest-examples.yaml
+++ b/expected/jest-examples.yaml
@@ -167,7 +167,7 @@ results:
   status: passed
   fields:
     layer: api
-    severity: low
+    severity: minor
     priority: low
   relations:
     suite:
@@ -227,7 +227,7 @@ results:
   status: failed
   fields:
     layer: api
-    severity: low
+    severity: minor
     priority: low
   relations:
     suite:


### PR DESCRIPTION
## Summary

Fixes Integration tests failure on tag-publish runs (visible in #25315111618, #25308518111, #25207108994).

The validator step `Validate Jest reporter` was failing with:
\`\`\`
Data validation errors:
    fields.severity: expected 'low', got 'minor'
\`\`\`

Cause: I previously updated \`examples/single/jest/test/api-errors.test.js\` and \`api-advanced.test.js\` from \`severity: 'low'\` → \`'minor'\` (PR #958, jest decomposition smoke fix) because V2 TestOps API rejects \`'low'\` (only accepts \`blocker|critical|major|normal|minor|trivial\`). But \`expected/jest-examples.yaml\` still pinned the old value, so the report-mode validator failed.

This patch updates the two expected severity values to \`'minor'\` to match the example.

## Test plan

- [ ] Integration tests step "Validate Jest reporter" passes on this branch.
- [x] Other reporters (mocha, vitest, playwright, cypress) unaffected — their expected severity values match their example values.