### PR TITLE
docs(playwright): align qase.step docs with actual signature

### DIFF
--- a/qase-playwright/docs/ATTACHMENTS.md
+++ b/qase-playwright/docs/ATTACHMENTS.md
@@ -129,7 +129,7 @@ import { test, expect } from '@playwright/test';
 import { qase } from 'playwright-qase-reporter';
 
 test('Test with step attachments', async ({ page }) => {
-  await qase.step('Navigate to page', async () => {
+  await test.step('Navigate to page', async () => {
     await page.goto('https://example.com');
 
     qase.attach({
@@ -139,7 +139,7 @@ test('Test with step attachments', async ({ page }) => {
     });
   });
 
-  await qase.step('Capture screenshot', async () => {
+  await test.step('Capture screenshot', async () => {
     const screenshot = await page.screenshot();
 
     qase.attach({

--- a/qase-playwright/docs/STEPS.md
+++ b/qase-playwright/docs/STEPS.md
@@ -18,37 +18,16 @@ Test steps provide granular visibility into test execution. Each step is reporte
 
 ## Defining Steps
 
-### Using Async Function
+In Playwright, steps are defined with the native `test.step()` API. The reporter listens to Playwright's step events and reports them to Qase automatically — no extra wrapper is required for ordinary steps.
 
-Playwright supports both `qase.step()` and native `test.step()` for defining test steps:
+`qase.step()` is a string helper that adds **expected result** and **data** markers to a step title; it does **not** execute a callback itself. See [Steps with Expected Result and Data](#steps-with-expected-result-and-data) below.
 
-```typescript
-import { test, expect } from '@playwright/test';
-import { qase } from 'playwright-qase-reporter';
-
-test('Test with multiple steps using qase.step()', async ({ page }) => {
-  await qase.step('Initialize the environment', async () => {
-    await page.goto('https://example.com');
-  });
-
-  await qase.step('Test Core Functionality of the app', async () => {
-    await page.click('#action-button');
-  });
-
-  await qase.step('Verify Expected Behavior of the app', async () => {
-    await expect(page.locator('.result')).toBeVisible();
-  });
-});
-```
-
-### Using Native test.step()
-
-Playwright's built-in `test.step()` is also fully supported and reported to Qase:
+### Using test.step()
 
 ```typescript
 import { test, expect } from '@playwright/test';
 
-test('Test with native test.step()', async ({ page }) => {
+test('Test with multiple steps', async ({ page }) => {
   await test.step('Initialize the environment', async () => {
     await page.goto('https://example.com');
   });
@@ -63,29 +42,23 @@ test('Test with native test.step()', async ({ page }) => {
 });
 ```
 
-**When to use which:**
-- Use `test.step()` for Playwright-native integration and when you want steps to appear in Playwright's trace viewer
-- Use `qase.step()` for cross-framework consistency if you're maintaining tests across multiple frameworks
-- Both methods are reported to Qase with the same level of detail
-
 ### Step Parameters
 
 Steps can include parameters for dynamic naming:
 
 ```typescript
 import { test, expect } from '@playwright/test';
-import { qase } from 'playwright-qase-reporter';
 
 test('Test with dynamic step names', async ({ page }) => {
   const username = 'john@example.com';
 
-  await qase.step(`Login as user ${username}`, async () => {
+  await test.step(`Login as user ${username}`, async () => {
     await page.fill('#email', username);
     await page.fill('#password', 'password');
     await page.click('button[type="submit"]');
   });
 
-  await qase.step(`Verify ${username} profile loaded`, async () => {
+  await test.step(`Verify ${username} profile loaded`, async () => {
     await expect(page.locator('.user-email')).toHaveText(username);
   });
 });
@@ -95,30 +68,12 @@ test('Test with dynamic step names', async ({ page }) => {
 
 ## Nested Steps
 
-Create hierarchical step structures with either method:
+Create hierarchical step structures by nesting `test.step()` calls:
 
 ```typescript
 import { test, expect } from '@playwright/test';
-import { qase } from 'playwright-qase-reporter';
 
-test('Test with nested steps using qase.step()', async ({ page }) => {
-  await qase.step('Complete user registration', async () => {
-    await qase.step('Fill registration form', async () => {
-      await page.fill('#name', 'John Doe');
-      await page.fill('#email', 'john@example.com');
-    });
-
-    await qase.step('Submit registration', async () => {
-      await page.click('button[type="submit"]');
-    });
-  });
-
-  await qase.step('Verify registration success', async () => {
-    await expect(page.locator('.success-message')).toBeVisible();
-  });
-});
-
-test('Test with nested steps using test.step()', async ({ page }) => {
+test('Test with nested steps', async ({ page }) => {
   await test.step('Complete user registration', async () => {
     await test.step('Fill registration form', async () => {
       await page.fill('#name', 'John Doe');
@@ -140,64 +95,61 @@ test('Test with nested steps using test.step()', async ({ page }) => {
 
 ## Steps with Expected Result and Data
 
-Define expected results and data for steps:
+When you need to attach an **expected result** or **input data** to a step, wrap the step name with `qase.step()`. It returns a formatted string with internal markers that the reporter parses and converts into structured fields in Qase.
+
+**Signature:**
+```typescript
+qase.step(
+  action: string,
+  expectedResult: string | undefined,
+  data: string | undefined,
+): string
+```
+
+**Usage — pass the result of `qase.step()` as the step name to `test.step()`:**
 
 ```typescript
 import { test, expect } from '@playwright/test';
 import { qase } from 'playwright-qase-reporter';
 
 test('Test with expected results', async ({ page }) => {
-  await qase.step(
-    'Click button',
+  await test.step(
+    qase.step('Click button', 'Button should be clicked', 'Button data'),
     async () => {
       await page.click('#submit-button');
     },
-    'Button should be clicked',
-    'Button data'
   );
 
-  await qase.step(
-    'Fill form',
+  await test.step(
+    qase.step('Fill form', 'Form should be filled', 'Form input data'),
     async () => {
       await page.fill('#input-field', 'test value');
     },
-    'Form should be filled',
-    'Form input data'
   );
 
-  await qase.step(
-    'Submit form',
+  await test.step(
+    qase.step('Submit form', 'Form should be submitted', undefined),
     async () => {
       await page.click('button[type="submit"]');
     },
-    'Form should be submitted',
-    'Form submission data'
   );
 });
 ```
 
-**Signature:**
-```typescript
-await qase.step(
-  name: string,
-  callback: () => Promise<void> | void,
-  expectedResult?: string,
-  data?: string
-): Promise<void>
-```
+> All three positional arguments are required. Pass `undefined` for `expectedResult` or `data` when you don't need them.
 
 ---
 
 ## Steps with Attachments
 
-Attach content to a specific step:
+Attach content to a specific step by calling `qase.attach()` from inside the step callback:
 
 ```typescript
 import { test, expect } from '@playwright/test';
 import { qase } from 'playwright-qase-reporter';
 
 test('Test with step attachments', async ({ page }) => {
-  await qase.step('Capture application state', async () => {
+  await test.step('Capture application state', async () => {
     const screenshot = await page.screenshot();
 
     qase.attach({
@@ -207,7 +159,7 @@ test('Test with step attachments', async ({ page }) => {
     });
   });
 
-  await qase.step('Verify state', async () => {
+  await test.step('Verify state', async () => {
     await expect(page.locator('.status')).toHaveText('active');
   });
 });
@@ -255,12 +207,12 @@ await test.step('Fill form and submit', async () => {  // Too broad
 
 ```typescript
 // Good: Clear action description
-await qase.step('Verify user is redirected to dashboard', async () => {
+await test.step('Verify user is redirected to dashboard', async () => {
   await expect(page).toHaveURL(/.*dashboard/);
 });
 
 // Avoid: Vague names
-await qase.step('Check page', async () => {
+await test.step('Check page', async () => {
   await expect(page).toHaveURL(/.*dashboard/);
 });
 ```
@@ -269,12 +221,12 @@ await qase.step('Check page', async () => {
 
 ```typescript
 // Good: Include relevant context
-await qase.step(`Add product '${productName}' to cart`, async () => {
+await test.step(`Add product '${productName}' to cart`, async () => {
   await page.click(`[data-product="${productName}"] .add-to-cart`);
 });
 
 // Better than generic:
-await qase.step('Add product', async () => {
+await test.step('Add product', async () => {
   await page.click(`[data-product="${productName}"] .add-to-cart`);
 });
 ```
@@ -287,21 +239,20 @@ await qase.step('Add product', async () => {
 
 ```typescript
 import { test, expect, Page } from '@playwright/test';
-import { qase } from 'playwright-qase-reporter';
 
 class LoginPage {
   constructor(private page: Page) {}
 
   async login(username: string, password: string) {
-    await qase.step(`Enter username: ${username}`, async () => {
+    await test.step(`Enter username: ${username}`, async () => {
       await this.page.fill('#email', username);
     });
 
-    await qase.step('Enter password', async () => {
+    await test.step('Enter password', async () => {
       await this.page.fill('#password', password);
     });
 
-    await qase.step('Click login button', async () => {
+    await test.step('Click login button', async () => {
       await this.page.click('button[type="submit"]');
     });
   }
@@ -318,20 +269,19 @@ test('User can login', async ({ page }) => {
 
 ```typescript
 import { test, expect } from '@playwright/test';
-import { qase } from 'playwright-qase-reporter';
 
 test('API returns correct user data', async ({ request }) => {
   let response;
 
-  await qase.step('Send GET request to /api/users/1', async () => {
+  await test.step('Send GET request to /api/users/1', async () => {
     response = await request.get('https://api.example.com/users/1');
   });
 
-  await qase.step('Verify response status is 200', async () => {
+  await test.step('Verify response status is 200', async () => {
     expect(response.status()).toBe(200);
   });
 
-  await qase.step('Verify response contains user data', async () => {
+  await test.step('Verify response contains user data', async () => {
     const data = await response.json();
     expect(data.id).toBe(1);
     expect(data.name).toBeDefined();
@@ -343,15 +293,14 @@ test('API returns correct user data', async ({ request }) => {
 
 ```typescript
 import { test, expect } from '@playwright/test';
-import { qase } from 'playwright-qase-reporter';
 
 test.describe('User tests', () => {
   test.beforeEach(async ({ page }) => {
-    await qase.step('Setup: Navigate to application', async () => {
+    await test.step('Setup: Navigate to application', async () => {
       await page.goto('https://example.com');
     });
 
-    await qase.step('Setup: Authenticate user', async () => {
+    await test.step('Setup: Authenticate user', async () => {
       await page.fill('#email', 'test@example.com');
       await page.fill('#password', 'password');
       await page.click('button[type="submit"]');
@@ -359,13 +308,13 @@ test.describe('User tests', () => {
   });
 
   test.afterEach(async ({ page }) => {
-    await qase.step('Cleanup: Logout user', async () => {
+    await test.step('Cleanup: Logout user', async () => {
       await page.click('#logout-button');
     });
   });
 
   test('Test user operations', async ({ page }) => {
-    await qase.step('Perform user action', async () => {
+    await test.step('Perform user action', async () => {
       await page.click('#user-action');
     });
   });
@@ -378,40 +327,39 @@ test.describe('User tests', () => {
 
 ### Steps Not Appearing
 
-1. Verify the step function is properly imported from `playwright-qase-reporter`
-2. Check that steps are executed within a test context
-3. Enable debug logging to trace step recording
-4. **Ensure you're using `await` with async step callbacks** - Missing `await` is the most common issue
+1. Check that steps are executed within a test context
+2. Enable debug logging to trace step recording
+3. **Ensure you're using `await` with `test.step()` callbacks** — missing `await` is the most common issue
 
 ```typescript
 // Incorrect: Missing await
-qase.step('Step name', async () => {  // Step won't be recorded properly
+test.step('Step name', async () => {  // Step won't be recorded properly
   // Logic
 });
 
 // Correct: Using await
-await qase.step('Step name', async () => {
+await test.step('Step name', async () => {
   // Logic
 });
 ```
 
 ### Nested Steps Flattened
 
-Ensure you're using the async callbacks correctly for nesting:
+Ensure callbacks are nested, not chained sequentially:
 
 ```typescript
 // Correct: Nested callbacks
-await qase.step('Parent step', async () => {
-  await qase.step('Child step', async () => {
+await test.step('Parent step', async () => {
+  await test.step('Child step', async () => {
     // Child step logic
   });
 });
 
 // Incorrect: Sequential, not nested
-await qase.step('Step 1', async () => {
+await test.step('Step 1', async () => {
   // Step 1 logic
 });
-await qase.step('Step 2', async () => {  // Not nested under Step 1
+await test.step('Step 2', async () => {  // Not nested under Step 1
   // Step 2 logic
 });
 ```

--- a/qase-playwright/docs/UPGRADE.md
+++ b/qase-playwright/docs/UPGRADE.md
@@ -29,7 +29,7 @@ Version 2.2.0 includes:
 - Full support for Qase TestOps API with batch result upload
 - Dual test case linking patterns: wrapper function and method-based annotation
 - Rich metadata support: titles, fields, suites, parameters, comments
-- Native Playwright test steps and qase.step() for custom steps
+- Native Playwright test steps with optional `qase.step()` helper for expected result / data
 - Screenshot and file attachments with `qase.attach()`
 - Multi-project support for reporting to multiple Qase projects
 - Flexible configuration via `qase.config.json` or playwright.config.ts
@@ -153,40 +153,43 @@ test('Test with metadata', async ({ page }) => {
 
 ### Steps
 
-**Custom Steps with qase.step():**
+**Native Playwright Steps:**
+
+Use Playwright's native `test.step()` — the reporter listens to its events and reports each step to Qase.
 
 ```typescript
-test('Test with custom steps', async ({ page }) => {
-  await qase.step('Navigate to login page', async () => {
+test('Test with steps', async ({ page }) => {
+  await test.step('Navigate to login page', async () => {
     await page.goto('https://example.com/login');
   });
 
-  await qase.step('Enter credentials', async () => {
+  await test.step('Enter credentials', async () => {
     await page.fill('#username', 'user@example.com');
     await page.fill('#password', 'password123');
   });
 
-  await qase.step('Verify login success', async () => {
+  await test.step('Verify login success', async () => {
     await expect(page.locator('.dashboard')).toBeVisible();
   });
 });
 ```
 
-**Native Playwright Steps:**
+**Steps with Expected Result and Data via `qase.step()`:**
+
+`qase.step(action, expectedResult, data)` is a string helper that decorates the step title with markers for expected result and input data. Pass its return value as the step name to `test.step()`:
 
 ```typescript
-test('Test with native steps', async ({ page }) => {
-  await test.step('Navigate to page', async () => {
-    await page.goto('https://example.com');
-  });
-
-  await test.step('Verify page loaded', async () => {
-    await expect(page).toHaveTitle('Example');
-  });
+test('Test with expected results', async ({ page }) => {
+  await test.step(
+    qase.step('Click login button', 'Button should be clicked', 'Login button data'),
+    async () => {
+      await page.click('button[type="submit"]');
+    },
+  );
 });
 ```
 
-Both patterns are reported to Qase. You can mix them in the same test if needed.
+All three positional arguments are required — pass `undefined` for `expectedResult` or `data` when not needed.
 
 ### Attachments
 

--- a/qase-playwright/docs/usage.md
+++ b/qase-playwright/docs/usage.md
@@ -328,46 +328,29 @@ Common MIME types are auto-detected. You can also specify explicitly:
 
 ## Working with Steps
 
-Define test steps for detailed reporting in Qase. Playwright supports **both** native `test.step()` and `qase.step()`.
+Define test steps for detailed reporting in Qase. Use Playwright's native `test.step()` API — the reporter listens to its events automatically.
 
-### Using qase.step (Async)
+### Using test.step
 
 ```typescript
 import { test, expect } from '@playwright/test';
-import { qase } from 'playwright-qase-reporter';
 
-test('Test with qase.step', async ({ page }) => {
-  await qase.step('Navigate to login page', async () => {
+test('Test with steps', async ({ page }) => {
+  await test.step('Navigate to login page', async () => {
     await page.goto('https://example.com/login');
   });
 
-  await qase.step('Fill login form', async () => {
+  await test.step('Fill login form', async () => {
     await page.fill('#email', 'user@example.com');
     await page.fill('#password', 'password123');
   });
 
-  await qase.step('Submit form', async () => {
+  await test.step('Submit form', async () => {
     await page.click('button[type="submit"]');
   });
 
-  await qase.step('Verify successful login', async () => {
+  await test.step('Verify successful login', async () => {
     await expect(page.locator('.dashboard')).toBeVisible();
-  });
-});
-```
-
-### Using Native test.step
-
-```typescript
-import { test, expect } from '@playwright/test';
-
-test('Test with native test.step', async ({ page }) => {
-  await test.step('Navigate to page', async () => {
-    await page.goto('https://example.com');
-  });
-
-  await test.step('Verify title', async () => {
-    await expect(page).toHaveTitle('Example Domain');
   });
 });
 ```
@@ -376,43 +359,44 @@ test('Test with native test.step', async ({ page }) => {
 
 ```typescript
 import { test } from '@playwright/test';
-import { qase } from 'playwright-qase-reporter';
 
 test('Test with nested steps', async ({ page }) => {
-  await qase.step('Authentication flow', async () => {
-    await qase.step('Open login page', async () => {
+  await test.step('Authentication flow', async () => {
+    await test.step('Open login page', async () => {
       await page.goto('https://example.com/login');
     });
 
-    await qase.step('Enter credentials', async () => {
+    await test.step('Enter credentials', async () => {
       await page.fill('#email', 'user@example.com');
       await page.fill('#password', 'password123');
     });
 
-    await qase.step('Click login button', async () => {
+    await test.step('Click login button', async () => {
       await page.click('button[type="submit"]');
     });
   });
 });
 ```
 
-### Steps with Expected Result
+### Steps with Expected Result and Data
+
+`qase.step()` is a string helper that decorates a step title with **expected result** and **data** markers. Pass its return value as the step name to `test.step()`:
 
 ```typescript
 import { test } from '@playwright/test';
 import { qase } from 'playwright-qase-reporter';
 
 test('Test with expected results', async ({ page }) => {
-  await qase.step(
-    'Click login button',
+  await test.step(
+    qase.step('Click login button', 'Button should be clicked', 'Login button data'),
     async () => {
       await page.click('button[type="submit"]');
     },
-    'Button should be clicked',
-    'Login button data'
   );
 });
 ```
+
+> All three positional arguments of `qase.step()` are required. Pass `undefined` for `expectedResult` or `data` when you don't need them.
 
 > For more details, see [Steps Guide](STEPS.md).
 
@@ -563,7 +547,7 @@ type MyFixtures = {
 
 const test = base.extend<MyFixtures>({
   authenticatedPage: async ({ page }, use) => {
-    await qase.step('Setup authenticated page', async () => {
+    await test.step('Setup authenticated page', async () => {
       await page.goto('https://example.com/login');
       await page.fill('#email', 'user@example.com');
       await page.fill('#password', 'password123');
@@ -572,7 +556,7 @@ const test = base.extend<MyFixtures>({
 
     await use(page);
 
-    await qase.step('Cleanup authenticated page', async () => {
+    await test.step('Cleanup authenticated page', async () => {
       await page.click('#logout');
     });
   },
@@ -594,18 +578,18 @@ class LoginPage {
   constructor(private page: Page) {}
 
   async navigate() {
-    await qase.step('Navigate to login page', async () => {
+    await test.step('Navigate to login page', async () => {
       await this.page.goto('https://example.com/login');
     });
   }
 
   async login(email: string, password: string) {
-    await qase.step('Enter credentials', async () => {
+    await test.step('Enter credentials', async () => {
       await this.page.fill('#email', email);
       await this.page.fill('#password', password);
     });
 
-    await qase.step('Click login button', async () => {
+    await test.step('Click login button', async () => {
       await this.page.click('button[type="submit"]');
     });
   }
@@ -811,7 +795,7 @@ test(qase(201, 'GET /users returns 200'), async () => {
   qase.suite('API Tests');
   qase.fields({ layer: 'api' });
 
-  await qase.step('Send GET request', async () => {
+  await test.step('Send GET request', async () => {
     const context = await request.newContext();
     const response = await context.get('https://api.example.com/users');
 
@@ -989,7 +973,7 @@ test(qase([1, 2], 'Comprehensive test with all features'), async ({ page, browse
   });
 
   // Execute test with steps
-  await qase.step('Navigate to registration page', async () => {
+  await test.step('Navigate to registration page', async () => {
     await page.goto('https://example.com/register');
 
     const screenshot = await page.screenshot();
@@ -1000,17 +984,17 @@ test(qase([1, 2], 'Comprehensive test with all features'), async ({ page, browse
     });
   });
 
-  await qase.step('Fill registration form', async () => {
+  await test.step('Fill registration form', async () => {
     await page.fill('#email', 'user@example.com');
     await page.fill('#password', 'password123');
     await page.fill('#confirmPassword', 'password123');
   });
 
-  await qase.step('Submit form', async () => {
+  await test.step('Submit form', async () => {
     await page.click('button[type="submit"]');
   });
 
-  await qase.step('Verify registration success', async () => {
+  await test.step('Verify registration success', async () => {
     await expect(page.locator('.success-message')).toBeVisible();
 
     const finalScreenshot = await page.screenshot();


### PR DESCRIPTION
## Summary

Fix documentation/code contradiction reported in #977.

`qase.step()` is documented across `STEPS.md`, `usage.md`, `UPGRADE.md` and `ATTACHMENTS.md` as a callback wrapper:

```typescript
await qase.step('Initialize the environment', async () => { ... });
```

…but its actual signature is a string helper that decorates a step title with `QaseExpRes:` / `QaseData:` markers and must be passed to native `test.step()`:

```typescript
qase.step(action: string, expectedResult: string | undefined, data: string | undefined): string
```

That mismatch causes the TypeScript error reported in the issue (`Expected 3 arguments, but got 2`).

This PR updates the docs only — the implementation is unchanged.

- `STEPS.md`: ordinary step examples now use native `test.step()`; `qase.step()` is documented as a string helper for expected result / data, with correct signature and usage.
- `usage.md`: all step examples (page object, fixtures, API testing, end-to-end flow) switched to `test.step()`; kept a `qase.step()` example for expected result / data.
- `UPGRADE.md`: updated to the real API.
- `ATTACHMENTS.md`: step-with-attachment example switched to `test.step()`.

## Test plan
- [ ] Read through `qase-playwright/docs/STEPS.md` end-to-end
- [ ] Spot-check `qase-playwright/docs/usage.md` step sections
- [ ] Verify `UPGRADE.md` and `ATTACHMENTS.md` examples
- [ ] Confirm a fresh project following the new docs compiles without `ts(2554)`

Closes #977