### PR TITLE
chore: add repository.directory and bump patch versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28126,7 +28126,7 @@
       }
     },
     "qase-api-client": {
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.16.0",
@@ -28145,7 +28145,7 @@
       }
     },
     "qase-api-v2-client": {
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.16.0",
@@ -28165,11 +28165,11 @@
     },
     "qase-cucumberjs": {
       "name": "cucumberjs-qase-reporter",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/messages": "^22.0.0",
-        "qase-javascript-commons": "~2.7.2"
+        "qase-javascript-commons": "~2.7.3"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -28221,10 +28221,10 @@
     },
     "qase-cypress": {
       "name": "cypress-qase-reporter",
-      "version": "3.6.3",
+      "version": "3.6.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.7.2",
+        "qase-javascript-commons": "~2.7.3",
         "uuid": "11.1.1"
       },
       "devDependencies": {
@@ -28250,7 +28250,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -28262,8 +28262,8 @@
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "mime-types": "^2.1.35",
-        "qase-api-client": "~1.1.8",
-        "qase-api-v2-client": "~1.0.8",
+        "qase-api-client": "~1.1.9",
+        "qase-api-v2-client": "~1.0.9",
         "strip-ansi": "^6.0.1",
         "uuid": "11.1.1"
       },
@@ -28285,12 +28285,12 @@
     },
     "qase-jest": {
       "name": "jest-qase-reporter",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "qase-javascript-commons": "~2.7.2",
+        "qase-javascript-commons": "~2.7.3",
         "uuid": "11.1.1"
       },
       "devDependencies": {
@@ -28312,12 +28312,12 @@
     },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "deasync-promise": "^1.0.1",
         "mocha": "^11.7.5",
-        "qase-javascript-commons": "~2.7.2",
+        "qase-javascript-commons": "~2.7.3",
         "uuid": "11.1.1"
       },
       "devDependencies": {
@@ -28339,10 +28339,10 @@
     },
     "qase-newman": {
       "name": "newman-reporter-qase",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.7.2",
+        "qase-javascript-commons": "~2.7.3",
         "semver": "^7.7.3"
       },
       "devDependencies": {
@@ -28376,11 +28376,11 @@
     },
     "qase-playwright": {
       "name": "playwright-qase-reporter",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
-        "qase-javascript-commons": "~2.7.2",
+        "qase-javascript-commons": "~2.7.3",
         "uuid": "11.1.1"
       },
       "devDependencies": {
@@ -28399,10 +28399,10 @@
     },
     "qase-testcafe": {
       "name": "testcafe-reporter-qase",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.7.2",
+        "qase-javascript-commons": "~2.7.3",
         "uuid": "11.1.1"
       },
       "devDependencies": {
@@ -28421,10 +28421,10 @@
     },
     "qase-vitest": {
       "name": "vitest-qase-reporter",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.7.2"
+        "qase-javascript-commons": "~2.7.3"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -28444,13 +28444,13 @@
     },
     "qase-wdio": {
       "name": "wdio-qase-reporter",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@wdio/reporter": "^8.43.0",
         "@wdio/types": "^8.41.0",
         "csv-stringify": "^6.6.0",
-        "qase-javascript-commons": "~2.7.2",
+        "qase-javascript-commons": "~2.7.3",
         "strip-ansi": "^7.1.2",
         "uuid": "11.1.1"
       },

