### PR TITLE
fix: gracefully handle non-positive Qase test case IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28165,11 +28165,11 @@
     },
     "qase-cucumberjs": {
       "name": "cucumberjs-qase-reporter",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/messages": "^22.0.0",
-        "qase-javascript-commons": "~2.7.3"
+        "qase-javascript-commons": "~2.7.4"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -28250,7 +28250,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.7.3",
+      "version": "2.7.4",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -28285,12 +28285,12 @@
     },
     "qase-jest": {
       "name": "jest-qase-reporter",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "qase-javascript-commons": "~2.7.3",
+        "qase-javascript-commons": "~2.7.4",
         "uuid": "11.1.1"
       },
       "devDependencies": {
@@ -28339,10 +28339,10 @@
     },
     "qase-newman": {
       "name": "newman-reporter-qase",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.7.3",
+        "qase-javascript-commons": "~2.7.4",
         "semver": "^7.7.3"
       },
       "devDependencies": {

--- a/qase-cucumberjs/changelog.md
+++ b/qase-cucumberjs/changelog.md
@@ -1,3 +1,9 @@
+# cucumberjs-qase-reporter@2.4.4
+
+## Fixed
+
+- Qase test case IDs that are `<= 0` (e.g. `@Q0` or `@QaseID=0`) are now dropped with a warning instead of being sent to the API, which previously rejected the whole batch with HTTP 400. Bumped `qase-javascript-commons` pin to `~2.7.4`.
+
 # cucumberjs-qase-reporter@2.4.3
 
 ## Fixed

--- a/qase-cucumberjs/package.json
+++ b/qase-cucumberjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumberjs-qase-reporter",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Qase TMS CucumberJS Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "main": "./dist/index.js",
@@ -41,7 +41,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/messages": "^22.0.0",
-    "qase-javascript-commons": "~2.7.3"
+    "qase-javascript-commons": "~2.7.4"
   },
   "peerDependencies": {
     "@cucumber/cucumber": ">=7.0.0"

--- a/qase-cucumberjs/src/modules/tagParser.ts
+++ b/qase-cucumberjs/src/modules/tagParser.ts
@@ -1,5 +1,6 @@
 import { PickleTag } from '@cucumber/messages';
 import { parseProjectMappingFromTags } from 'qase-javascript-commons';
+import { filterPositiveIds } from 'qase-javascript-commons/internal';
 import { TestMetadata } from '../models';
 
 const qaseIdRegExp = /^@[Qq]-?(\d+)$/;
@@ -31,13 +32,17 @@ export class TagParser {
 
     for (const tag of tags) {
       if (qaseIdRegExp.test(tag.name)) {
-        metadata.ids.push(Number(tag.name.replace(/^@[Qq]-?/, '')));
+        metadata.ids.push(
+          ...filterPositiveIds([Number(tag.name.replace(/^@[Qq]-?/, ''))]),
+        );
         continue;
       }
 
       if (newQaseIdRegExp.test(tag.name)) {
         const idsStr = tag.name.replace(/^@[Qq]ase[Ii][Dd]=/, '');
-        metadata.ids.push(...idsStr.split(',').map((s) => Number(s.trim())));
+        metadata.ids.push(
+          ...filterPositiveIds(idsStr.split(',').map((s) => Number(s.trim()))),
+        );
         continue;
       }
 

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+## 2.7.4
+
+### Fixed
+
+- Qase test case IDs that are `<= 0` (e.g. an accidental `(Qase ID: 0)` in a test title or `@qaseid(0)` tag) no longer cause the API to reject the whole result batch with HTTP 400. The invalid ID is dropped with a warning and the result is sent without an ID, exactly as if no ID had been specified. Filtering happens in a new internal `filterPositiveIds()` helper applied by `parseQaseIdsFromString`, `parseProjectMappingFromTitle`, and `parseProjectMappingFromTags`. The warning routes through the provided `LoggerInterface` (logged at INFO level with a `Warning:` prefix in the message) or falls back to `console.warn` when no logger is available.
+
 ## 2.7.3
 
 ### Fixed

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/internal/filter-positive-ids.ts
+++ b/qase-javascript-commons/src/internal/filter-positive-ids.ts
@@ -1,0 +1,39 @@
+import { LoggerInterface } from '../utils/logger';
+
+/**
+ * Filter a list of Qase test case IDs, dropping non-positive (<= 0) and
+ * non-finite numbers. Each dropped non-positive ID produces a warning so
+ * users can spot accidental "0" IDs in their test code.
+ *
+ * NaN and non-finite values are dropped silently — they come from upstream
+ * parse failures (parseInt('abc') etc.) that are already handled at their
+ * source and are not user-facing mistakes worth warning about.
+ *
+ * Warning routing:
+ *   - if a logger is provided, it goes through logger.log (INFO level, since
+ *     the LoggerInterface has no warn level);
+ *   - otherwise, it falls back to console.warn with a "[qase] " prefix so the
+ *     message still reaches the user.
+ */
+export function filterPositiveIds(
+  ids: number[],
+  logger?: LoggerInterface,
+): number[] {
+  const valid: number[] = [];
+  for (const n of ids) {
+    if (!Number.isFinite(n)) {
+      continue;
+    }
+    if (n <= 0) {
+      const message = `Warning: Qase test case ID must be greater than 0, got "${n}". This ID will be ignored and the result will be sent without it.`;
+      if (logger) {
+        logger.log(message);
+      } else {
+        console.warn(`[qase] ${message}`);
+      }
+      continue;
+    }
+    valid.push(n);
+  }
+  return valid;
+}

--- a/qase-javascript-commons/src/internal/ids-parser.ts
+++ b/qase-javascript-commons/src/internal/ids-parser.ts
@@ -1,15 +1,23 @@
+import { filterPositiveIds } from './filter-positive-ids';
+import { LoggerInterface } from '../utils/logger';
+
 /**
  * Parses a comma-separated string of Qase IDs into an array of numbers.
  * Whitespace around each entry is trimmed; non-numeric entries are skipped.
+ * IDs that are not positive integers (<= 0) are filtered out with a warning.
  *
  * Examples: "1,2,3" → [1, 2, 3], "42" → [42], "" → [].
  */
-export function parseQaseIdsFromString(value: string): number[] {
+export function parseQaseIdsFromString(
+  value: string,
+  logger?: LoggerInterface,
+): number[] {
   if (!value?.trim()) {
     return [];
   }
-  return value
+  const parsed = value
     .split(',')
     .map((part) => parseInt(part.trim(), 10))
     .filter((n) => !Number.isNaN(n));
+  return filterPositiveIds(parsed, logger);
 }

--- a/qase-javascript-commons/src/internal/index.ts
+++ b/qase-javascript-commons/src/internal/index.ts
@@ -4,4 +4,5 @@ export type { ExtractedStep } from './step-parser';
 export { getFile } from './suite-file';
 export type { FileSuiteNode } from './suite-file';
 export { parseQaseIdsFromString } from './ids-parser';
+export { filterPositiveIds } from './filter-positive-ids';
 export { normalizeSuitePart } from './suite-normalizer';

--- a/qase-javascript-commons/src/utils/project-mapping-utils.ts
+++ b/qase-javascript-commons/src/utils/project-mapping-utils.ts
@@ -1,4 +1,6 @@
 import type { TestopsProjectMapping } from '../models';
+import { filterPositiveIds } from '../internal/filter-positive-ids';
+import { LoggerInterface } from './logger';
 
 /**
  * Result of parsing project/ID markers from a test title.
@@ -22,8 +24,8 @@ export interface ParsedTagsProjectMapping {
   projectMapping: TestopsProjectMapping;
 }
 
-/** Matches @qaseid(123) or @qaseid.PROJ1(123,124). */
-const QASEID_TAG_REGEXP = /@qaseid(?:\.([A-Za-z0-9_]+))?\(([\d,]+)\)/gi;
+/** Matches @qaseid(123) or @qaseid.PROJ1(123,124). Allows negative numbers. */
+const QASEID_TAG_REGEXP = /@qaseid(?:\.([A-Za-z0-9_]+))?\(([-\d,]+)\)/gi;
 
 /**
  * Parse @qaseid and @qaseid.PROJECT tags into legacy IDs and project mapping.
@@ -31,7 +33,10 @@ const QASEID_TAG_REGEXP = /@qaseid(?:\.([A-Za-z0-9_]+))?\(([\d,]+)\)/gi;
  * @param tags — e.g. ["@qaseid(1,2)", "@qaseid.PROJ2(3)"]
  * @returns legacyIds from @qaseid(...), projectMapping from @qaseid.PROJ(...)
  */
-export function parseProjectMappingFromTags(tags: string[]): ParsedTagsProjectMapping {
+export function parseProjectMappingFromTags(
+  tags: string[],
+  logger?: LoggerInterface,
+): ParsedTagsProjectMapping {
   const legacyIds: number[] = [];
   const projectMapping: TestopsProjectMapping = {};
 
@@ -41,7 +46,11 @@ export function parseProjectMappingFromTags(tags: string[]): ParsedTagsProjectMa
     while ((m = re.exec(tag)) !== null) {
       const projectCode = m[1]; // undefined for @qaseid(1)
       const idsStr = m[2] ?? '';
-      const ids = idsStr.split(',').map((s) => parseInt(s, 10)).filter((n) => !Number.isNaN(n));
+      const rawIds = idsStr
+        .split(',')
+        .map((s) => parseInt(s, 10))
+        .filter((n) => !Number.isNaN(n));
+      const ids = filterPositiveIds(rawIds, logger);
 
       if (!projectCode || projectCode.toUpperCase() === 'ID') {
         legacyIds.push(...ids);
@@ -55,8 +64,8 @@ export function parseProjectMappingFromTags(tags: string[]): ParsedTagsProjectMa
   return { legacyIds, projectMapping };
 }
 
-/** Matches "(Qase ID: 123)" or "(Qase PROJ1: 123,124)" — optional space after "Qase". */
-const QASE_MARKER_REGEXP = /\(Qase\s+([A-Za-z0-9_]+):\s*([\d,]+)\)/gi;
+/** Matches "(Qase ID: 123)" or "(Qase PROJ1: 123,124)" — optional space after "Qase". Allows negative numbers. */
+const QASE_MARKER_REGEXP = /\(Qase\s+([A-Za-z0-9_]+):\s*([-\d,]+)\)/gi;
 
 /**
  * Parse multi-project and legacy Qase ID markers from a test title.
@@ -66,7 +75,10 @@ const QASE_MARKER_REGEXP = /\(Qase\s+([A-Za-z0-9_]+):\s*([\d,]+)\)/gi;
  * @param title — test title that may contain "(Qase ID: …)" or "(Qase PROJECT_CODE: …)".
  * @returns legacyIds, projectMapping, and cleanedTitle with all markers stripped.
  */
-export function parseProjectMappingFromTitle(title: string): ParsedProjectMapping {
+export function parseProjectMappingFromTitle(
+  title: string,
+  logger?: LoggerInterface,
+): ParsedProjectMapping {
   const legacyIds: number[] = [];
   const projectMapping: TestopsProjectMapping = {};
   let cleanedTitle = title;
@@ -76,7 +88,11 @@ export function parseProjectMappingFromTitle(title: string): ParsedProjectMappin
   while ((m = re.exec(title)) !== null) {
     const projectCode = m[1] ?? '';
     const idsStr = m[2] ?? '';
-    const ids = idsStr.split(',').map((s) => parseInt(s, 10)).filter((n) => !Number.isNaN(n));
+    const rawIds = idsStr
+      .split(',')
+      .map((s) => parseInt(s, 10))
+      .filter((n) => !Number.isNaN(n));
+    const ids = filterPositiveIds(rawIds, logger);
 
     if (projectCode.toUpperCase() === 'ID') {
       legacyIds.push(...ids);

--- a/qase-javascript-commons/test/internal/filter-positive-ids.test.ts
+++ b/qase-javascript-commons/test/internal/filter-positive-ids.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { filterPositiveIds } from '../../src/internal/filter-positive-ids';
+
+describe('filterPositiveIds', () => {
+  it('returns the same array when all ids are positive', () => {
+    expect(filterPositiveIds([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it('drops zero ids', () => {
+    expect(filterPositiveIds([1, 0, 2])).toEqual([1, 2]);
+  });
+
+  it('drops negative ids', () => {
+    expect(filterPositiveIds([1, -5, 2])).toEqual([1, 2]);
+  });
+
+  it('drops NaN values', () => {
+    expect(filterPositiveIds([1, Number.NaN, 2])).toEqual([1, 2]);
+  });
+
+  it('drops non-finite values', () => {
+    expect(filterPositiveIds([1, Number.POSITIVE_INFINITY, 2])).toEqual([1, 2]);
+  });
+
+  it('returns empty array when every id is invalid', () => {
+    expect(filterPositiveIds([0, -1, Number.NaN])).toEqual([]);
+  });
+
+  it('calls logger.log once per dropped non-positive id with the expected message', () => {
+    const log = jest.fn();
+    const logger = { log, logError: jest.fn(), logDebug: jest.fn() };
+
+    filterPositiveIds([1, 0, -3, 2], logger);
+
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenNthCalledWith(
+      1,
+      'Warning: Qase test case ID must be greater than 0, got "0". This ID will be ignored and the result will be sent without it.',
+    );
+    expect(log).toHaveBeenNthCalledWith(
+      2,
+      'Warning: Qase test case ID must be greater than 0, got "-3". This ID will be ignored and the result will be sent without it.',
+    );
+  });
+
+  it('does not call logger.log for NaN or non-finite values', () => {
+    const log = jest.fn();
+    const logger = { log, logError: jest.fn(), logDebug: jest.fn() };
+
+    filterPositiveIds([Number.NaN, Number.POSITIVE_INFINITY], logger);
+
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('falls back to console.warn when no logger is provided', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      filterPositiveIds([1, 0, 2]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[qase] Warning: Qase test case ID must be greater than 0, got "0". This ID will be ignored and the result will be sent without it.',
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/qase-javascript-commons/test/internal/ids-parser.test.ts
+++ b/qase-javascript-commons/test/internal/ids-parser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import { parseQaseIdsFromString } from '../../src/internal/ids-parser';
 
 describe('parseQaseIdsFromString', () => {
@@ -24,5 +24,25 @@ describe('parseQaseIdsFromString', () => {
 
   it('returns an empty array for a whitespace-only string', () => {
     expect(parseQaseIdsFromString('   ')).toEqual([]);
+  });
+
+  it('drops zero ids', () => {
+    expect(parseQaseIdsFromString('1,0,2')).toEqual([1, 2]);
+  });
+
+  it('drops negative ids', () => {
+    expect(parseQaseIdsFromString('1,-5,2')).toEqual([1, 2]);
+  });
+
+  it('returns empty array when only zero is given', () => {
+    expect(parseQaseIdsFromString('0')).toEqual([]);
+  });
+
+  it('passes warnings to the provided logger', () => {
+    const log = jest.fn();
+    const logger = { log, logError: jest.fn(), logDebug: jest.fn() };
+    parseQaseIdsFromString('1,0,2', logger);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]?.[0]).toContain('got "0"');
   });
 });

--- a/qase-javascript-commons/test/utils/project-mapping-utils.test.ts
+++ b/qase-javascript-commons/test/utils/project-mapping-utils.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  parseProjectMappingFromTitle,
+  parseProjectMappingFromTags,
+} from '../../src/utils/project-mapping-utils';
+
+describe('parseProjectMappingFromTitle', () => {
+  it('parses a legacy id from a title', () => {
+    const parsed = parseProjectMappingFromTitle('Login (Qase ID: 5)');
+    expect(parsed.legacyIds).toEqual([5]);
+    expect(parsed.projectMapping).toEqual({});
+    expect(parsed.cleanedTitle).toBe('Login');
+  });
+
+  it('parses a comma-separated legacy id list', () => {
+    const parsed = parseProjectMappingFromTitle('Login (Qase ID: 1,2,3)');
+    expect(parsed.legacyIds).toEqual([1, 2, 3]);
+  });
+
+  it('parses a project mapping marker', () => {
+    const parsed = parseProjectMappingFromTitle('Login (Qase PROJ1: 1,2)');
+    expect(parsed.legacyIds).toEqual([]);
+    expect(parsed.projectMapping).toEqual({ PROJ1: [1, 2] });
+  });
+
+  it('drops zero ids from legacy markers', () => {
+    const parsed = parseProjectMappingFromTitle('Login (Qase ID: 1,0,2)');
+    expect(parsed.legacyIds).toEqual([1, 2]);
+  });
+
+  it('drops negative ids from legacy markers', () => {
+    const parsed = parseProjectMappingFromTitle('Login (Qase ID: -3,4)');
+    expect(parsed.legacyIds).toEqual([4]);
+  });
+
+  it('omits a project entirely when all of its ids are non-positive', () => {
+    const parsed = parseProjectMappingFromTitle('Login (Qase PROJ1: 0)');
+    expect(parsed.projectMapping).toEqual({});
+  });
+
+  it('keeps positive ids in a project when some are invalid', () => {
+    const parsed = parseProjectMappingFromTitle('Login (Qase PROJ1: 0,5)');
+    expect(parsed.projectMapping).toEqual({ PROJ1: [5] });
+  });
+
+  it('passes warnings to the provided logger', () => {
+    const log = jest.fn();
+    const logger = { log, logError: jest.fn(), logDebug: jest.fn() };
+    parseProjectMappingFromTitle('Login (Qase ID: 0)', logger);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]?.[0]).toContain('got "0"');
+  });
+});
+
+describe('parseProjectMappingFromTags', () => {
+  it('parses @qaseid(1,2)', () => {
+    const parsed = parseProjectMappingFromTags(['@qaseid(1,2)']);
+    expect(parsed.legacyIds).toEqual([1, 2]);
+  });
+
+  it('parses @qaseid.PROJ1(1,2)', () => {
+    const parsed = parseProjectMappingFromTags(['@qaseid.PROJ1(1,2)']);
+    expect(parsed.projectMapping).toEqual({ PROJ1: [1, 2] });
+  });
+
+  it('drops zero ids', () => {
+    const parsed = parseProjectMappingFromTags(['@qaseid(1,0,2)']);
+    expect(parsed.legacyIds).toEqual([1, 2]);
+  });
+
+  it('drops negative ids', () => {
+    const parsed = parseProjectMappingFromTags(['@qaseid(-1,3)']);
+    expect(parsed.legacyIds).toEqual([3]);
+  });
+
+  it('omits a project entirely when all of its tag ids are non-positive', () => {
+    const parsed = parseProjectMappingFromTags(['@qaseid.PROJ1(0)']);
+    expect(parsed.projectMapping).toEqual({});
+  });
+
+  it('keeps positive ids in a project tag when some are invalid', () => {
+    const parsed = parseProjectMappingFromTags(['@qaseid.PROJ1(0,5)']);
+    expect(parsed.projectMapping).toEqual({ PROJ1: [5] });
+  });
+
+  it('passes warnings to the provided logger', () => {
+    const log = jest.fn();
+    const logger = { log, logError: jest.fn(), logDebug: jest.fn() };
+    parseProjectMappingFromTags(['@qaseid(0)'], logger);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]?.[0]).toContain('got "0"');
+  });
+});

--- a/qase-jest/changelog.md
+++ b/qase-jest/changelog.md
@@ -1,3 +1,9 @@
+# jest-qase-reporter@2.5.4
+
+## Fixed
+
+- Qase test case IDs that are `<= 0` (e.g. an accidental `(Qase ID: 0)` in a test title) are now dropped with a warning instead of being sent to the API, which previously rejected the whole batch with HTTP 400. The signature derivation path also filters non-positive IDs to stay consistent with the reported IDs. Bumped `qase-javascript-commons` pin to `~2.7.4`.
+
 # jest-qase-reporter@2.5.3
 
 ## Fixed

--- a/qase-jest/package.json
+++ b/qase-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-qase-reporter",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Qase TMS Jest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -46,7 +46,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",
-    "qase-javascript-commons": "~2.7.3",
+    "qase-javascript-commons": "~2.7.4",
     "uuid": "11.1.1"
   },
   "devDependencies": {

--- a/qase-jest/src/modules/resultBuilder.ts
+++ b/qase-jest/src/modules/resultBuilder.ts
@@ -12,6 +12,7 @@ import {
   TestStepType,
 } from 'qase-javascript-commons';
 import {
+  filterPositiveIds,
   normalizeSuitePart,
   removeQaseIdsFromTitle,
 } from 'qase-javascript-commons/internal';
@@ -173,6 +174,9 @@ export class ResultBuilder {
 
   private static getCaseId(title: string): number[] {
     const m = title.match(QASE_ID_REGEXP);
-    return m?.[1] ? m[1].split(',').map((id) => Number(id)) : [];
+    if (!m?.[1]) {
+      return [];
+    }
+    return filterPositiveIds(m[1].split(',').map((id) => Number(id)));
   }
 }

--- a/qase-newman/changelog.md
+++ b/qase-newman/changelog.md
@@ -1,3 +1,9 @@
+# newman-reporter-qase@2.3.3
+
+## Fixed
+
+- Qase test case IDs that are `<= 0` (e.g. `// qase: 0` in a Postman test script) are now dropped with a warning instead of being sent to the API, which previously rejected the whole batch with HTTP 400. Bumped `qase-javascript-commons` pin to `~2.7.4`.
+
 # newman-reporter-qase@2.3.2
 
 ## Fixed

--- a/qase-newman/package.json
+++ b/qase-newman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-qase",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Qase TMS Newman Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -40,7 +40,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.7.3",
+    "qase-javascript-commons": "~2.7.4",
     "semver": "^7.7.3"
   },
   "devDependencies": {

--- a/qase-newman/src/modules/metadataExtractor.ts
+++ b/qase-newman/src/modules/metadataExtractor.ts
@@ -1,5 +1,6 @@
 import { EventList, Item, PropertyBase, PropertyBaseDefinition } from 'postman-collection';
 import { TestopsProjectMapping } from 'qase-javascript-commons';
+import { filterPositiveIds } from 'qase-javascript-commons/internal';
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class MetadataExtractor {
@@ -20,7 +21,7 @@ export class MetadataExtractor {
         });
       }
     });
-    return ids;
+    return filterPositiveIds(ids);
   }
 
   static getProjectMapping(eventList: EventList): TestopsProjectMapping {
@@ -33,7 +34,11 @@ export class MetadataExtractor {
           while ((m = re.exec(line)) !== null) {
             const projectCode = m[1]?.trim();
             const idsStr = (m[2] ?? '').replace(/\s/g, '');
-            const ids = idsStr.split(',').map((s) => parseInt(s, 10)).filter((n) => !Number.isNaN(n));
+            const rawIds = idsStr
+              .split(',')
+              .map((s) => parseInt(s, 10))
+              .filter((n) => !Number.isNaN(n));
+            const ids = filterPositiveIds(rawIds);
             if (projectCode && projectCode.toUpperCase() !== 'ID' && ids.length > 0) {
               const existing = projectMapping[projectCode] ?? [];
               projectMapping[projectCode] = [...existing, ...ids];

--- a/qase-newman/test/metadataExtractor.test.ts
+++ b/qase-newman/test/metadataExtractor.test.ts
@@ -17,6 +17,14 @@ describe('MetadataExtractor.getCaseIds', () => {
     expect(MetadataExtractor.getCaseIds(eventListFromExec(['// qase: 1,2,3']))).toEqual([1, 2, 3]);
   });
 
+  it('filters out zero from `// qase: 1,0,2`', () => {
+    expect(MetadataExtractor.getCaseIds(eventListFromExec(['// qase: 1,0,2']))).toEqual([1, 2]);
+  });
+
+  it('returns [] for `// qase: 0`', () => {
+    expect(MetadataExtractor.getCaseIds(eventListFromExec(['// qase: 0']))).toEqual([]);
+  });
+
   it('returns [] for non-test event listeners', () => {
     expect(MetadataExtractor.getCaseIds(eventListFromExec(['// qase: 1'], 'prerequest'))).toEqual([]);
   });
@@ -60,6 +68,16 @@ describe('MetadataExtractor.getProjectMapping', () => {
         eventListFromExec(['// qase PROJ: 1', '// qase PROJ: 2,3']),
       ),
     ).toEqual({ PROJ: [1, 2, 3] });
+  });
+
+  it('filters zero: `// qase PROJ1: 0,5` returns { PROJ1: [5] }', () => {
+    expect(MetadataExtractor.getProjectMapping(eventListFromExec(['// qase PROJ1: 0,5'])))
+      .toEqual({ PROJ1: [5] });
+  });
+
+  it('drops project entirely when all ids are zero: `// qase PROJ1: 0` returns {}', () => {
+    expect(MetadataExtractor.getProjectMapping(eventListFromExec(['// qase PROJ1: 0'])))
+      .toEqual({});
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `filterPositiveIds` helper in `qase-javascript-commons/src/internal/` that drops Qase test case IDs `<= 0` and logs a warning per dropped ID (via `LoggerInterface` when available, falling back to `console.warn` otherwise).
- Apply the helper inside all ID-producing parsers: the three central commons parsers (`parseQaseIdsFromString`, `parseProjectMappingFromTitle`, `parseProjectMappingFromTags`) and three reporter-local parsers (newman `MetadataExtractor`, jest `ResultBuilder.getCaseId`, cucumberjs `TagParser` for `@Q…` and `@QaseID=` formats).
- Bumped patch versions: `qase-javascript-commons` 2.7.3 → 2.7.4, `newman-reporter-qase` 2.3.2 → 2.3.3, `jest-qase-reporter` 2.5.3 → 2.5.4, `cucumberjs-qase-reporter` 2.4.3 → 2.4.4. Updated changelogs and commons pins.

## Why

Reported by users: when a contributor accidentally sets a Qase test case ID to `0` in test code (e.g. `(Qase ID: 0)`, `@qaseid(0)`, `// qase: 0`), the API rejects the result with HTTP 400 and the entire batch is dropped. Hard to control for every contributor not to do this inadvertently.

Now the invalid ID is silently stripped (with a warning), and the result is reported without an ID — same outcome as if no ID had been specified.

## Test plan

- [x] `npm test` in `qase-javascript-commons` — 515/515 pass (8 new tests for `filterPositiveIds`, 4 new for `parseQaseIdsFromString`, 15 new in `project-mapping-utils.test.ts`)
- [x] `npm test` in `qase-jest` — 84/84 pass
- [x] `npm test` in `qase-cucumberjs` — 84/84 pass
- [x] `npm test` in `qase-newman` — 59/59 pass (4 new tests for zero-filtering in `MetadataExtractor`)
- [x] `npm run build --workspaces --if-present` — all packages build
- [x] `npm run lint --workspaces --if-present` — 0 errors (only pre-existing warnings)