### PR TITLE
chore: remove unused dependencies across packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28113,7 +28113,7 @@
       }
     },
     "qase-api-client": {
-      "version": "1.1.10",
+      "version": "1.1.12",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.16.0",
@@ -28234,8 +28234,7 @@
         "async-mutex": "~0.5.0",
         "chalk": "^4.1.2",
         "env-schema": "^5.2.1",
-        "form-data": "4.0.6",
-        "lodash.get": "^4.4.2",
+        "form-data": "^4.0.6",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "mime-types": "^2.1.35",
@@ -28247,7 +28246,6 @@
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.14",
-        "@types/lodash.get": "^4.4.9",
         "@types/lodash.merge": "^4.6.9",
         "@types/lodash.mergewith": "^4.6.9",
         "@types/mime-types": "^2.1.4",
@@ -28353,7 +28351,7 @@
     },
     "qase-playwright": {
       "name": "playwright-qase-reporter",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28183,7 +28183,7 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.7.5",
+      "version": "2.7.6",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",
@@ -28242,12 +28242,12 @@
     },
     "qase-mocha": {
       "name": "mocha-qase-reporter",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "deasync-promise": "^1.0.1",
         "mocha": "^11.7.5",
-        "qase-javascript-commons": "~2.7.3",
+        "qase-javascript-commons": "~2.7.6",
         "uuid": "11.1.1"
       },
       "devDependencies": {
@@ -28304,10 +28304,10 @@
     },
     "qase-playwright": {
       "name": "playwright-qase-reporter",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.7.5",
+        "qase-javascript-commons": "~2.7.6",
         "uuid": "11.1.1"
       },
       "devDependencies": {
@@ -28348,10 +28348,10 @@
     },
     "qase-vitest": {
       "name": "vitest-qase-reporter",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "qase-javascript-commons": "~2.7.3"
+        "qase-javascript-commons": "~2.7.6"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -28370,11 +28370,11 @@
     },
     "qase-wdio": {
       "name": "wdio-qase-reporter",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@wdio/reporter": "^8.43.0",
-        "qase-javascript-commons": "~2.7.4",
+        "qase-javascript-commons": "~2.7.6",
         "uuid": "11.1.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5443,13 +5443,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/caseless": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
-      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -5667,37 +5660,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/request": {
-      "version": "2.48.13",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
-      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.5"
-      }
-    },
-    "node_modules/@types/request/node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.35",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/@types/semver": {
@@ -11927,12 +11889,6 @@
       "version": "4.16.3",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
       "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==",
-      "license": "MIT"
-    },
-    "node_modules/csv-stringify": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
-      "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==",
       "license": "MIT"
     },
     "node_modules/cucumber": {
@@ -28249,7 +28205,6 @@
         "@types/lodash.merge": "^4.6.9",
         "@types/lodash.mergewith": "^4.6.9",
         "@types/mime-types": "^2.1.4",
-        "@types/minimatch": "^6.0.0",
         "axios": "^1.16.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.4.5"
@@ -28300,12 +28255,10 @@
         "@types/deasync-promise": "^1.0.2",
         "@types/jest": "^29.5.14",
         "@types/mocha": "^10.0.10",
-        "@types/request": "^2.48.13",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "eslint": "^8.57.1",
         "jest": "^29.7.0",
-        "prettier": "^2.8.8",
         "ts-jest": "^29.4.5"
       },
       "engines": {
@@ -28354,7 +28307,6 @@
       "version": "2.5.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "^4.1.2",
         "qase-javascript-commons": "~2.7.5",
         "uuid": "11.1.1"
       },
@@ -28404,7 +28356,6 @@
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.14",
-        "ajv": "^8.18.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.4.5",
         "typescript": "^5.9.3",
@@ -28423,41 +28374,11 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@wdio/reporter": "^8.43.0",
-        "@wdio/types": "^8.41.0",
-        "csv-stringify": "^6.6.0",
         "qase-javascript-commons": "~2.7.4",
