### PR TITLE
fix(playwright): make qase.step expectedResult and data optional

### DIFF
--- a/qase-playwright/changelog.md
+++ b/qase-playwright/changelog.md
@@ -1,3 +1,9 @@
+# playwright-qase-reporter@2.5.6
+
+## Fixed
+
+- `qase.step` now types `expectedResult` and `data` as optional (`?`) instead of positionally required `string | undefined`. Previously the documented calls `qase.step('action')` and `qase.step('action', 'expected')` failed to compile with `ts(2554): Expected 3 arguments`, forcing callers to pass `undefined` explicitly to omit them. This is a type-only change — runtime behavior is unchanged and fully backward compatible. The docstring now also clarifies that `qase.step` is a title decorator meant to be passed to Playwright's `test.step()`, not a step runner. Fixes #981.
+
 # playwright-qase-reporter@2.5.5
 
 ## Fixed

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-playwright/src/playwright.ts
+++ b/qase-playwright/src/playwright.ts
@@ -317,18 +317,25 @@ qase.tags = function(...values: string[]) {
 };
 
 /**
- * Set a expected result and data for the test step
- * @param action
- * @param expectedResult
- * @param data
+ * Build a step title with optional expected result and data markers.
+ *
+ * This is a title decorator, not a step runner: it returns a string meant to be
+ * passed to Playwright's `test.step()`. `expectedResult` and `data` are optional.
+ *
+ * @param action — step title
+ * @param expectedResult — optional expected result
+ * @param data — optional step data
  * @example
  * test('test', async ({ page }) => {
+ *    await test.step(qase.step('action'), async () => {
+ *      await page.goto('https://example.com');
+ *    });
  *    await test.step(qase.step('action', 'expected result', 'data'), async () => {
  *      await page.goto('https://example.com');
  *    });
  * });
  */
-qase.step = function(action: string, expectedResult: string | undefined, data: string | undefined): string {
+qase.step = function(action: string, expectedResult?: string, data?: string): string {
   return `${action} QaseExpRes:${expectedResult ? `: ${expectedResult}` : ''} QaseData:${data ? `: ${data}` : ''}`;
 };
 

--- a/qase-playwright/test/playwright.test.ts
+++ b/qase-playwright/test/playwright.test.ts
@@ -204,6 +204,16 @@ describe('qase API', () => {
       const result = qase.step('Click button', 'Button should be clicked', 'Button data');
       expect(result).toBe('Click button QaseExpRes:: Button should be clicked QaseData:: Button data');
     });
+
+    it('should accept a single action argument (optional params omitted)', () => {
+      const result = qase.step('Click button');
+      expect(result).toBe('Click button QaseExpRes: QaseData:');
+    });
+
+    it('should accept action and expected result without data', () => {
+      const result = qase.step('Click button', 'Button should be clicked');
+      expect(result).toBe('Click button QaseExpRes:: Button should be clicked QaseData:');
+    });
   });
 
   describe('qase with non-positive ID (regression test)', () => {


### PR DESCRIPTION
## Summary

Fixes #981.

`qase.step` in `playwright-qase-reporter` typed `expectedResult` and `data` as `string | undefined` but positionally **required** them. This meant the documented callback-free calls did not compile:

```ts
qase.step('action')                  // ts(2554): Expected 3 arguments, but got 1
qase.step('action', 'expected')      // ts(2554): Expected 3 arguments, but got 2
```

Callers were forced to pass `undefined` explicitly to omit optional arguments.

## Changes

- Mark `expectedResult` and `data` as optional (`?`) in the `qase.step` signature. Body logic is unchanged — **fully backward compatible** (existing 3-argument calls and calls passing `undefined` still work identically).
- Clarify the docstring: `qase.step` is a title decorator meant to be passed to Playwright's `test.step()`, not a step runner. Added a one-argument example.
- Add tests for the one- and two-argument forms that previously failed to type-check.

## Scope

This PR covers only the type fix (requests #1 partially and #2 from the issue). The ergonomic callback overload (`qase.step(title, callback)`, request #3) and the external docs update on developers.qase.io are out of scope for this change.

## Verification

- `npm run build` — 0 errors; generated `dist/playwright.d.ts` now shows `step(action: string, expectedResult?: string, data?: string): string`
- `npm test` — 101 passed (2 new)
- `npm run lint` — 0 errors