### PR TITLE
chore: update API clients to latest specification

### DIFF
--- a/qase-api-client/docs/TestStepResult.md
+++ b/qase-api-client/docs/TestStepResult.md
@@ -7,8 +7,12 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **status** | **number** | 1 - passed, 2 - failed, 3 - blocked, 5 - skipped, 7 - in_progress | [optional] [default to undefined]
 **position** | **number** |  | [optional] [default to undefined]
+**comment** | **string** | Comment left for the step. | [optional] [default to undefined]
+**start_time** | **number** | Unix timestamp of the step start time. | [optional] [default to undefined]
+**end_time** | **number** | Unix timestamp of the step end time. | [optional] [default to undefined]
+**duration_ms** | **number** | Step duration in milliseconds. | [optional] [default to undefined]
 **attachments** | [**Array&lt;Attachment&gt;**](Attachment.md) |  | [optional] [default to undefined]
-**steps** | **Array&lt;object&gt;** | Nested steps results will be here. The same structure is used for them for them. | [optional] [default to undefined]
+**steps** | [**Array&lt;TestStepResult&gt;**](TestStepResult.md) | Nested steps results will be here. The same structure is used for them. | [optional] [default to undefined]
 
 ## Example
 
@@ -18,6 +22,10 @@ import { TestStepResult } from 'qase-api-client';
 const instance: TestStepResult = {
     status,
     position,
+    comment,
+    start_time,
+    end_time,
+    duration_ms,
     attachments,
     steps,
 };

--- a/qase-api-client/package.json
+++ b/qase-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-api-client",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Qase TMS Javascript API V1 Client",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-api-client/src/model/test-step-result.ts
+++ b/qase-api-client/src/model/test-step-result.ts
@@ -34,16 +34,40 @@ export interface TestStepResult {
      */
     'position'?: number;
     /**
+     * Comment left for the step.
+     * @type {string}
+     * @memberof TestStepResult
+     */
+    'comment'?: string;
+    /**
+     * Unix timestamp of the step start time.
+     * @type {number}
+     * @memberof TestStepResult
+     */
+    'start_time'?: number | null;
+    /**
+     * Unix timestamp of the step end time.
+     * @type {number}
+     * @memberof TestStepResult
+     */
+    'end_time'?: number | null;
+    /**
+     * Step duration in milliseconds.
+     * @type {number}
+     * @memberof TestStepResult
+     */
+    'duration_ms'?: number | null;
+    /**
      * 
      * @type {Array<Attachment>}
      * @memberof TestStepResult
      */
     'attachments'?: Array<Attachment>;
     /**
-     * Nested steps results will be here. The same structure is used for them for them.
-     * @type {Array<object>}
+     * Nested steps results will be here. The same structure is used for them.
+     * @type {Array<TestStepResult>}
      * @memberof TestStepResult
      */
-    'steps'?: Array<object>;
+    'steps'?: Array<TestStepResult>;
 }
 


### PR DESCRIPTION
## Summary

Updated the v1 API client to the latest OpenAPI specification.

### Targets updated
- v1 (`qase-api-client`): 1.1.10 → 1.1.11

### Changes
`TestStepResult` model now includes the fields actually returned by the public API v1:
- `comment` (string)
- `start_time`, `end_time`, `duration_ms` (nullable)
- nested `steps` now typed recursively as `Array<TestStepResult>`

### Protected files (skipped)
- `.npmignore`
- `src/configuration.ts`

### Warnings
None