### PR TITLE
fix: do not send empty testops_ids array to the API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28126,7 +28126,7 @@
       }
     },
     "qase-api-client": {
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.16.0",
@@ -28250,7 +28250,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.7.4",
+      "version": "2.7.5",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -28376,11 +28376,11 @@
     },
     "qase-playwright": {
       "name": "playwright-qase-reporter",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
-        "qase-javascript-commons": "~2.7.4",
+        "qase-javascript-commons": "~2.7.5",
         "uuid": "11.1.1"
       },
       "devDependencies": {

--- a/qase-javascript-commons/changelog.md
+++ b/qase-javascript-commons/changelog.md
@@ -1,3 +1,9 @@
+## 2.7.5
+
+### Fixed
+
+- `ResultTransformer.transform()` now maps an empty-array `testops_id` to `null` in the outgoing payload (was leaking `testops_ids: []`, which the API rejects with HTTP 400 — `"Each testops_ids item must be a positive integer."`). This is a defensive guard: in 2.7.4 a `[]` could still slip out from reporter result-builders that fed the registry-lookup branch after all IDs got filtered.
+
 ## 2.7.4
 
 ### Fixed

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/src/client/services/result-transformer.ts
+++ b/qase-javascript-commons/src/client/services/result-transformer.ts
@@ -52,7 +52,7 @@ export class ResultTransformer {
       title: result.title,
       execution: this.getExecution(result.execution),
       testops_ids: Array.isArray(result.testops_id)
-        ? result.testops_id
+        ? (result.testops_id.length > 0 ? result.testops_id : null)
         : result.testops_id !== null ? [result.testops_id] : null,
       attachments: attachments,
       steps: steps,

--- a/qase-javascript-commons/test/client/services/result-transformer.test.ts
+++ b/qase-javascript-commons/test/client/services/result-transformer.test.ts
@@ -83,6 +83,11 @@ describe('ResultTransformer', () => {
       expect(model.testops_ids).toBeNull();
     });
 
+    it('should map empty-array testops_id to null (API rejects []) ', async () => {
+      const model = await transformer.transform(makeResult({ testops_id: [] }), mockUploader);
+      expect(model.testops_ids).toBeNull();
+    });
+
     it('should handle undefined tags', async () => {
       const result = makeResult();
       delete result.tags;

--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,9 @@
+# playwright-qase-reporter@2.5.5
+
+## Fixed
+
+- Calling `qase(0, name)` (and any case where every supplied ID gets filtered out) no longer leaks an empty array into the static registry, and the result-builder no longer returns an empty array for an empty registry entry. In 2.5.4, `qase(0, name)` would publish results with `"testops_ids": []`, which the API rejects with HTTP 400 (`"Each testops_ids item must be a positive integer."`). After this fix the result is published with `testops_ids: null` — i.e. with no ID — same as if no ID had been specified. Bumped `qase-javascript-commons` pin to `~2.7.5`.
+
 # playwright-qase-reporter@2.5.4
 
 ## Fixed

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -49,7 +49,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^4.1.2",
-    "qase-javascript-commons": "~2.7.4",
+    "qase-javascript-commons": "~2.7.5",
     "uuid": "11.1.1"
   },
   "peerDependencies": {

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -61,7 +61,10 @@ export const qase = (
 
   const newName = `${name} (Qase ID: ${caseIds.join(',')})`;
 
-  PlaywrightQaseReporter.addIds(filterPositiveIds(ids), newName);
+  const filteredIds = filterPositiveIds(ids);
+  if (filteredIds.length > 0) {
+    PlaywrightQaseReporter.addIds(filteredIds, newName);
+  }
 
   return newName;
 };

--- a/qase-playwright/src/result-builder.ts
+++ b/qase-playwright/src/result-builder.ts
@@ -106,7 +106,8 @@ export class ResultBuilder {
       testops_id = titleParsed.legacyIds.length === 1 ? titleParsed.legacyIds[0]! : titleParsed.legacyIds;
       testops_project_mapping = null;
     } else {
-      testops_id = qaseIdsRegistry.get(test.title) ?? null;
+      const registryIds = qaseIdsRegistry.get(test.title);
+      testops_id = registryIds && registryIds.length > 0 ? registryIds : null;
       testops_project_mapping = null;
     }
 

--- a/qase-playwright/test/result-builder.test.ts
+++ b/qase-playwright/test/result-builder.test.ts
@@ -115,6 +115,13 @@ describe('ResultBuilder precedence chain', () => {
     const r = builder.build(args)!;
     expect(r.testops_id).toEqual([99]);
   });
+
+  it('returns null testops_id when registry entry is an empty array (regression: qase(0,...) used to leak [])', () => {
+    const registry = new Map<string, number[]>([['fallback test', []]]);
+    const args = defaultArgs({ test: makeTest('fallback test'), qaseIdsRegistry: registry });
+    const r = builder.build(args)!;
+    expect(r.testops_id).toBeNull();
+  });
 });
 
 describe('ResultBuilder feature flags and merging', () => {


### PR DESCRIPTION
## Summary

Follow-up to #974 reported by the user: with playwright-qase-reporter@2.5.4, `qase(0, "Test Name")` still produces HTTP 400 — but for a different reason than before.

**Root cause:**

1. \`qase(0, "...")\` ran my filter from #974 and called \`PlaywrightQaseReporter.addIds([], "Test Name (Qase ID: 0)")\` — registering an **empty array** in the static fallback Map.
2. \`result-builder.ts:109\`: \`testops_id = qaseIdsRegistry.get(test.title) ?? null\` — the \`??\` operator only fires on null/undefined, so \`[] ?? null = []\`. \`testops_id\` became \`[]\`.
3. \`result-transformer.ts:54-56\`: \`Array.isArray([])\` is true → \`testops_ids: []\` shipped to the API → HTTP 400 (\`"Each testops_ids item must be a positive integer."\`).

The API rejects empty arrays the same way it rejects \`0\`.

## Fix (defense in depth)

Three layers so this class of bug can't recur:

- **playwright \`qase()\`** — only call \`PlaywrightQaseReporter.addIds\` when the filtered list is non-empty (don't register \`[]\` in the registry).
- **playwright \`result-builder.ts\`** — registry lookup falls back to \`null\` when the entry is an empty array.
- **commons \`result-transformer.ts\`** — maps empty-array \`testops_id\` to \`null\` in the outgoing payload.

After the fix all four formats from the user's repro produce \`testops_id: null\` (no ID), letting the result land normally.

## Verified end-to-end

Built playwright reporter locally, ran the repro spec with \`QASE_MODE=report\` (writes JSON locally), and read \`[DEBUG] qase: Adding test result\` log lines for each of the four formats:

\`\`\`
Format 1: qase(0, "...")           → "testops_id":null,"testops_project_mapping":null
Format 2: qase.id(0)               → "testops_id":null,"testops_project_mapping":null
Format 3: annotation QaseID="0"    → "testops_id":null,"testops_project_mapping":null
Format 4: qase.projects({P:[0]})   → "testops_id":null,"testops_project_mapping":null
\`\`\`

Previously Format 1 was \`"testops_id":[]\`. All four now correctly emit \`null\`.

## Test plan

- [x] \`npm test\` in \`qase-javascript-commons\` — 516/516 (1 new for empty-array testops_id → null in transformer)
- [x] \`npm test\` in \`qase-playwright\` — 99/99 (1 new for empty-array registry → null testops_id)
- [x] \`npm run build\` for both packages

## Versions

- \`qase-javascript-commons\` 2.7.4 → **2.7.5**
- \`playwright-qase-reporter\` 2.5.4 → **2.5.5**, commons pin \`~2.7.5\`