### PR TITLE
fix(examples/jest): correct severity field in expected report

### DIFF
--- a/expected/jest-examples.yaml
+++ b/expected/jest-examples.yaml
@@ -167,7 +167,7 @@ results:
   status: passed
   fields:
     layer: api
-    severity: low
+    severity: minor
     priority: low
   relations:
     suite:
@@ -227,7 +227,7 @@ results:
   status: failed
   fields:
     layer: api
-    severity: low
+    severity: minor
     priority: low
   relations:
     suite:


### PR DESCRIPTION
## Summary
- Two entries in `expected/jest-examples.yaml` set `severity: low`, but `low` is a priority value — not in the qase severity vocabulary (`blocker`, `critical`, `major`, `normal`, `minor`, `trivial`).
- The test sources (`api-errors.test.js`, `api-advanced.test.js`) already declare `severity: 'minor'`.
- Align the expected report so `reporters-validator` stops flagging `fields.severity: expected 'low', got 'minor'` on the Integration tests job.

## Test plan
- [ ] CI integration job for the Jest reporter passes without severity validation errors.