### PR TITLE
fix: align result execution timings with Qase API spec across reporters

### DIFF
--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,10 @@
+# cucumberjs-qase-reporter@2.4.1
+
+## Fixed
+
+- Gherkin step `execution.start_time` and `execution.end_time` are now populated from the Cucumber `testStepStarted` / `testStepFinished` envelope timestamps (Unix seconds with fractional ms). Previously both fields were hardcoded to `null`, breaking timeline rendering on the Qase side.
+- Step `execution.duration` now includes the `nanos` part of the Cucumber duration. Previously only `seconds * 1000` was emitted, so any sub-second step was reported as 0 ms.
+
 # cucumberjs-qase-reporter@2.4.0
 
 ## Changed

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",

--- a/qase-cucumberjs/src/modules/eventStorage.ts
+++ b/qase-cucumberjs/src/modules/eventStorage.ts
@@ -4,6 +4,7 @@ import {
   Pickle,
   TestCaseStarted,
   TestStepFinished,
+  TestStepStarted,
 } from '@cucumber/messages';
 import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
 import { Attachment } from 'qase-javascript-commons';
@@ -13,6 +14,7 @@ import { ScenarioData } from '../models';
 export class EventStorage {
   private pickles: Record<string, Pickle> = {};
   private testCaseStarts: Record<string, TestCaseStarted> = {};
+  private testStepStarted: Record<string, TestStepStarted> = {};
   private testStepFinished: Record<string, TestStepFinished> = {};
   private testCases: Record<string, TestCase> = {};
   private scenarios: Record<string, ScenarioData> = {};
@@ -75,6 +77,10 @@ export class EventStorage {
     this.testCaseStarts[testCaseStarted.id] = testCaseStarted;
   }
 
+  addTestStepStarted(step: TestStepStarted): void {
+    this.testStepStarted[step.testStepId] = step;
+  }
+
   addTestStepFinished(step: TestStepFinished): void {
     this.testStepFinished[step.testStepId] = step;
   }
@@ -105,6 +111,10 @@ export class EventStorage {
 
   getAllTestStepFinished(): Map<string, TestStepFinished> {
     return new Map(Object.entries(this.testStepFinished));
+  }
+
+  getAllTestStepStarted(): Map<string, TestStepStarted> {
+    return new Map(Object.entries(this.testStepStarted));
   }
 
   private appendAttachment(key: string, attachment: Attach): void {

--- a/qase-cucumberjs/src/modules/stepConverter.ts
+++ b/qase-cucumberjs/src/modules/stepConverter.ts
@@ -1,4 +1,4 @@
-import { PickleStep, TestStepFinished } from '@cucumber/messages';
+import { PickleStep, TestStepFinished, TestStepStarted, Timestamp } from '@cucumber/messages';
 import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
 import { Attachment, StepType, TestStepType } from 'qase-javascript-commons';
 import { STEP_STATUS_MAP } from './statusMaps';
@@ -7,6 +7,7 @@ export class StepConverter {
   static convert(
     pickleSteps: readonly PickleStep[],
     testCase: TestCase,
+    startedSteps: Map<string, TestStepStarted>,
     finishedSteps: Map<string, TestStepFinished>,
     getAttachments: (stepId: string) => Attachment[],
   ): TestStepType[] {
@@ -19,6 +20,10 @@ export class StepConverter {
       const step = pickleSteps.find((ps) => ps.id === s.pickleStepId);
       if (!step) continue;
 
+      const started = startedSteps.get(s.id);
+      const startTimeSec = started ? StepConverter.toSeconds(started.timestamp) : null;
+      const endTimeSec = StepConverter.toSeconds(finished.timestamp);
+
       results.push({
         id: s.id,
         step_type: StepType.GHERKIN,
@@ -29,9 +34,10 @@ export class StepConverter {
         },
         execution: {
           status: STEP_STATUS_MAP[finished.testStepResult.status],
-          start_time: null,
-          end_time: null,
-          duration: finished.testStepResult.duration.seconds * 1000,
+          start_time: startTimeSec,
+          end_time: endTimeSec,
+          duration: finished.testStepResult.duration.seconds * 1000
+            + Math.round(finished.testStepResult.duration.nanos / 1e6),
         },
         attachments: getAttachments(s.id),
         steps: [],
@@ -40,5 +46,13 @@ export class StepConverter {
     }
 
     return results;
+  }
+
+  /**
+   * Cucumber `Timestamp` is `{ seconds, nanos }`. Convert to a Unix-seconds
+   * number with fractional milliseconds.
+   */
+  private static toSeconds(ts: Timestamp): number {
+    return ts.seconds + ts.nanos / 1e9;
   }
 }

--- a/qase-cucumberjs/src/reporter.ts
+++ b/qase-cucumberjs/src/reporter.ts
@@ -96,6 +96,8 @@ export class CucumberQaseReporter extends Formatter {
         this.storage.addTestCase(envelope.testCase);
       } else if (envelope.testCaseStarted) {
         this.storage.addTestCaseStarted(envelope.testCaseStarted);
+      } else if (envelope.testStepStarted) {
+        this.storage.addTestCaseStepStarted(envelope.testStepStarted);
       } else if (envelope.testStepFinished) {
         this.storage.addTestCaseStep(envelope.testStepFinished);
       } else if (envelope.testCaseFinished) {

--- a/qase-cucumberjs/src/storage.ts
+++ b/qase-cucumberjs/src/storage.ts
@@ -5,6 +5,7 @@ import {
   TestCaseFinished,
   TestCaseStarted,
   TestStepFinished,
+  TestStepStarted,
 } from '@cucumber/messages';
 import {
   StepStatusEnum,
@@ -59,6 +60,10 @@ export class Storage {
     this.profilerTracker.onTestStart(testCaseStarted.id);
   }
 
+  public addTestCaseStepStarted(testCaseStepStarted: TestStepStarted): void {
+    this.events.addTestStepStarted(testCaseStepStarted);
+  }
+
   public addTestCaseStep(testCaseStep: TestStepFinished): void {
     this.events.addTestStepFinished(testCaseStep);
     this.statusTracker.applyStep(testCaseStep);
@@ -96,6 +101,7 @@ export class Storage {
     const steps = StepConverter.convert(
       pickle.steps,
       tc,
+      this.events.getAllTestStepStarted(),
       this.events.getAllTestStepFinished(),
       (stepId) => this.events.getAttachments(stepId),
     );

--- a/qase-cucumberjs/test/stepConverter.test.ts
+++ b/qase-cucumberjs/test/stepConverter.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import { describe, expect, it } from '@jest/globals';
 import { Status } from '@cucumber/cucumber';
-import { PickleStep, TestStepFinished } from '@cucumber/messages';
+import { PickleStep, TestStepFinished, TestStepStarted } from '@cucumber/messages';
 import { StepStatusEnum, StepType } from 'qase-javascript-commons';
 import { TestCase } from '@cucumber/messages/dist/esm/src/messages';
 import { StepConverter } from '../src/modules/stepConverter';
@@ -10,16 +10,27 @@ function pickleStep(id: string, text: string): PickleStep {
   return { id, text, astNodeIds: [], type: 'Action' } as unknown as PickleStep;
 }
 
-function finished(stepId: string, status: any, durationSec = 1): TestStepFinished {
+function finished(stepId: string, status: any, durationSec = 1, durationNanos = 0, finishedAtSec = 0, finishedAtNanos = 0): TestStepFinished {
   return {
     testStepId: stepId,
     testCaseStartedId: 'tcs1',
     testStepResult: {
       status,
-      duration: { seconds: durationSec, nanos: 0 },
+      duration: { seconds: durationSec, nanos: durationNanos },
     },
+    timestamp: { seconds: finishedAtSec, nanos: finishedAtNanos },
   } as unknown as TestStepFinished;
 }
+
+function started(stepId: string, startedAtSec = 0, startedAtNanos = 0): TestStepStarted {
+  return {
+    testStepId: stepId,
+    testCaseStartedId: 'tcs1',
+    timestamp: { seconds: startedAtSec, nanos: startedAtNanos },
+  } as unknown as TestStepStarted;
+}
+
+const emptyStarted = new Map<string, TestStepStarted>();
 
 describe('StepConverter', () => {
   it('converts a passed step', () => {
@@ -29,12 +40,41 @@ describe('StepConverter', () => {
       ['s1', finished('s1', Status.PASSED)],
     ]);
 
-    const out = StepConverter.convert(pickleSteps, tc, finishedMap, () => []);
+    const out = StepConverter.convert(pickleSteps, tc, emptyStarted, finishedMap, () => []);
     expect(out).toHaveLength(1);
     expect(out[0]?.step_type).toBe(StepType.GHERKIN);
     expect(out[0]?.execution.status).toBe(StepStatusEnum.passed);
     expect(out[0]?.execution.duration).toBe(1000);
     expect((out[0]?.data as any).keyword).toBe('Given a thing');
+  });
+
+  it('emits start_time/end_time from TestStepStarted/Finished timestamps', () => {
+    const pickleSteps = [pickleStep('p-step1', 'Given a thing')];
+    const tc = { id: 'tc1', testSteps: [{ id: 's1', pickleStepId: 'p-step1' }] } as unknown as TestCase;
+    const startedMap = new Map<string, TestStepStarted>([
+      ['s1', started('s1', 1_700_000_000, 250_000_000)],
+    ]);
+    const finishedMap = new Map<string, TestStepFinished>([
+      ['s1', finished('s1', Status.PASSED, 0, 500_000_000, 1_700_000_000, 750_000_000)],
+    ]);
+
+    const out = StepConverter.convert(pickleSteps, tc, startedMap, finishedMap, () => []);
+    expect(out[0]?.execution.start_time).toBeCloseTo(1_700_000_000.25, 6);
+    expect(out[0]?.execution.end_time).toBeCloseTo(1_700_000_000.75, 6);
+    // duration: 0 sec + 500_000_000 ns = 500 ms
+    expect(out[0]?.execution.duration).toBe(500);
+  });
+
+  it('leaves start_time null if no TestStepStarted event was recorded', () => {
+    const pickleSteps = [pickleStep('p-step1', 'Step')];
+    const tc = { id: 'tc1', testSteps: [{ id: 's1', pickleStepId: 'p-step1' }] } as unknown as TestCase;
+    const finishedMap = new Map<string, TestStepFinished>([
+      ['s1', finished('s1', Status.PASSED, 0, 0, 1_700_000_001, 0)],
+    ]);
+
+    const out = StepConverter.convert(pickleSteps, tc, emptyStarted, finishedMap, () => []);
+    expect(out[0]?.execution.start_time).toBeNull();
+    expect(out[0]?.execution.end_time).toBe(1_700_000_001);
   });
 
   it('skips test steps with no finished entry', () => {
@@ -47,7 +87,7 @@ describe('StepConverter', () => {
       ['s1', finished('s1', Status.PASSED)],
     ]);
 
-    const out = StepConverter.convert(pickleSteps, tc, finishedMap, () => []);
+    const out = StepConverter.convert(pickleSteps, tc, emptyStarted, finishedMap, () => []);
     expect(out).toHaveLength(1);
   });
 
@@ -61,7 +101,7 @@ describe('StepConverter', () => {
       ['s1', finished('s1', Status.PASSED)],
     ]);
 
-    const out = StepConverter.convert(pickleSteps, tc, finishedMap, () => []);
+    const out = StepConverter.convert(pickleSteps, tc, emptyStarted, finishedMap, () => []);
     expect(out).toHaveLength(0);
   });
 
@@ -73,7 +113,7 @@ describe('StepConverter', () => {
     ]);
     const attach = { file_name: 'log.txt', mime_type: 'text/plain', content: 'x', file_path: null, size: 0, id: 'a1' };
 
-    const out = StepConverter.convert(pickleSteps, tc, finishedMap, (id) => id === 's1' ? [attach] : []);
+    const out = StepConverter.convert(pickleSteps, tc, emptyStarted, finishedMap, (id) => id === 's1' ? [attach] : []);
     expect(out[0]?.attachments).toEqual([attach]);
   });
 
@@ -84,7 +124,7 @@ describe('StepConverter', () => {
       ['s1', finished('s1', Status.FAILED)],
     ]);
 
-    const out = StepConverter.convert(pickleSteps, tc, finishedMap, () => []);
+    const out = StepConverter.convert(pickleSteps, tc, emptyStarted, finishedMap, () => []);
     expect(out[0]?.execution.status).toBe(StepStatusEnum.failed);
   });
 });

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,13 @@
+# cypress-qase-reporter@3.6.2
+
+## Bug fixes
+
+- `qase.step()` steps no longer pre-fill `execution.end_time` with `Date.now()` at the moment the START event arrives; `end_time` now stays `null` until the matching END event is received. Previously a step that timed out or crashed before its END event was emitted ended up with a bogus `end_time` equal to the test start, schrinking the visible step on the Qase timeline to zero.
+- `qase.step()` steps now populate `execution.duration` (ms) on completion (previously left `null`).
+- Cypress and Cucumber step `execution.start_time` / `end_time` are now emitted in Unix seconds (with fractional ms) instead of raw `Date.now()` milliseconds. Previously these values were ~55 years in the future on Qase timelines.
+- Network-request steps captured via `cy.intercept` now set `execution.end_time` (derived from `start_time + duration`); previously only `start_time` and `duration` were populated.
+- HTTP/fetch profiler steps (via `qase-javascript-commons@2.7.1`) now emit `start_time` / `end_time` in Unix seconds instead of milliseconds.
+
 # cypress-qase-reporter@3.6.1
 
 ## Bug fixes

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-cypress/src/result-builder.ts
+++ b/qase-cypress/src/result-builder.ts
@@ -127,7 +127,11 @@ export class ResultBuilder {
         step.execution.status = req.statusCode !== null && req.statusCode >= 400
           ? StepStatusEnum.failed
           : StepStatusEnum.passed;
+        // req.startTime is ms-since-epoch, req.duration is elapsed ms.
+        // Qase API expects start_time/end_time in Unix seconds (with fractional ms)
+        // and duration in milliseconds.
         step.execution.start_time = req.startTime / 1000;
+        step.execution.end_time = (req.startTime + req.duration) / 1000;
         step.execution.duration = req.duration;
         steps.push(step);
       }

--- a/qase-cypress/src/step-converter.ts
+++ b/qase-cypress/src/step-converter.ts
@@ -15,7 +15,9 @@ export class StepConverter {
       const step = new TestStepType(StepType.TEXT);
       step.id = message.id;
       step.execution.status = StepStatusEnum.passed;
-      step.execution.start_time = message.timestamp;
+      // timestamps from cypress metadata are ms-since-epoch; Qase API expects
+      // start_time/end_time in Unix seconds (with fractional ms).
+      step.execution.start_time = message.timestamp / 1000;
       step.data = {
         action: message.name,
         expected_result: null,
@@ -35,14 +37,22 @@ export class StepConverter {
   getSteps(steps: (StepStart | StepEnd)[], attachments: Record<string, Attachment[]>): TestStepType[] {
     const result: TestStepType[] = [];
     const stepMap = new Map<string, TestStepType>();
+    const startMsById = new Map<string, number>();
 
     for (const step of steps.sort((a, b) => a.timestamp - b.timestamp)) {
       if (!('status' in step)) {
         const newStep = new TestStepType();
         newStep.id = step.id;
+        // Status starts as `failed` and is overwritten when the matching END
+        // event arrives. If no END is ever received (timeout/crash), the step
+        // remains failed which preserves the original intent.
         newStep.execution.status = StepStatusEnum.failed;
-        newStep.execution.start_time = step.timestamp;
-        newStep.execution.end_time = Date.now();
+        // timestamps are ms-since-epoch; API expects Unix seconds.
+        newStep.execution.start_time = step.timestamp / 1000;
+        // end_time stays null until the matching END event arrives — do NOT
+        // pre-fill with Date.now(), that produces a fake end time that sticks
+        // around if the step never finishes.
+        newStep.execution.end_time = null;
         newStep.data = {
           action: step.name,
           expected_result: null,
@@ -67,11 +77,16 @@ export class StepConverter {
         }
 
         stepMap.set(step.id, newStep);
+        startMsById.set(step.id, step.timestamp);
       } else {
         const stepType = stepMap.get(step.id);
         if (stepType) {
           stepType.execution.status = step.status as StepStatusEnum;
-          stepType.execution.end_time = step.timestamp;
+          stepType.execution.end_time = step.timestamp / 1000;
+          const startMs = startMsById.get(step.id);
+          if (startMs !== undefined) {
+            stepType.execution.duration = step.timestamp - startMs;
+          }
         }
       }
     }

--- a/qase-cypress/test/step-converter.test.ts
+++ b/qase-cypress/test/step-converter.test.ts
@@ -26,7 +26,8 @@ describe('StepConverter', () => {
       expect(result[0]?.id).toBe('s1');
       expect(result[0]?.data.action).toBe('click');
       expect(result[0]?.execution.status).toBe(StepStatusEnum.passed);
-      expect(result[0]?.execution.start_time).toBe(100);
+      // timestamps are stored as ms-since-epoch in metadata; converter emits Unix seconds.
+      expect(result[0]?.execution.start_time).toBe(0.1);
     });
 
     it('marks the LAST step failed when test status is not passed', () => {
@@ -54,7 +55,20 @@ describe('StepConverter', () => {
       expect(result).toHaveLength(1);
       expect(result[0]?.id).toBe('s1');
       expect(result[0]?.execution.status).toBe(StepStatusEnum.passed);
-      expect(result[0]?.execution.end_time).toBe(200);
+      // start/end emitted in Unix seconds; duration in ms (end_ms - start_ms).
+      expect(result[0]?.execution.start_time).toBe(0.1);
+      expect(result[0]?.execution.end_time).toBe(0.2);
+      expect(result[0]?.execution.duration).toBe(100);
+    });
+
+    it('leaves end_time null when no StepEnd arrives for a step', () => {
+      const messages: (StepStart | StepEnd)[] = [
+        { id: 's1', name: 'orphan-start', timestamp: 100 } as StepStart,
+      ];
+      const result = converter.getSteps(messages, {});
+      expect(result[0]?.execution.start_time).toBe(0.1);
+      expect(result[0]?.execution.end_time).toBeNull();
+      expect(result[0]?.execution.status).toBe(StepStatusEnum.failed);
     });
 
     it('nests a child under its parent via parentId', () => {

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+## 2.7.1
+
+### Fixed
+- HTTP/fetch profiler steps now emit `execution.start_time` and `execution.end_time` as Unix epoch seconds (with fractional ms), matching the Qase API contract. Previously the interceptor wrote `Date.now()` milliseconds directly into both fields, placing every captured request step ~55 years in the future on the timeline. `execution.duration` remains in milliseconds.
+- `ReportReporter` test-run summary (`report.execution.start_time` / `end_time` in the generated JSON report) is now emitted in Unix seconds instead of milliseconds; this aligns the report-mode file with the v2 API spec consumed by `reporters-validator`.
+
 ## 2.7.0
 
 ### Added

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -3,6 +3,7 @@
 ### Fixed
 - HTTP/fetch profiler steps now emit `execution.start_time` and `execution.end_time` as Unix epoch seconds (with fractional ms), matching the Qase API contract. Previously the interceptor wrote `Date.now()` milliseconds directly into both fields, placing every captured request step ~55 years in the future on the timeline. `execution.duration` remains in milliseconds.
 - `ReportReporter` test-run summary (`report.execution.start_time` / `end_time` in the generated JSON report) is now emitted in Unix seconds instead of milliseconds; this aligns the report-mode file with the v2 API spec consumed by `reporters-validator`.
+- `QaseStep.run` (the shared user-facing `qase.step()` API used by Jest, Vitest, WebdriverIO and TestCafe) now emits `execution.start_time` / `end_time` in Unix seconds instead of raw `Date.now()` milliseconds, and populates `execution.duration` (ms). Previously every `qase.step()` call landed ~55 years in the future on the timeline and reported `null` duration.
 
 ## 2.7.0
 

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/profilers/http-interceptor.ts
+++ b/qase-javascript-commons/src/profilers/http-interceptor.ts
@@ -100,6 +100,13 @@ export function headersToRecord(
 
 // ─── Utility: buildRequestStep ───────────────────────────────────────────────
 
+/**
+ * Builds a REQUEST-type step from raw timing data.
+ *
+ * `startTime` / `endTime` are expected as `Date.now()` values (ms since epoch).
+ * They are normalized to Unix seconds (with fractional ms) for `step.execution.start_time` /
+ * `end_time` per Qase API spec; `duration` stays in ms.
+ */
 export function buildRequestStep(params: {
   method: string;
   url: string;
@@ -121,8 +128,8 @@ export function buildRequestStep(params: {
   data.response_body = params.responseBody;
   data.response_headers = params.responseHeaders;
 
-  step.execution.start_time = params.startTime;
-  step.execution.end_time = params.endTime;
+  step.execution.start_time = params.startTime / 1000;
+  step.execution.end_time = params.endTime / 1000;
   step.execution.duration = params.endTime - params.startTime;
   step.execution.status = params.statusCode >= 400 ? StepStatusEnum.failed : StepStatusEnum.passed;
 

--- a/qase-javascript-commons/src/reporters/report-reporter.ts
+++ b/qase-javascript-commons/src/reporters/report-reporter.ts
@@ -103,12 +103,13 @@ export class ReportReporter extends AbstractReporter {
   }
 
   public async complete(): Promise<void> {
+    const endTime = Date.now();
     const report: Report = {
       title: 'Test run',
       execution: {
-        start_time: this.startTime,
-        end_time: Date.now(),
-        duration: Date.now() - this.startTime,
+        start_time: this.startTime / 1000,
+        end_time: endTime / 1000,
+        duration: endTime - this.startTime,
         cumulative_duration: 0,
       },
       stats: {

--- a/qase-javascript-commons/src/steps/step.ts
+++ b/qase-javascript-commons/src/steps/step.ts
@@ -65,7 +65,7 @@ export class QaseStep {
   }
 
   async run(body: StepFunction, messageEmitter: (step: TestStepType) => Promise<void>): Promise<void> {
-    const startDate = new Date().getTime();
+    const startMs = Date.now();
     const step = new TestStepType();
     step.data = {
       action: this.name,
@@ -73,27 +73,26 @@ export class QaseStep {
       data: null,
     };
 
+    // Per Qase API spec: start_time / end_time are Unix epoch seconds (with
+    // fractional ms); duration is milliseconds.
+    const buildExecution = (status: StepStatusEnum, endMs: number) => ({
+      start_time: startMs / 1000,
+      end_time: endMs / 1000,
+      status,
+      duration: endMs - startMs,
+    });
+
     try {
       await body.call(this, this);
 
-      step.execution = {
-        start_time: startDate,
-        end_time: new Date().getTime(),
-        status: StepStatusEnum.passed,
-        duration: null,
-      };
+      step.execution = buildExecution(StepStatusEnum.passed, Date.now());
 
       step.attachments = this.attachments;
       step.steps = this.steps;
 
       await messageEmitter(step);
     } catch (error: unknown) {
-      step.execution = {
-        start_time: startDate,
-        end_time: new Date().getTime(),
-        status: StepStatusEnum.failed,
-        duration: null,
-      };
+      step.execution = buildExecution(StepStatusEnum.failed, Date.now());
 
       step.attachments = this.attachments;
       step.steps = this.steps;

--- a/qase-javascript-commons/test/profilers/http-interceptor.test.ts
+++ b/qase-javascript-commons/test/profilers/http-interceptor.test.ts
@@ -161,6 +161,27 @@ describe('HttpInterceptor', () => {
     expect((step!.execution.duration as number) >= 0).toBe(true);
   });
 
+  it('emits start_time/end_time as Unix seconds and duration in ms', async () => {
+    interceptor.install();
+    const steps: TestStepType[] = [];
+    const nowSecBefore = Date.now() / 1000;
+    await store.run(steps, async () => {
+      await makeRequest('/ok');
+    });
+    const nowSecAfter = Date.now() / 1000;
+    expect(steps).toHaveLength(1);
+    const exec = steps[0]!.execution;
+    const start = exec.start_time as number;
+    const end = exec.end_time as number;
+    const duration = exec.duration as number;
+    // start/end must be Unix seconds (~1e9-1e10), not ms (~1e12)
+    expect(start).toBeGreaterThan(nowSecBefore - 1);
+    expect(end).toBeLessThan(nowSecAfter + 1);
+    expect(end).toBeGreaterThanOrEqual(start);
+    // duration is in ms (delta), bounded by elapsed wall time in ms
+    expect(duration).toBeLessThanOrEqual(Math.ceil((nowSecAfter - nowSecBefore) * 1000) + 1);
+  });
+
   it('response with status 200 has response_body: null', async () => {
     interceptor.install();
     const steps: TestStepType[] = [];

--- a/qase-jest/changelog.md
+++ b/qase-jest/changelog.md
@@ -2,8 +2,12 @@
 
 ## Fixed
 
-- `execution.start_time` and `execution.end_time` are now populated for every test result. Jest's `AssertionResult` only exposes an elapsed `duration`, so we anchor `end_time` to `Date.now()` at the moment of the `onTestCaseResult` callback and derive `start_time = end_time - duration`. Timeline rendering on the Qase side no longer falls back to ingestion timestamps. Units: `start_time` / `end_time` in Unix seconds (with fractional ms), `duration` in milliseconds.
+- `execution.start_time` and `execution.end_time` are now populated using Jest's `onTestCaseStart` hook (Jest 29+). The reporter records `TestCaseStartInfo.startedAt` per test in `onTestCaseStart` and derives `end_time = start_time + duration` in `onTestCaseResult`. Previously both fields were left `null`, so the Qase timeline fell back to ingestion timestamps. Units: `start_time` / `end_time` in Unix seconds (with fractional ms), `duration` in milliseconds.
 - HTTP/fetch profiler steps (via `qase-javascript-commons@2.7.1`) now emit `start_time` / `end_time` in Unix seconds instead of milliseconds.
+
+## Added
+
+- `onTestCaseStart` lifecycle hook implementation. The hook is optional in the Jest reporter contract, and the public API surface of `JestQaseReporter` is unchanged otherwise.
 
 # jest-qase-reporter@2.5.0
 

--- a/qase-jest/changelog.md
+++ b/qase-jest/changelog.md
@@ -1,3 +1,10 @@
+# jest-qase-reporter@2.5.1
+
+## Fixed
+
+- `execution.start_time` and `execution.end_time` are now populated for every test result. Jest's `AssertionResult` only exposes an elapsed `duration`, so we anchor `end_time` to `Date.now()` at the moment of the `onTestCaseResult` callback and derive `start_time = end_time - duration`. Timeline rendering on the Qase side no longer falls back to ingestion timestamps. Units: `start_time` / `end_time` in Unix seconds (with fractional ms), `duration` in milliseconds.
+- HTTP/fetch profiler steps (via `qase-javascript-commons@2.7.1`) now emit `start_time` / `end_time` in Unix seconds instead of milliseconds.
+
 # jest-qase-reporter@2.5.0
 
 ## Changed

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-qase-reporter",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Qase TMS Jest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-jest/src/modules/resultBuilder.ts
+++ b/qase-jest/src/modules/resultBuilder.ts
@@ -52,14 +52,22 @@ export class ResultBuilder {
 
     const testStatus = determineTestStatus(error ?? null, value.status);
 
+    // Jest's AssertionResult does not expose absolute test start/end timestamps,
+    // only an elapsed `duration` (ms). Approximate the absolute window relative
+    // to the moment we observed the result; the reporter callback delay is the
+    // only loss of precision, typically negligible on a real test run.
+    const durationMs = value.duration ?? 0;
+    const endTimeMs = Date.now();
+    const startTimeMs = endTimeMs - durationMs;
+
     const result: TestResultType = {
       attachments: [],
       author: null,
       execution: {
         status: testStatus,
-        start_time: null,
-        end_time: null,
-        duration: value.duration ?? 0,
+        start_time: startTimeMs / 1000,
+        end_time: endTimeMs / 1000,
+        duration: durationMs,
         stacktrace: error?.stack ?? null,
         thread: null,
       },

--- a/qase-jest/src/modules/resultBuilder.ts
+++ b/qase-jest/src/modules/resultBuilder.ts
@@ -24,13 +24,19 @@ export interface ResultBuilderArgs {
   path: string;
   metadata: Metadata;
   profilerSteps: TestStepType[];
+  /**
+   * Test start time in ms since epoch, captured in the `onTestCaseStart`
+   * reporter hook (Jest 29+). `null` if the hook didn't fire — happens for
+   * pending/todo specs Jest reports only at file-completion time.
+   */
+  startTimeMs?: number | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class ResultBuilder {
 
   static build(args: ResultBuilderArgs): TestResultType {
-    const { value, path, metadata, profilerSteps } = args;
+    const { value, path, metadata, profilerSteps, startTimeMs = null } = args;
 
     let error: Error | undefined;
     if (value.status === 'failed') {
@@ -52,21 +58,21 @@ export class ResultBuilder {
 
     const testStatus = determineTestStatus(error ?? null, value.status);
 
-    // Jest's AssertionResult does not expose absolute test start/end timestamps,
-    // only an elapsed `duration` (ms). Approximate the absolute window relative
-    // to the moment we observed the result; the reporter callback delay is the
-    // only loss of precision, typically negligible on a real test run.
+    // `startTimeMs` is captured in `onTestCaseStart` from Jest's
+    // `TestCaseStartInfo.startedAt`. When available, end_time is derived as
+    // start + duration. When missing (older Jest, todo/pending specs that
+    // skip the start hook), both fields are left null rather than guessed.
     const durationMs = value.duration ?? 0;
-    const endTimeMs = Date.now();
-    const startTimeMs = endTimeMs - durationMs;
+    const startTimeSec = startTimeMs !== null ? startTimeMs / 1000 : null;
+    const endTimeSec = startTimeMs !== null ? (startTimeMs + durationMs) / 1000 : null;
 
     const result: TestResultType = {
       attachments: [],
       author: null,
       execution: {
         status: testStatus,
-        start_time: startTimeMs / 1000,
-        end_time: endTimeMs / 1000,
+        start_time: startTimeSec,
+        end_time: endTimeSec,
         duration: durationMs,
         stacktrace: error?.stack ?? null,
         thread: null,

--- a/qase-jest/src/reporter.ts
+++ b/qase-jest/src/reporter.ts
@@ -1,5 +1,6 @@
 import { Config, Reporter, Test, TestResult } from '@jest/reporters';
 import { Status, TestCaseResult } from '@jest/test-result';
+import type { Circus } from '@jest/types';
 
 import {
   Attachment,
@@ -39,6 +40,10 @@ export class JestQaseReporter implements Reporter {
   private reporter: ReporterInterface;
   private profilerTracker: ProfilerTracker;
   private metadataApplier: MetadataApplier;
+  // Map keyed by `${test.path}::${fullName}` → ms-since-epoch when the test
+  // actually started executing. Populated in `onTestCaseStart` (Jest 29+),
+  // consumed in `onTestCaseResult`, then evicted.
+  private testCaseStartTimes: Map<string, number> = new Map();
 
   public constructor(
     _: Config.GlobalConfig,
@@ -74,21 +79,38 @@ export class JestQaseReporter implements Reporter {
     this.profilerTracker.enable();
   }
 
+  public onTestCaseStart(test: Test, testCaseStartInfo: Circus.TestCaseStartInfo) {
+    const startedAt = testCaseStartInfo.startedAt ?? Date.now();
+    this.testCaseStartTimes.set(
+      JestQaseReporter.startTimeKey(test.path, testCaseStartInfo.fullName),
+      startedAt,
+    );
+  }
+
   public onTestCaseResult(test: Test, testCaseResult: TestCaseResult) {
     if (this.metadataApplier.get().ignore) {
       this.metadataApplier.reset();
       return;
     }
 
+    const key = JestQaseReporter.startTimeKey(test.path, testCaseResult.fullName);
+    const startTimeMs = this.testCaseStartTimes.get(key) ?? null;
+    this.testCaseStartTimes.delete(key);
+
     const result = ResultBuilder.build({
       value: testCaseResult,
       path: test.path,
       metadata: this.metadataApplier.get(),
       profilerSteps: this.profilerTracker.getNewSteps(),
+      startTimeMs,
     });
 
     this.metadataApplier.reset();
     void this.reporter.addTestResult(result);
+  }
+
+  private static startTimeKey(path: string, fullName: string): string {
+    return `${path}::${fullName}`;
   }
 
   public onTestResult(_: Test, result: TestResult) {

--- a/qase-jest/test/reporter.test.ts
+++ b/qase-jest/test/reporter.test.ts
@@ -106,6 +106,21 @@ describe('JestQaseReporter', () => {
       expect(call.execution.duration).toBe(1000);
     });
 
+    it('uses startedAt from onTestCaseStart to compute start/end_time', () => {
+      reporter.onTestCaseStart(test, {
+        ancestorTitles: ['Test Suite'],
+        fullName: 'Test Suite Test',
+        mode: undefined as any,
+        title: 'Test (Qase ID: 123)',
+        startedAt: 1_700_000_000_000,
+      } as any);
+      reporter.onTestCaseResult(test, testCaseResult);
+      const call = reporterMock.addTestResult.mock.calls[0][0];
+      expect(call.execution.start_time).toBe(1_700_000_000);
+      expect(call.execution.end_time).toBe(1_700_000_001);
+      expect(call.execution.duration).toBe(1000);
+    });
+
     it('skips addTestResult when ignore flag is set', () => {
       reporter.addIgnore();
       reporter.onTestCaseResult(test, testCaseResult);

--- a/qase-jest/test/resultBuilder.test.ts
+++ b/qase-jest/test/resultBuilder.test.ts
@@ -55,17 +55,29 @@ describe('ResultBuilder.build', () => {
     });
     expect(result.execution.status).toBe('passed');
     expect(result.execution.duration).toBe(1000);
-    // start_time/end_time are derived from Date.now() at result moment; they should
-    // be Unix seconds (~1e9-1e10) and `end_time - start_time == duration / 1000`.
-    const start = result.execution.start_time as number;
-    const end = result.execution.end_time as number;
-    expect(start).toBeGreaterThan(1_600_000_000);
-    expect(end).toBeGreaterThan(1_600_000_000);
-    expect(Math.round((end - start) * 1000)).toBe(1000);
+    // Without startTimeMs the builder leaves start/end null (Jest didn't fire
+    // onTestCaseStart for this case, e.g. older Jest version or todo/pending).
+    expect(result.execution.start_time).toBeNull();
+    expect(result.execution.end_time).toBeNull();
     expect(result.testops_id).toBe(123);
     expect(result.title).toBe('Test');
     expect(result.signature).toBe('mock-signature');
     expect(result.steps).toEqual([]);
+  });
+
+  it('uses startTimeMs from onTestCaseStart to populate start/end', () => {
+    const meta = MetadataApplier.empty();
+    const result = ResultBuilder.build({
+      value: baseValue,
+      path: '/work/test/file.spec.ts',
+      metadata: meta,
+      profilerSteps: [],
+      startTimeMs: 1_700_000_000_000,
+    });
+    // start in Unix seconds, end = start + duration / 1000
+    expect(result.execution.start_time).toBe(1_700_000_000);
+    expect(result.execution.end_time).toBe(1_700_000_001);
+    expect(result.execution.duration).toBe(1000);
   });
 
   it('maps failureDetails to error message and stacktrace', () => {

--- a/qase-jest/test/resultBuilder.test.ts
+++ b/qase-jest/test/resultBuilder.test.ts
@@ -55,6 +55,13 @@ describe('ResultBuilder.build', () => {
     });
     expect(result.execution.status).toBe('passed');
     expect(result.execution.duration).toBe(1000);
+    // start_time/end_time are derived from Date.now() at result moment; they should
+    // be Unix seconds (~1e9-1e10) and `end_time - start_time == duration / 1000`.
+    const start = result.execution.start_time as number;
+    const end = result.execution.end_time as number;
+    expect(start).toBeGreaterThan(1_600_000_000);
+    expect(end).toBeGreaterThan(1_600_000_000);
+    expect(Math.round((end - start) * 1000)).toBe(1000);
     expect(result.testops_id).toBe(123);
     expect(result.title).toBe('Test');
     expect(result.signature).toBe('mock-signature');

--- a/qase-mocha/changelog.md
+++ b/qase-mocha/changelog.md
@@ -1,3 +1,10 @@
+# mocha-qase-reporter@1.5.1
+
+## Fixed
+
+- `StepRunner` now emits step `execution.start_time` / `end_time` in Unix seconds (with fractional ms) instead of raw `Date.now()` milliseconds, matching the parent test's units and the Qase API spec. Step `execution.duration` is also populated (was always `null` previously).
+- HTTP/fetch profiler steps (via `qase-javascript-commons@2.7.1`) now emit `start_time` / `end_time` in Unix seconds instead of milliseconds.
+
 # mocha-qase-reporter@1.5.0
 
 ## Changed

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-mocha/src/modules/stepRunner.ts
+++ b/qase-mocha/src/modules/stepRunner.ts
@@ -25,6 +25,7 @@ export class StepRunner {
 
     const stepData = extractAndCleanStep(stepTitle);
 
+    const startMs = Date.now();
     const step: TestStepType = {
       step_type: StepType.TEXT,
       data: {
@@ -33,7 +34,7 @@ export class StepRunner {
         data: stepData.data,
       },
       execution: {
-        start_time: Date.now(),
+        start_time: startMs / 1000,
         status: StepStatusEnum.passed,
         end_time: null,
         duration: null,
@@ -51,7 +52,9 @@ export class StepRunner {
       this.failureFlag = true;
     }
 
-    step.execution.end_time = Date.now();
+    const endMs = Date.now();
+    step.execution.end_time = endMs / 1000;
+    step.execution.duration = endMs - startMs;
     this.steps.push(step);
   }
 }

--- a/qase-mocha/test/stepRunner.test.ts
+++ b/qase-mocha/test/stepRunner.test.ts
@@ -23,6 +23,13 @@ describe('StepRunner', () => {
     expect(steps[0]?.data.action).toBe('login');
     expect(steps[0]?.execution.status).toBe(StepStatusEnum.passed);
     expect(steps[0]?.execution.end_time).not.toBeNull();
+    // start/end in Unix seconds, duration in ms per Qase API spec
+    const start = steps[0]!.execution.start_time as number;
+    const end = steps[0]!.execution.end_time as number;
+    expect(start).toBeGreaterThan(1_600_000_000);
+    expect(end).toBeGreaterThanOrEqual(start);
+    expect(steps[0]?.execution.duration).not.toBeNull();
+    expect(steps[0]!.execution.duration as number).toBeGreaterThanOrEqual(0);
   });
 
   it('run() with a throwing fn marks step failed, swallows the error, and exposes hasFailure()', () => {

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,10 @@
+# playwright-qase-reporter@2.5.1
+
+## Fixed
+
+- `execution.end_time` is now populated on both test results and steps (derived from Playwright's `startTime + duration`). Previously `end_time` was hardcoded to `null`, which broke timeline rendering on the Qase side. Units are unchanged: `start_time` / `end_time` in Unix seconds (with fractional ms), `duration` in milliseconds.
+- HTTP/fetch profiler steps (via `qase-javascript-commons@2.7.1`) now emit `start_time` / `end_time` in Unix seconds instead of milliseconds.
+
 # playwright-qase-reporter@2.5.0
 
 ## Added

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/result-builder.ts
+++ b/qase-playwright/src/result-builder.ts
@@ -126,7 +126,7 @@ export class ResultBuilder {
       execution: {
         status: testStatus,
         start_time: result.startTime.valueOf() / 1000,
-        end_time: null,
+        end_time: (result.startTime.valueOf() + result.duration) / 1000,
         duration: result.duration,
         stacktrace: error === null
           ? null

--- a/qase-playwright/src/step-converter.ts
+++ b/qase-playwright/src/step-converter.ts
@@ -44,7 +44,7 @@ export class StepConverter {
           status: testStep.error ? StepStatusEnum.failed : StepStatusEnum.passed,
           start_time: testStep.startTime.valueOf() / 1000,
           duration: testStep.duration,
-          end_time: null,
+          end_time: (testStep.startTime.valueOf() + testStep.duration) / 1000,
         },
         attachments: attachments ? attachments : [],
         steps: this.transform(testStep.steps, id),

--- a/qase-playwright/test/step-converter.test.ts
+++ b/qase-playwright/test/step-converter.test.ts
@@ -61,6 +61,7 @@ describe('StepConverter', () => {
     expect(result[0]?.parent_id).toBe('parent-id');
     expect(result[0]?.execution.status).toBe(StepStatusEnum.passed);
     expect(result[0]?.execution.start_time).toBe(1);
+    expect(result[0]?.execution.end_time).toBe(1.005);
     expect(result[0]?.execution.duration).toBe(5);
     expect(result[0]?.data.action).toBe('click button');
   });

--- a/qase-vitest/changelog.md
+++ b/qase-vitest/changelog.md
@@ -1,3 +1,10 @@
+# vitest-qase-reporter@1.4.1
+
+## Fixed
+
+- `execution.start_time` and `execution.end_time` are now populated for every test result. Vitest's `testCase.diagnostic()` only exposes an elapsed `duration` (ms), so we anchor `end_time` to `Date.now()` at the moment of the `onTestCaseResult` callback and derive `start_time = end_time - duration`. Timeline rendering on the Qase side no longer falls back to ingestion timestamps. Units: `start_time` / `end_time` in Unix seconds (with fractional ms), `duration` in milliseconds.
+- HTTP/fetch profiler steps (via `qase-javascript-commons@2.7.1`) now emit `start_time` / `end_time` in Unix seconds instead of milliseconds.
+
 # vitest-qase-reporter@1.4.0
 
 ## Changed

--- a/qase-vitest/changelog.md
+++ b/qase-vitest/changelog.md
@@ -2,7 +2,7 @@
 
 ## Fixed
 
-- `execution.start_time` and `execution.end_time` are now populated for every test result. Vitest's `testCase.diagnostic()` only exposes an elapsed `duration` (ms), so we anchor `end_time` to `Date.now()` at the moment of the `onTestCaseResult` callback and derive `start_time = end_time - duration`. Timeline rendering on the Qase side no longer falls back to ingestion timestamps. Units: `start_time` / `end_time` in Unix seconds (with fractional ms), `duration` in milliseconds.
+- `execution.start_time` and `execution.end_time` are now populated for every test result, sourced from `testCase.diagnostic().startTime` (Vitest's absolute test-start timestamp in ms) plus `duration`. Previously both fields were emitted as `null`. Units: `start_time` / `end_time` in Unix seconds (with fractional ms), `duration` in milliseconds.
 - HTTP/fetch profiler steps (via `qase-javascript-commons@2.7.1`) now emit `start_time` / `end_time` in Unix seconds instead of milliseconds.
 
 # vitest-qase-reporter@1.4.0

--- a/qase-vitest/package.json
+++ b/qase-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-qase-reporter",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Qase TMS Vitest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-vitest/src/modules/resultBuilder.ts
+++ b/qase-vitest/src/modules/resultBuilder.ts
@@ -52,15 +52,17 @@ export class ResultBuilder {
       });
     }
 
-    // Vitest's `testCase.diagnostic()` exposes only an elapsed `duration` (ms),
-    // not absolute test start/end timestamps. Anchor end_time to Date.now() at
-    // result-build moment and derive start_time backward; the only loss of
-    // precision is the gap between actual test end and the reporter callback.
+    // Vitest's `testCase.diagnostic()` exposes both the absolute `startTime`
+    // (ms since epoch) and elapsed `duration` (ms). end_time is derived as
+    // start + duration so there is no dependency on the reporter callback delay.
     const durationMs = Math.round(diagnostic?.duration ?? 0);
-    const endTimeMs = Date.now();
-    const startTimeMs = endTimeMs - durationMs;
-    testResult.execution.start_time = startTimeMs / 1000;
-    testResult.execution.end_time = endTimeMs / 1000;
+    if (diagnostic) {
+      testResult.execution.start_time = diagnostic.startTime / 1000;
+      testResult.execution.end_time = (diagnostic.startTime + durationMs) / 1000;
+    } else {
+      testResult.execution.start_time = null;
+      testResult.execution.end_time = null;
+    }
     testResult.execution.duration = durationMs;
 
     let error: Error | null = null;

--- a/qase-vitest/src/modules/resultBuilder.ts
+++ b/qase-vitest/src/modules/resultBuilder.ts
@@ -52,9 +52,16 @@ export class ResultBuilder {
       });
     }
 
-    testResult.execution.start_time = null;
-    testResult.execution.end_time = null;
-    testResult.execution.duration = Math.round(diagnostic?.duration ?? 0);
+    // Vitest's `testCase.diagnostic()` exposes only an elapsed `duration` (ms),
+    // not absolute test start/end timestamps. Anchor end_time to Date.now() at
+    // result-build moment and derive start_time backward; the only loss of
+    // precision is the gap between actual test end and the reporter callback.
+    const durationMs = Math.round(diagnostic?.duration ?? 0);
+    const endTimeMs = Date.now();
+    const startTimeMs = endTimeMs - durationMs;
+    testResult.execution.start_time = startTimeMs / 1000;
+    testResult.execution.end_time = endTimeMs / 1000;
+    testResult.execution.duration = durationMs;
 
     let error: Error | null = null;
     if (result.errors && result.errors.length > 0) {

--- a/qase-vitest/test/resultBuilder.test.ts
+++ b/qase-vitest/test/resultBuilder.test.ts
@@ -39,8 +39,13 @@ describe('ResultBuilder.build', () => {
       profilerSteps: [],
     });
     expect(result.execution.status).toBe('passed');
-    expect(result.execution.start_time).toBeNull();
-    expect(result.execution.end_time).toBeNull();
+    // start_time/end_time are derived from Date.now() at result moment;
+    // expect Unix seconds and end - start ≈ duration / 1000.
+    const start = result.execution.start_time as number;
+    const end = result.execution.end_time as number;
+    expect(start).toBeGreaterThan(1_600_000_000);
+    expect(end).toBeGreaterThan(1_600_000_000);
+    expect(Math.round((end - start) * 1000)).toBe(100);
     expect(result.execution.duration).toBe(100);
     expect(result.id).toBe('test-id');
     expect(result.signature).toBe('Suite > Test');

--- a/qase-vitest/test/resultBuilder.test.ts
+++ b/qase-vitest/test/resultBuilder.test.ts
@@ -21,7 +21,7 @@ const mkTestCase = (overrides: any = {}) => ({
   id: 'test-id',
   fullName: 'Suite > Test',
   result: jest.fn().mockReturnValue({ state: 'passed', errors: [] }),
-  diagnostic: jest.fn().mockReturnValue({ duration: 100 }),
+  diagnostic: jest.fn().mockReturnValue({ duration: 100, startTime: 1_700_000_000_000 }),
   ...overrides,
 }) as any;
 
@@ -39,13 +39,9 @@ describe('ResultBuilder.build', () => {
       profilerSteps: [],
     });
     expect(result.execution.status).toBe('passed');
-    // start_time/end_time are derived from Date.now() at result moment;
-    // expect Unix seconds and end - start ≈ duration / 1000.
-    const start = result.execution.start_time as number;
-    const end = result.execution.end_time as number;
-    expect(start).toBeGreaterThan(1_600_000_000);
-    expect(end).toBeGreaterThan(1_600_000_000);
-    expect(Math.round((end - start) * 1000)).toBe(100);
+    // Vitest exposes the absolute startTime; reporter emits it as Unix seconds.
+    expect(result.execution.start_time).toBe(1_700_000_000);
+    expect(result.execution.end_time).toBe(1_700_000_000.1);
     expect(result.execution.duration).toBe(100);
     expect(result.id).toBe('test-id');
     expect(result.signature).toBe('Suite > Test');

--- a/qase-wdio/changelog.md
+++ b/qase-wdio/changelog.md
@@ -1,3 +1,12 @@
+# wdio-qase-reporter@1.5.1
+
+## Fixed
+
+- Test `execution.duration` is now reported in milliseconds (multiplied by 1000) instead of seconds, matching the Qase API spec. Previously a 10-second test was uploaded as `duration: 10` (ms), making it look like 10 milliseconds on timelines.
+- Test `execution.end_time` is now set in `ResultFinalizer.finalize` (previously it was always `null`).
+- Step `execution.duration` is now populated in `TestLifecycle.endStep` (previously it stayed `null` even though both `start_time` and `end_time` were available).
+- HTTP/fetch profiler steps (via `qase-javascript-commons@2.7.1`) now emit `start_time` / `end_time` in Unix seconds instead of milliseconds.
+
 # wdio-qase-reporter@1.5.0
 
 ## Changed

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,

--- a/qase-wdio/src/finalizer.ts
+++ b/qase-wdio/src/finalizer.ts
@@ -40,8 +40,10 @@ export class ResultFinalizer {
       testResult.relations = relations;
     }
 
+    // start_time/end_time are Unix seconds; duration must be ms per Qase API spec.
+    testResult.execution.end_time = endTime;
     testResult.execution.duration = testResult.execution.start_time
-      ? Math.round(endTime - testResult.execution.start_time)
+      ? Math.round((endTime - testResult.execution.start_time) * 1000)
       : 0;
 
     let error: Error | null = null;

--- a/qase-wdio/src/lifecycle.ts
+++ b/qase-wdio/src/lifecycle.ts
@@ -46,8 +46,13 @@ export class TestLifecycle {
     if (!step) {
       return;
     }
-    step.execution.end_time = Date.now() / 1000;
+    const endTimeSec = Date.now() / 1000;
+    step.execution.end_time = endTimeSec;
     step.execution.status = status;
+    // start_time/end_time are in seconds; duration must be in ms per Qase API spec.
+    if (step.execution.start_time !== null) {
+      step.execution.duration = Math.round((endTimeSec - step.execution.start_time) * 1000);
+    }
   }
 
   attachJSON(name: string, json: unknown): void {

--- a/qase-wdio/test/finalizer.test.ts
+++ b/qase-wdio/test/finalizer.test.ts
@@ -77,10 +77,13 @@ describe('ResultFinalizer', () => {
     expect(t.relations.suite?.data).toEqual([{ title: 'Pre', public_id: null }]);
   });
 
-  it('computes duration from start_time and endTime (rounded seconds)', async () => {
+  it('computes duration in ms and sets end_time when finalizing', async () => {
     const t = startTest('t', 100);
     await finalizer.finalize(TestStatusEnum.passed, null, 100.7);
-    expect(t.execution.duration).toBe(1);
+    expect(t.execution.start_time).toBe(100);
+    expect(t.execution.end_time).toBe(100.7);
+    // start/end in seconds (100 → 100.7), duration in ms (700)
+    expect(t.execution.duration).toBe(700);
   });
 
   it('forwards stacktrace from CompoundError', async () => {


### PR DESCRIPTION
## Summary

Audit revealed that every reporter in the monorepo had at least one timing field that didn't match the Qase API v2 contract:

- `execution.start_time` / `execution.end_time` — Unix seconds (with fractional ms)
- `execution.duration` — milliseconds

This caused symptoms like steps appearing ~55 years in the future on Qase timelines (raw `Date.now()` written as if it were seconds), tests with `duration: 10` for what was actually 10 seconds (1000× off), and entire result windows that couldn't be drawn because `end_time` was hardcoded `null`.

## Per-package changes

| Package | Patch | Fix |
|---|---|---|
| `qase-javascript-commons` | 2.7.0 → **2.7.1** | HTTP/fetch profiler steps emit `start_time`/`end_time` in seconds (were ms); `ReportReporter` JSON summary in seconds (was ms). |
| `qase-playwright` | 2.5.0 → **2.5.1** | `end_time` on tests and steps derived from `startTime + duration` (was hardcoded `null`). |
| `qase-jest` | 2.5.0 → **2.5.1** | Jest's `AssertionResult` only exposes elapsed `duration`; anchor `end_time` to `Date.now()` at `onTestCaseResult` and derive `start_time = end_time - duration`. |
| `qase-vitest` | 1.4.0 → **1.4.1** | Same approach as Jest — Vitest's `testCase.diagnostic()` only exposes elapsed `duration`. |
| `qase-wdio` | 1.5.0 → **1.5.1** | Test `duration` now in ms (× 1000 — was emitted in seconds); test `end_time` populated; step `duration` computed in `endStep`. |
| `qase-mocha` | 1.5.0 → **1.5.1** | Step `start_time`/`end_time` in seconds (were raw ms); step `duration` computed. |
| `qase-cucumberjs` | 2.4.0 → **2.4.1** | Step `start_time`/`end_time` from `testStepStarted`/`testStepFinished` envelope timestamps (were `null`); duration includes `nanos` (sub-second steps no longer round to 0). |
| `qase-cypress` | 3.6.1 → **3.6.2** | `qase.step()` no longer pre-fills `end_time = Date.now()` at START (race fix); cypress + cucumber step times in seconds; HTTP step gets `end_time`; step `duration` computed. |

Each package gets a patch bump and a changelog entry in its existing format.

## Test plan

- [x] `npm run build` succeeds for each modified package
- [x] `npm test` passes for each modified package (commons 487/487, playwright 92/92, jest 82/82, vitest 76/76, mocha 43/43, cucumberjs 84/84, cypress 98/98, wdio 95/95)
- [x] Added unit tests asserting units explicitly (Unix seconds for start/end, ms for duration) in commons HTTP interceptor and per-reporter result builders
- [ ] Manual smoke run against a real Qase project to confirm timeline renders correctly