-        "strip-ansi": "^7.1.2",
         "uuid": "11.1.1"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "qase-wdio/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "qase-wdio/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "qaseio": {

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -55,7 +55,6 @@
     "chalk": "^4.1.2",
     "env-schema": "^5.2.1",
     "form-data": "^4.0.6",
-    "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2",
     "mime-types": "^2.1.35",
@@ -67,7 +66,6 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.14",
-    "@types/lodash.get": "^4.4.9",
     "@types/lodash.merge": "^4.6.9",
     "@types/lodash.mergewith": "^4.6.9",
     "@types/mime-types": "^2.1.4",

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qase-javascript-commons",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "description": "Qase JS Reporters",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/qase-javascript-commons/package.json
+++ b/qase-javascript-commons/package.json
@@ -69,7 +69,6 @@
     "@types/lodash.merge": "^4.6.9",
     "@types/lodash.mergewith": "^4.6.9",
     "@types/mime-types": "^2.1.4",
-    "@types/minimatch": "^6.0.0",
     "axios": "^1.16.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.5"

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-qase-reporter",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Mocha Cypress Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -44,7 +44,7 @@
   "dependencies": {
     "deasync-promise": "^1.0.1",
     "mocha": "^11.7.5",
-    "qase-javascript-commons": "~2.7.3",
+    "qase-javascript-commons": "~2.7.6",
     "uuid": "11.1.1"
   },
   "devDependencies": {

--- a/qase-mocha/package.json
+++ b/qase-mocha/package.json
@@ -52,12 +52,10 @@
     "@types/deasync-promise": "^1.0.2",
     "@types/jest": "^29.5.14",
     "@types/mocha": "^10.0.10",
-    "@types/request": "^2.48.13",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^8.57.1",
     "jest": "^29.7.0",
-    "prettier": "^2.8.8",
     "ts-jest": "^29.4.5"
   }
 }

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -48,7 +48,6 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "chalk": "^4.1.2",
     "qase-javascript-commons": "~2.7.5",
     "uuid": "11.1.1"
   },

--- a/qase-playwright/package.json
+++ b/qase-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-qase-reporter",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Qase TMS Playwright Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -48,7 +48,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.7.5",
+    "qase-javascript-commons": "~2.7.6",
     "uuid": "11.1.1"
   },
   "peerDependencies": {

--- a/qase-vitest/package.json
+++ b/qase-vitest/package.json
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.14",
-    "ajv": "^8.18.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.5",
     "typescript": "^5.9.3",

--- a/qase-vitest/package.json
+++ b/qase-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-qase-reporter",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Qase TMS Vitest Reporter",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -46,7 +46,7 @@
   "author": "Qase Team <support@qase.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "qase-javascript-commons": "~2.7.3"
+    "qase-javascript-commons": "~2.7.6"
   },
   "peerDependencies": {
     "vitest": ">=3.0.0"

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-qase-reporter",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Qase WebDriverIO Reporter",
   "homepage": "https://github.com/qase-tms/qase-javascript",
   "sideEffects": false,
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@wdio/reporter": "^8.43.0",
-    "qase-javascript-commons": "~2.7.4",
+    "qase-javascript-commons": "~2.7.6",
     "uuid": "11.1.1"
   }
 }

--- a/qase-wdio/package.json
+++ b/qase-wdio/package.json
@@ -34,10 +34,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@wdio/reporter": "^8.43.0",
-    "@wdio/types": "^8.41.0",
-    "csv-stringify": "^6.6.0",
     "qase-javascript-commons": "~2.7.4",
-    "strip-ansi": "^7.1.2",
     "uuid": "11.1.1"
   }
 }


### PR DESCRIPTION
## Summary

Removes dependencies that are declared in `package.json` files but never imported in source across the monorepo. Verified with `depcheck` plus manual grep of each candidate.

## Removed

### `qase-javascript-commons`
- `lodash.get` + `@types/lodash.get` — deprecated on npm; not imported anywhere (only `lodash.merge` / `lodash.mergewith` are used). Produced an install-time deprecation warning for all downstream consumers, e.g. `playwright-qase-reporter -> qase-javascript-commons -> lodash.get`.
- `@types/minimatch` — types for `minimatch`, which is not even a dependency.

### `qase-playwright`
- `chalk` (runtime) — unused.

### `qase-wdio`
- `@wdio/types`, `csv-stringify`, `strip-ansi` (runtime) — unused.

### `qase-vitest`
- `ajv` — unused.

### `qase-mocha`
- `@types/request`, `prettier` — unused.

## Intentionally kept (depcheck false positives)
- `@types/jest` — required for test globals.
- `@typescript-eslint/*` in `qase-mocha` — used via `eslint-disable` rule references.
- `qase-jest` keeps `lodash.get` — it is actually used in `resultBuilder.ts`.

## Verification
- `npm run build` — passes for all affected packages.
- `npm run lint` (qase-mocha) — passes (0 errors; pre-existing warnings only), confirming lint tooling still resolves.
- `npm test` — all green: commons 516, playwright 101, wdio 99, vitest 76, mocha 43.

## Impact
Install-time noise reduction and smaller dependency trees. No runtime behavior change.

Closes #984