### PR TITLE
chore: enforce npm min-release-age to mitigate supply chain attacks

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_ENGINE_STRICT: 'false'
     strategy:
       max-parallel: 5
       matrix:
@@ -24,9 +26,7 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install -g npm@latest
-      env:
-        npm_config_engine_strict: 'false'
+    - run: npm install npm@latest
     - run: npm ci
     - run: npm run build -ws --if-present
     - run: npm run lint -w ${{ matrix.prefix }}
@@ -35,15 +35,15 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     needs: test
+    env:
+      NPM_CONFIG_ENGINE_STRICT: 'false'
     name: Integration tests
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
         node-version: '22'
-    - run: npm install -g npm@latest
-      env:
-        npm_config_engine_strict: 'false'
+    - run: npm install npm@latest
     - run: npm ci
     - run: npm run build -ws --if-present
 
@@ -143,6 +143,8 @@ jobs:
   build-n-publish:
     runs-on: ubuntu-latest
     needs: test
+    env:
+      NPM_CONFIG_ENGINE_STRICT: 'false'
     strategy:
       max-parallel: 5
       matrix:
@@ -159,9 +161,7 @@ jobs:
     
     - name: Update npm
       if: contains(github.event.ref, matrix.prefix)
-      run: npm install -g npm@latest
-      env:
-        npm_config_engine_strict: 'false'
+      run: npm install npm@latest
 
     - name: Install dependencies
       if: contains(github.event.ref, matrix.prefix)

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -24,7 +24,9 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install npm@latest    
+    - run: npm install npm@latest
+      env:
+        npm_config_engine_strict: 'false'
     - run: npm ci
     - run: npm run build -ws --if-present
     - run: npm run lint -w ${{ matrix.prefix }}
@@ -40,6 +42,8 @@ jobs:
       with:
         node-version: '22'
     - run: npm install npm@latest
+      env:
+        npm_config_engine_strict: 'false'
     - run: npm ci
     - run: npm run build -ws --if-present
 
@@ -156,6 +160,8 @@ jobs:
     - name: Update npm
       if: contains(github.event.ref, matrix.prefix)
       run: npm install npm@latest
+      env:
+        npm_config_engine_strict: 'false'
 
     - name: Install dependencies
       if: contains(github.event.ref, matrix.prefix)

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install npm@latest
+    - run: npm install -g npm@latest
       env:
         npm_config_engine_strict: 'false'
     - run: npm ci
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: '22'
-    - run: npm install npm@latest
+    - run: npm install -g npm@latest
       env:
         npm_config_engine_strict: 'false'
     - run: npm ci
@@ -159,7 +159,7 @@ jobs:
     
     - name: Update npm
       if: contains(github.event.ref, matrix.prefix)
-      run: npm install npm@latest
+      run: npm install -g npm@latest
       env:
         npm_config_engine_strict: 'false'
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+save=true
+save-exact=true
+engine-strict=true
+min-release-age=3

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "git+https://github.com/qase-tms/qase-javascript.git"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=14",
+    "npm": ">=11.5.1"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Add `.npmrc` with `min-release-age=3` so npm refuses to install package versions released less than 3 days ago — defense against the recent wave of npm supply chain attacks via freshly published malicious versions.
- Require `npm >=11.5.1` in `engines` (first version that supports `min-release-age`) so the existing `engine-strict=true` prevents older npm clients from silently ignoring the setting.
- Add `npm_config_engine_strict=false` env to the CI `npm install npm@latest` steps so the default npm shipped with Node 22 can self-upgrade past engine-strict before normal install steps run.

## Test plan
- [ ] CI runs green on this branch (test matrix on Node 22 & 24, integration tests, no publish step triggers without a tag)
- [ ] Verify locally that `npm install` with a fresh package newer than 3 days fails / older one succeeds (optional)