--- a/qase-api-client/package.json
+++ b/qase-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-client",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Qase TMS Javascript API V1 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -10,7 +10,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-api-client"
   },
   "engines": {
     "node": ">=18"

--- a/qase-api-v2-client/package.json
+++ b/qase-api-v2-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-v2-client",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Qase TMS Javascript API V2 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -10,7 +10,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-api-v2-client"
   },
   "engines": {
     "node": ">=18"

--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,9 @@
+# cucumberjs-qase-reporter@2.4.3
+
+## Fixed
+
+- Added `repository.directory: "qase-cucumberjs"` so npmjs.com correctly resolves relative links in the README. Bumped `qase-javascript-commons` pin to `~2.7.3`.
+
 # cucumberjs-qase-reporter@2.4.2
 
 ## Security

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",
@@ -25,7 +25,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-cucumberjs"
   },
   "engines": {
     "node": ">=18"
@@ -40,7 +41,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/messages": "^22.0.0",
-    "qase-javascript-commons": "~2.7.2"
+    "qase-javascript-commons": "~2.7.3"
   },
   "peerDependencies": {
     "@cucumber/cucumber": ">=7.0.0"

--- a/qase-cypress/changelog.md
+++ b/qase-cypress/changelog.md
@@ -1,3 +1,9 @@
+# cypress-qase-reporter@3.6.4
+
+## Fixed
+
+- Added `repository.directory: "qase-cypress"` so npmjs.com correctly resolves relative links in the README (links to `../examples/`, `docs/*.md`, etc. previously rendered as broken `github.com/.../blob/<path>` URLs without a branch). Bumped `qase-javascript-commons` pin to `~2.7.3`.
+
 # cypress-qase-reporter@3.6.3
 
 ## Security

--- a/qase-cypress/package.json
+++ b/qase-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-qase-reporter",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "description": "Qase Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -37,7 +37,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-cypress"
   },
   "engines": {
     "node": ">=18"
@@ -51,7 +52,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.7.2",
+    "qase-javascript-commons": "~2.7.3",
     "uuid": "11.1.1"
   },
   "peerDependencies": {

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+## 2.7.3
+
+### Fixed
+
+- Added `repository.directory: "qase-javascript-commons"` so npmjs.com correctly resolves relative links in this package's README (previously rendered as broken `github.com/.../blob/<path>` URLs without a branch).
+
 ## 2.7.2
 
 ### Security

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -35,7 +35,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-javascript-commons"
   },
   "engines": {
     "node": ">=18"
@@ -58,8 +59,8 @@
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
     "mime-types": "^2.1.35",
-    "qase-api-client": "~1.1.8",
-    "qase-api-v2-client": "~1.0.8",
+    "qase-api-client": "~1.1.9",
+    "qase-api-v2-client": "~1.0.9",
     "strip-ansi": "^6.0.1",
     "uuid": "11.1.1"
   },

--- a/qase-jest/changelog.md
+++ b/qase-jest/changelog.md
@@ -1,3 +1,9 @@
+# jest-qase-reporter@2.5.3
+
+## Fixed
+
+- Added `repository.directory: "qase-jest"` so npmjs.com correctly resolves relative links in the README. Bumped `qase-javascript-commons` pin to `~2.7.3`.
+
 # jest-qase-reporter@2.5.2
 
 ## Security

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-qase-reporter",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Qase TMS Jest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -29,7 +29,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-jest"
   },
   "engines": {
     "node": ">=18"
@@ -45,7 +46,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
-    "qase-javascript-commons": "~2.7.2",
+    "qase-javascript-commons": "~2.7.3",
     "uuid": "11.1.1"
   },
   "devDependencies": {

--- a/qase-mocha/changelog.md
+++ b/qase-mocha/changelog.md
@@ -1,3 +1,9 @@
+# mocha-qase-reporter@1.5.3
+
+## Fixed
+
+- Added `repository.directory: "qase-mocha"` so npmjs.com correctly resolves relative links in the README. Bumped `qase-javascript-commons` pin to `~2.7.3`.
+
 # mocha-qase-reporter@1.5.2
 
 ## Security

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -27,7 +27,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-mocha"
   },
   "engines": {
     "node": ">=18"
@@ -43,7 +44,7 @@
   "dependencies": {
     "deasync-promise": "^1.0.1",
     "mocha": "^11.7.5",
-    "qase-javascript-commons": "~2.7.2",
+    "qase-javascript-commons": "~2.7.3",
     "uuid": "11.1.1"
   },
   "devDependencies": {

--- a/qase-newman/changelog.md
+++ b/qase-newman/changelog.md
@@ -1,3 +1,9 @@
+# newman-reporter-qase@2.3.2
+
+## Fixed
+
+- Added `repository.directory: "qase-newman"` so npmjs.com correctly resolves relative links in the README. Bumped `qase-javascript-commons` pin to `~2.7.3`.
+
 # newman-reporter-qase@2.3.1
 
 ## Changed

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-qase",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Qase TMS Newman Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,7 +25,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-newman"
   },
   "engines": {
     "node": ">=18"
@@ -39,7 +40,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.7.2",
+    "qase-javascript-commons": "~2.7.3",
     "semver": "^7.7.3"
   },
   "devDependencies": {

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,9 @@
+# playwright-qase-reporter@2.5.3
+
+## Fixed
+
+- Added `repository.directory: "qase-playwright"` so npmjs.com correctly resolves relative links in the README. Bumped `qase-javascript-commons` pin to `~2.7.3`.
+
 # playwright-qase-reporter@2.5.2
 
 ## Security

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -33,7 +33,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-playwright"
   },
   "engines": {
     "node": ">=18"
@@ -48,7 +49,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.2",
-    "qase-javascript-commons": "~2.7.2",
+    "qase-javascript-commons": "~2.7.3",
     "uuid": "11.1.1"
   },
   "peerDependencies": {

--- a/qase-testcafe/changelog.md
+++ b/qase-testcafe/changelog.md
@@ -1,3 +1,9 @@
+# testcafe-reporter-qase@2.6.2
+
+## Fixed
+
+- Added `repository.directory: "qase-testcafe"` so npmjs.com correctly resolves relative links in the README. Bumped `qase-javascript-commons` pin to `~2.7.3`.
+
 # testcafe-reporter-qase@2.6.1
 
 ## Security

--- a/qase-testcafe/package.json
+++ b/qase-testcafe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-qase",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Qase TMS TestCafe Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-testcafe"
   },
   "engines": {
     "node": ">=18"
@@ -40,7 +41,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.7.2",
+    "qase-javascript-commons": "~2.7.3",
     "uuid": "11.1.1"
   },
   "peerDependencies": {

--- a/qase-vitest/changelog.md
+++ b/qase-vitest/changelog.md
@@ -1,3 +1,9 @@
+# vitest-qase-reporter@1.4.3
+
+## Fixed
+
+- Added `repository.directory: "qase-vitest"` so npmjs.com correctly resolves relative links in the README. Bumped `qase-javascript-commons` pin to `~2.7.3`.
+
 # vitest-qase-reporter@1.4.2
 
 ## Security

--- a/qase-vitest/package.json
+++ b/qase-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-qase-reporter",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Qase TMS Vitest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,7 +25,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-vitest"
   },
   "engines": {
     "node": ">=18"
@@ -45,7 +46,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.7.2"
+    "qase-javascript-commons": "~2.7.3"
   },
   "peerDependencies": {
     "vitest": ">=3.0.0"

--- a/qase-wdio/changelog.md
+++ b/qase-wdio/changelog.md
@@ -1,3 +1,9 @@
+# wdio-qase-reporter@1.5.3
+
+## Fixed
+
+- Added `repository.directory: "qase-wdio"` so npmjs.com correctly resolves relative links in the README. Bumped `qase-javascript-commons` pin to `~2.7.3`.
+
 # wdio-qase-reporter@1.5.2
 
 ## Security

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -18,7 +18,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qase-tms/qase-javascript.git"
+    "url": "git+https://github.com/qase-tms/qase-javascript.git",
+    "directory": "qase-wdio"
   },
   "engines": {
     "node": ">=18"
@@ -35,7 +36,7 @@
     "@wdio/reporter": "^8.43.0",
     "@wdio/types": "^8.41.0",
     "csv-stringify": "^6.6.0",
-    "qase-javascript-commons": "~2.7.2",
+    "qase-javascript-commons": "~2.7.3",
     "strip-ansi": "^7.1.2",
     "uuid": "11.1.1"
   }


### PR DESCRIPTION
## Summary

Adds the standard `repository.directory` field to every package's `package.json` so npmjs.com can resolve relative README links correctly. Without it, links like `[examples directory](../examples/)` rendered as broken URLs missing a branch component (e.g. `github.com/qase-tms/qase-javascript/blob/examples/`).

Bumps a patch version on every package so npm picks up the change at next publish.

## Patch bumps

- qase-api-client 1.1.8 → 1.1.9
- qase-api-v2-client 1.0.8 → 1.0.9
- qase-javascript-commons 2.7.2 → 2.7.3
- cypress-qase-reporter 3.6.3 → 3.6.4
- cucumberjs-qase-reporter 2.4.2 → 2.4.3
- jest-qase-reporter 2.5.2 → 2.5.3
- mocha-qase-reporter 1.5.2 → 1.5.3
- newman-reporter-qase 2.3.1 → 2.3.2
- playwright-qase-reporter 2.5.2 → 2.5.3
- testcafe-reporter-qase 2.6.1 → 2.6.2
- vitest-qase-reporter 1.4.2 → 1.4.3
- wdio-qase-reporter 1.5.2 → 1.5.3

Cross-package pins synced: reporters pin `qase-javascript-commons` `~2.7.2 → ~2.7.3`; `commons` pins `qase-api-client ~1.1.8 → ~1.1.9`, `qase-api-v2-client ~1.0.8 → ~1.0.9`.

## Test plan

- [x] `npm install` rebuilds lockfile cleanly
- [x] Unit tests across all reporters — 1161 passed / 0 failed